### PR TITLE
Add support for multiple aggregate functions in grouping

### DIFF
--- a/gradoop-core/src/main/java/org/gradoop/model/impl/properties/PropertyValueList.java
+++ b/gradoop-core/src/main/java/org/gradoop/model/impl/properties/PropertyValueList.java
@@ -28,6 +28,7 @@ import java.io.DataInputStream;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
@@ -36,7 +37,13 @@ import java.util.Iterator;
  * Represents a list of property values.
  */
 public class PropertyValueList
-  implements Iterable<PropertyValue>, WritableComparable<PropertyValueList> {
+  implements
+  Iterable<PropertyValue>, WritableComparable<PropertyValueList>, Serializable {
+
+  /**
+   * Class version for serialization.
+   */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Property values are stored in their byte representation.
@@ -44,7 +51,7 @@ public class PropertyValueList
   private byte[] bytes;
 
   /**
-   * Default constructor.
+   * Default constructor (used for (de-)serialization.
    */
   public PropertyValueList() {
   }
@@ -56,6 +63,15 @@ public class PropertyValueList
    */
   private PropertyValueList(byte[] bytes) {
     this.bytes = bytes;
+  }
+
+  /**
+   * Creates a new property value list containing no elements.
+   *
+   * @return empty property value list
+   */
+  public static PropertyValueList createEmptyList() {
+    return new PropertyValueList(new byte[0]);
   }
 
   /**

--- a/gradoop-examples/src/main/java/org/gradoop/examples/grouping/GroupingRunner.java
+++ b/gradoop-examples/src/main/java/org/gradoop/examples/grouping/GroupingRunner.java
@@ -149,8 +149,8 @@ public class GroupingRunner implements ProgramDescription {
       .addEdgeGroupingKey(edgeKey)
       .useVertexLabel(useVertexLabels)
       .useEdgeLabel(useEdgeLabels)
-      .setVertexValueAggregator(new CountAggregator())
-      .setEdgeValueAggregator(new CountAggregator())
+      .addVertexAggregator(new CountAggregator())
+      .addEdgeAggregator(new CountAggregator())
       .build();
   }
 

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/LogicalGraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/LogicalGraph.java
@@ -470,8 +470,8 @@ public class LogicalGraph
         .setStrategy(GroupingStrategy.GROUP_REDUCE)
         .useVertexLabel(false)
         .useEdgeLabel(false)
-        .setVertexValueAggregator(new CountAggregator())
-        .setEdgeValueAggregator(new CountAggregator())
+        .addVertexAggregator(new CountAggregator())
+        .addEdgeAggregator(new CountAggregator())
         .build());
   }
 
@@ -519,8 +519,8 @@ public class LogicalGraph
         .setStrategy(GroupingStrategy.GROUP_REDUCE)
         .useVertexLabel(true)
         .useEdgeLabel(false)
-        .setVertexValueAggregator(new CountAggregator())
-        .setEdgeValueAggregator(new CountAggregator())
+        .addVertexAggregator(new CountAggregator())
+        .addEdgeAggregator(new CountAggregator())
         .build());
   }
 
@@ -568,8 +568,8 @@ public class LogicalGraph
         .setStrategy(GroupingStrategy.GROUP_REDUCE)
         .useVertexLabel(true)
         .useEdgeLabel(true)
-        .setVertexValueAggregator(new CountAggregator())
-        .setEdgeValueAggregator(new CountAggregator())
+        .addVertexAggregator(new CountAggregator())
+        .addEdgeAggregator(new CountAggregator())
         .build());
   }
 

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/grouping/GroupingGroupReduce.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/grouping/GroupingGroupReduce.java
@@ -71,21 +71,21 @@ public class GroupingGroupReduce<
    *
    * @param vertexGroupingKeys  property key to group vertices
    * @param useVertexLabels     group on vertex label true/false
-   * @param vertexAggregator    aggregate function for grouped vertices
+   * @param vertexAggregators   aggregate functions for grouped vertices
    * @param edgeGroupingKeys    property key to group edges
    * @param useEdgeLabels       group on edge label true/false
-   * @param edgeAggregator      aggregate function for grouped edges
+   * @param edgeAggregators     aggregate functions for grouped edges
    */
   GroupingGroupReduce(
     List<String> vertexGroupingKeys,
     boolean useVertexLabels,
-    PropertyValueAggregator vertexAggregator,
+    List<PropertyValueAggregator> vertexAggregators,
     List<String> edgeGroupingKeys,
     boolean useEdgeLabels,
-    PropertyValueAggregator edgeAggregator) {
+    List<PropertyValueAggregator> edgeAggregators) {
     super(
-      vertexGroupingKeys, useVertexLabels, vertexAggregator,
-      edgeGroupingKeys, useEdgeLabels, edgeAggregator);
+      vertexGroupingKeys, useVertexLabels, vertexAggregators,
+      edgeGroupingKeys, useEdgeLabels, edgeAggregators);
   }
 
   /**
@@ -97,21 +97,21 @@ public class GroupingGroupReduce<
     DataSet<VertexGroupItem> verticesForGrouping = graph.getVertices()
       // map vertex to vertex group item
       .map(new BuildVertexGroupItem<V>(
-        getVertexGroupingKeys(), useVertexLabels(), getVertexAggregator()));
+        getVertexGroupingKeys(), useVertexLabels(), getVertexAggregators()));
 
     DataSet<VertexGroupItem> vertexGroupItems =
       // group vertices by label / properties / both
       groupVertices(verticesForGrouping)
         // apply aggregate function
-        .reduceGroup(
-          new ReduceVertexGroupItems(useVertexLabels(), getVertexAggregator()));
+        .reduceGroup(new ReduceVertexGroupItems(
+          useVertexLabels(), getVertexAggregators()));
 
     DataSet<V> superVertices = vertexGroupItems
       // filter group representative tuples
       .filter(new FilterCandidates())
       // build super vertices
       .map(new BuildSuperVertex<>(getVertexGroupingKeys(),
-        useVertexLabels(), getVertexAggregator(), config.getVertexFactory()));
+        useVertexLabels(), getVertexAggregators(), config.getVertexFactory()));
 
     DataSet<VertexWithRepresentative> vertexToRepresentativeMap =
       vertexGroupItems

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/grouping/functions/BuildEdgeGroupItem.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/grouping/functions/BuildEdgeGroupItem.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.gradoop.model.api.EPGMEdge;
 import org.gradoop.model.impl.operators.grouping.functions.aggregation.PropertyValueAggregator;
 import org.gradoop.model.impl.operators.grouping.tuples.EdgeGroupItem;
-import org.gradoop.model.impl.properties.PropertyValue;
+import org.gradoop.model.impl.properties.PropertyValueList;
 
 import java.util.List;
 
@@ -48,16 +48,15 @@ public class BuildEdgeGroupItem<E extends EPGMEdge>
    *
    * @param groupPropertyKeys vertex property key for grouping
    * @param useLabel          true, if vertex label shall be used
-   * @param edgeAggregator    aggregate function for summarized edges
+   * @param edgeAggregators   aggregate functions for super edges
    */
   public BuildEdgeGroupItem(List<String> groupPropertyKeys,
-    boolean useLabel, PropertyValueAggregator edgeAggregator) {
-    super(groupPropertyKeys, useLabel, edgeAggregator);
+    boolean useLabel, List<PropertyValueAggregator> edgeAggregators) {
+    super(groupPropertyKeys, useLabel, edgeAggregators);
     this.reuseEdgeGroupItem = new EdgeGroupItem();
-    if (doAggregate() && isCountAggregator()) {
-      this.reuseEdgeGroupItem.setGroupAggregate(PropertyValue.create(1L));
-    } else {
-      this.reuseEdgeGroupItem.setGroupAggregate(PropertyValue.NULL_VALUE);
+    if (!doAggregate()) {
+      this.reuseEdgeGroupItem.setAggregateValues(
+        PropertyValueList.createEmptyList());
     }
   }
 
@@ -69,9 +68,9 @@ public class BuildEdgeGroupItem<E extends EPGMEdge>
     reuseEdgeGroupItem.setSourceId(edge.getSourceId());
     reuseEdgeGroupItem.setTargetId(edge.getTargetId());
     reuseEdgeGroupItem.setGroupLabel(getLabel(edge));
-    reuseEdgeGroupItem.setGroupPropertyValues(getGroupProperties(edge));
-    if (doAggregate() && !isCountAggregator()) {
-      reuseEdgeGroupItem.setGroupAggregate(getValueForAggregation(edge));
+    reuseEdgeGroupItem.setGroupingValues(getGroupProperties(edge));
+    if (doAggregate()) {
+      reuseEdgeGroupItem.setAggregateValues(getAggregateValues(edge));
     }
     return reuseEdgeGroupItem;
   }

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/grouping/functions/BuildSuperEdge.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/grouping/functions/BuildSuperEdge.java
@@ -21,6 +21,7 @@ import org.gradoop.model.impl.operators.grouping.functions.aggregation.PropertyV
 import org.gradoop.model.impl.operators.grouping.tuples.EdgeGroupItem;
 import org.gradoop.util.GConstants;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -29,19 +30,19 @@ import java.util.List;
  * @see ReduceEdgeGroupItems
  * @see CombineEdgeGroupItems
  */
-public abstract class BuildSuperEdge extends BuildBase {
+abstract class BuildSuperEdge extends BuildBase {
 
   /**
    * Creates group reducer / combiner
    *
    * @param groupPropertyKeys edge property keys
    * @param useLabel          use edge label
-   * @param valueAggregator   aggregate function for edge values
+   * @param valueAggregators  aggregate functions for edge values
    */
   public BuildSuperEdge(List<String> groupPropertyKeys,
     boolean useLabel,
-    PropertyValueAggregator valueAggregator) {
-    super(groupPropertyKeys, useLabel, valueAggregator);
+    List<PropertyValueAggregator> valueAggregators) {
+    super(groupPropertyKeys, useLabel, valueAggregators);
   }
 
   /**
@@ -51,34 +52,34 @@ public abstract class BuildSuperEdge extends BuildBase {
    * @return group representative item
    */
   protected EdgeGroupItem reduceInternal(
-    Iterable<EdgeGroupItem> edgeGroupItems) {
+    Iterable<EdgeGroupItem> edgeGroupItems) throws IOException {
 
     EdgeGroupItem edgeGroupItem = new EdgeGroupItem();
 
     boolean firstElement = true;
 
-    for (EdgeGroupItem e : edgeGroupItems) {
+    for (EdgeGroupItem edge : edgeGroupItems) {
       if (firstElement) {
-        edgeGroupItem.setSourceId(e.getSourceId());
-        edgeGroupItem.setTargetId(e.getTargetId());
+        edgeGroupItem.setSourceId(edge.getSourceId());
+        edgeGroupItem.setTargetId(edge.getTargetId());
         if (useLabel()) {
-          edgeGroupItem.setGroupLabel(e.getGroupLabel());
+          edgeGroupItem.setGroupLabel(edge.getGroupLabel());
         } else {
           edgeGroupItem.setGroupLabel(GConstants.DEFAULT_EDGE_LABEL);
         }
-        edgeGroupItem.setGroupPropertyValues(e.getGroupPropertyValues());
+        edgeGroupItem.setGroupingValues(edge.getGroupingValues());
         firstElement = false;
       }
 
       if (doAggregate()) {
-        aggregate(e.getGroupAggregate());
+        aggregate(edge.getAggregateValues());
       } else {
         // no need to iterate further
         break;
       }
     }
 
-    edgeGroupItem.setGroupAggregate(getAggregate());
+    edgeGroupItem.setAggregateValues(getAggregateValues());
 
     return edgeGroupItem;
   }

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/grouping/functions/BuildSuperVertex.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/grouping/functions/BuildSuperVertex.java
@@ -32,9 +32,8 @@ import org.gradoop.model.impl.operators.grouping.functions.aggregation.PropertyV
 import java.util.List;
 
 /**
- * Creates a new vertex representing a vertex group. The vertex stores the
- * group label, the group property value and the number of vertices in the
- * group.
+ * Creates a new super vertex representing a vertex group. The vertex stores the
+ * group label, the group property value and the aggregate values for its group.
  *
  * @param <V> EPGM vertex type
  */
@@ -54,14 +53,14 @@ public class BuildSuperVertex<V extends EPGMVertex>
    *
    * @param groupPropertyKeys vertex property key for grouping
    * @param useLabel          true, if vertex label shall be considered
-   * @param valueAggregator   aggregate function for vertex values
+   * @param valueAggregators  aggregate functions for vertex values
    * @param vertexFactory     vertex factory
    */
   public BuildSuperVertex(List<String> groupPropertyKeys,
     boolean useLabel,
-    PropertyValueAggregator valueAggregator,
+    List<PropertyValueAggregator> valueAggregators,
     EPGMVertexFactory<V> vertexFactory) {
-    super(groupPropertyKeys, useLabel, valueAggregator);
+    super(groupPropertyKeys, useLabel, valueAggregators);
     this.vertexFactory = vertexFactory;
   }
 
@@ -76,13 +75,13 @@ public class BuildSuperVertex<V extends EPGMVertex>
   @Override
   public V map(VertexGroupItem groupItem) throws
     Exception {
-    V sumVertex = vertexFactory.initVertex(groupItem.getGroupRepresentative());
+    V supVertex = vertexFactory.initVertex(groupItem.getGroupRepresentative());
 
-    setLabel(sumVertex, groupItem.getGroupLabel());
-    setGroupProperties(sumVertex, groupItem.getGroupPropertyValues());
-    setAggregate(sumVertex, groupItem.getGroupAggregate());
+    setLabel(supVertex, groupItem.getGroupLabel());
+    setGroupProperties(supVertex, groupItem.getGroupingValues());
+    setAggregateValues(supVertex, groupItem.getAggregateValues());
 
-    return sumVertex;
+    return supVertex;
   }
 
   /**

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/grouping/functions/CombineEdgeGroupItems.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/grouping/functions/CombineEdgeGroupItems.java
@@ -35,11 +35,11 @@ public class CombineEdgeGroupItems
    *
    * @param groupPropertyKeys edge property keys
    * @param useLabel          use edge label
-   * @param valueAggregator   aggregate function for edge values
+   * @param valueAggregators  aggregate functions for edge values
    */
   public CombineEdgeGroupItems(List<String> groupPropertyKeys, boolean useLabel,
-    PropertyValueAggregator valueAggregator) {
-    super(groupPropertyKeys, useLabel, valueAggregator);
+    List<PropertyValueAggregator> valueAggregators) {
+    super(groupPropertyKeys, useLabel, valueAggregators);
   }
 
   /**
@@ -53,6 +53,6 @@ public class CombineEdgeGroupItems
   public void combine(Iterable<EdgeGroupItem> edgeGroupItems,
     Collector<EdgeGroupItem> collector) throws Exception {
     collector.collect(reduceInternal(edgeGroupItems));
-    resetAggregator();
+    resetAggregators();
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/grouping/functions/ReduceEdgeGroupItems.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/grouping/functions/ReduceEdgeGroupItems.java
@@ -31,7 +31,8 @@ import org.gradoop.model.impl.operators.grouping.tuples.EdgeGroupItem;
 import java.util.List;
 
 /**
- * Creates a new super {@link EPGMEdge} from a group of {@link EdgeGroupItem}.
+ * Creates a new super edge representing an edge group. The edge stores the
+ * group label, the group property value and the aggregate values for its group.
  *
  * @param <E> EPGM edge type
  */
@@ -50,12 +51,14 @@ public class ReduceEdgeGroupItems<E extends EPGMEdge>
    *
    * @param groupPropertyKeys edge property keys
    * @param useLabel          use edge label
-   * @param valueAggregator   aggregate function for edge values
+   * @param valueAggregators  aggregate functions for edge values
    * @param edgeFactory       edge factory
    */
-  public ReduceEdgeGroupItems(List<String> groupPropertyKeys, boolean useLabel,
-    PropertyValueAggregator valueAggregator, EPGMEdgeFactory<E> edgeFactory) {
-    super(groupPropertyKeys, useLabel, valueAggregator);
+  public ReduceEdgeGroupItems(List<String> groupPropertyKeys,
+    boolean useLabel,
+    List<PropertyValueAggregator> valueAggregators,
+    EPGMEdgeFactory<E> edgeFactory) {
+    super(groupPropertyKeys, useLabel, valueAggregators);
     this.edgeFactory = edgeFactory;
   }
 
@@ -73,16 +76,16 @@ public class ReduceEdgeGroupItems<E extends EPGMEdge>
 
     EdgeGroupItem edgeGroupItem = reduceInternal(edgeGroupItems);
 
-    E sumEdge = edgeFactory.createEdge(
+    E supEdge = edgeFactory.createEdge(
       edgeGroupItem.getGroupLabel(),
       edgeGroupItem.getSourceId(),
       edgeGroupItem.getTargetId());
 
-    setGroupProperties(sumEdge, edgeGroupItem.getGroupPropertyValues());
-    setAggregate(sumEdge);
-    resetAggregator();
+    setGroupProperties(supEdge, edgeGroupItem.getGroupingValues());
+    setAggregateValues(supEdge);
+    resetAggregators();
 
-    collector.collect(sumEdge);
+    collector.collect(supEdge);
   }
 
   /**

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/grouping/functions/ReduceVertexGroupItems.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/grouping/functions/ReduceVertexGroupItems.java
@@ -26,8 +26,11 @@ import org.gradoop.model.impl.operators.grouping.functions.aggregation.PropertyV
 
 import org.gradoop.model.impl.properties.PropertyValueList;
 
+import java.io.IOException;
+import java.util.List;
+
 /**
- * Reduces or combines a group of {@link VertexGroupItem} instances.
+ * Reduces a group of {@link VertexGroupItem} instances.
  */
 @FunctionAnnotation.ForwardedFields("f0;f3;f4") // vertexId, label, properties
 public class ReduceVertexGroupItems
@@ -43,11 +46,11 @@ public class ReduceVertexGroupItems
    * Creates group reduce function.
    *
    * @param useLabel          true, iff labels are used for grouping
-   * @param vertexAggregator  aggregate function for summarized vertices
+   * @param vertexAggregators aggregate functions for super vertices
    */
   public ReduceVertexGroupItems(boolean useLabel,
-    PropertyValueAggregator vertexAggregator) {
-    super(null, useLabel, vertexAggregator);
+    List<PropertyValueAggregator> vertexAggregators) {
+    super(null, useLabel, vertexAggregators);
     this.reuseVertexGroupItem = new VertexGroupItem();
   }
 
@@ -65,15 +68,15 @@ public class ReduceVertexGroupItems
       if (firstElement) {
         groupRepresentative = GradoopId.get();
         groupLabel          = groupItem.getGroupLabel();
-        groupPropertyValues = groupItem.getGroupPropertyValues();
+        groupPropertyValues = groupItem.getGroupingValues();
 
         if (useLabel()) {
           reuseVertexGroupItem.setGroupLabel(groupLabel);
         }
 
-        reuseVertexGroupItem.setGroupPropertyValues(groupPropertyValues);
+        reuseVertexGroupItem.setGroupingValues(groupPropertyValues);
         reuseVertexGroupItem.setGroupRepresentative(groupRepresentative);
-        reuseVertexGroupItem.setGroupAggregate(groupItem.getGroupAggregate());
+        reuseVertexGroupItem.setAggregateValues(groupItem.getAggregateValues());
         reuseVertexGroupItem.setCandidate(groupItem.isCandidate());
 
         firstElement = false;
@@ -83,7 +86,7 @@ public class ReduceVertexGroupItems
       collector.collect(reuseVertexGroupItem);
 
       if (doAggregate()) {
-        aggregate(groupItem.getGroupAggregate());
+        aggregate(groupItem.getAggregateValues());
       }
     }
 
@@ -93,7 +96,7 @@ public class ReduceVertexGroupItems
       groupLabel,
       groupPropertyValues));
 
-    resetAggregator();
+    resetAggregators();
   }
 
   /**
@@ -106,11 +109,12 @@ public class ReduceVertexGroupItems
    * @return vertex group item
    */
   private VertexGroupItem createCandidateTuple(GradoopId groupRepresentative,
-    String groupLabel, PropertyValueList groupPropertyValues) {
+    String groupLabel, PropertyValueList groupPropertyValues)
+      throws IOException {
     reuseVertexGroupItem.setVertexId(groupRepresentative);
     reuseVertexGroupItem.setGroupLabel(groupLabel);
-    reuseVertexGroupItem.setGroupPropertyValues(groupPropertyValues);
-    reuseVertexGroupItem.setGroupAggregate(getAggregate());
+    reuseVertexGroupItem.setGroupingValues(groupPropertyValues);
+    reuseVertexGroupItem.setAggregateValues(getAggregateValues());
     reuseVertexGroupItem.setCandidate(true);
     return reuseVertexGroupItem;
   }

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/grouping/tuples/EdgeGroupItem.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/grouping/tuples/EdgeGroupItem.java
@@ -19,21 +19,20 @@ package org.gradoop.model.impl.operators.grouping.tuples;
 
 import org.apache.flink.api.java.tuple.Tuple5;
 import org.gradoop.model.impl.id.GradoopId;
-import org.gradoop.model.impl.properties.PropertyValue;
 import org.gradoop.model.impl.properties.PropertyValueList;
 
 /**
- * Edge representation used in grouping edges to summarized edges.
+ * Edge representation used for grouping edges to super edges.
  *
  * f0: source vertex id
  * f1: target vertex id
  * f2: edge group label
  * f3: edge group property values
- * f4: edge group aggregate value
+ * f4: edge group aggregate values
  */
 public class EdgeGroupItem
   extends
-  Tuple5<GradoopId, GradoopId, String, PropertyValueList, PropertyValue> {
+  Tuple5<GradoopId, GradoopId, String, PropertyValueList, PropertyValueList> {
 
   public GradoopId getSourceId() {
     return f0;
@@ -59,19 +58,19 @@ public class EdgeGroupItem
     f2 = groupLabel;
   }
 
-  public PropertyValueList getGroupPropertyValues() {
+  public PropertyValueList getGroupingValues() {
     return f3;
   }
 
-  public void setGroupPropertyValues(PropertyValueList groupPropertyValues) {
+  public void setGroupingValues(PropertyValueList groupPropertyValues) {
     f3 = groupPropertyValues;
   }
 
-  public PropertyValue getGroupAggregate() {
+  public PropertyValueList getAggregateValues() {
     return f4;
   }
 
-  public void setGroupAggregate(PropertyValue value) {
+  public void setAggregateValues(PropertyValueList value) {
     this.f4 = value;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/grouping/tuples/VertexGroupItem.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/grouping/tuples/VertexGroupItem.java
@@ -19,22 +19,21 @@ package org.gradoop.model.impl.operators.grouping.tuples;
 
 import org.apache.flink.api.java.tuple.Tuple6;
 import org.gradoop.model.impl.id.GradoopId;
-import org.gradoop.model.impl.properties.PropertyValue;
 import org.gradoop.model.impl.properties.PropertyValueList;
 
 /**
- * Vertex representation which is used as output of group reduce.
+ * Vertex representation used for grouping vertices to super vertices.
  *
  * f0: vertex id
  * f1: group representative vertex id
  * f2: vertex group label
  * f3: vertex group properties
- * f4: vertex group aggregate value
+ * f4: vertex group aggregate values
  * f5: candidate tuple yes/no
  */
 public class VertexGroupItem
-  extends Tuple6
-    <GradoopId, GradoopId, String, PropertyValueList, PropertyValue, Boolean> {
+  extends Tuple6<GradoopId, GradoopId, String,
+  PropertyValueList, PropertyValueList, Boolean> {
 
   public GradoopId getVertexId() {
     return f0;
@@ -61,19 +60,19 @@ public class VertexGroupItem
     f2 = groupLabel;
   }
 
-  public PropertyValueList getGroupPropertyValues() {
+  public PropertyValueList getGroupingValues() {
     return f3;
   }
 
-  public void setGroupPropertyValues(PropertyValueList groupPropertyValues) {
+  public void setGroupingValues(PropertyValueList groupPropertyValues) {
     f3 = groupPropertyValues;
   }
 
-  public PropertyValue getGroupAggregate() {
+  public PropertyValueList getAggregateValues() {
     return f4;
   }
 
-  public void setGroupAggregate(PropertyValue groupCount) {
+  public void setAggregateValues(PropertyValueList groupCount) {
     f4 = groupCount;
   }
 

--- a/gradoop-flink/src/test/java/org/gradoop/model/impl/operators/grouping/GroupingTestBase.java
+++ b/gradoop-flink/src/test/java/org/gradoop/model/impl/operators/grouping/GroupingTestBase.java
@@ -58,8 +58,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
     LogicalGraph<GraphHeadPojo, VertexPojo, EdgePojo> output =
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .addVertexGroupingKey("city")
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -92,8 +92,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
     LogicalGraph<GraphHeadPojo, VertexPojo, EdgePojo> output =
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .addVertexGroupingKey("city")
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -133,8 +133,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .addVertexGroupingKey("city")
         .addVertexGroupingKey("gender")
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -161,8 +161,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
     LogicalGraph<GraphHeadPojo, VertexPojo, EdgePojo> output =
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .addVertexGroupingKey("city")
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -191,8 +191,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .addVertexGroupingKey("city")
         .addVertexGroupingKey("gender")
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -227,8 +227,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .addVertexGroupingKey("city")
         .addEdgeGroupingKey("since")
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -281,8 +281,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addVertexGroupingKey("a")
         .addEdgeGroupingKey("a")
         .addEdgeGroupingKey("b")
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(loader.getLogicalGraphByVariable("input"));
@@ -338,8 +338,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addVertexGroupingKey("b")
         .addEdgeGroupingKey("a")
         .addEdgeGroupingKey("b")
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(loader.getLogicalGraphByVariable("input"));
@@ -369,8 +369,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .addVertexGroupingKey("city")
         .addEdgeGroupingKey("since")
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -400,8 +400,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
     LogicalGraph<GraphHeadPojo, VertexPojo, EdgePojo> output =
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .useVertexLabel(true)
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -435,8 +435,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .useVertexLabel(true)
         .addVertexGroupingKey("city")
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -477,8 +477,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .useVertexLabel(true)
         .addVertexGroupingKey("city")
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -508,8 +508,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .useVertexLabel(true)
         .addEdgeGroupingKey("since")
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -543,8 +543,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .useVertexLabel(true)
         .addEdgeGroupingKey("since")
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -580,8 +580,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .useVertexLabel(true)
         .addVertexGroupingKey("city")
         .addEdgeGroupingKey("since")
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -614,8 +614,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .useVertexLabel(true)
         .useEdgeLabel(true)
         .setStrategy(getStrategy())
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .build()
         .execute(input);
 
@@ -650,8 +650,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addVertexGroupingKey("city")
         .useVertexLabel(true)
         .useEdgeLabel(true)
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -694,8 +694,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addVertexGroupingKey("city")
         .useVertexLabel(true)
         .useEdgeLabel(true)
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -726,8 +726,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addEdgeGroupingKey("since")
         .useVertexLabel(true)
         .useEdgeLabel(true)
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -764,8 +764,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addEdgeGroupingKey("since")
         .useVertexLabel(true)
         .useEdgeLabel(true)
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -802,8 +802,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addEdgeGroupingKey("since")
         .useVertexLabel(true)
         .useEdgeLabel(true)
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -849,8 +849,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addEdgeGroupingKey("since")
         .useVertexLabel(true)
         .useEdgeLabel(true)
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -862,6 +862,48 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
   //----------------------------------------------------------------------------
   // Tests for aggregate functions
   //----------------------------------------------------------------------------
+
+  @Test
+  public void testNoAggregate() throws Exception {
+    FlinkAsciiGraphLoader<GraphHeadPojo, VertexPojo, EdgePojo> loader =
+      getLoaderFromString("input[" +
+        "(v0:Blue {a=3});" +
+        "(v1:Blue {a=2});" +
+        "(v2:Blue {a=4});" +
+        "(v3:Red  {a=4});" +
+        "(v4:Red  {a=2});" +
+        "(v5:Red  {a=4});" +
+        "(v0)-[{b=2}]->(v1);" +
+        "(v0)-[{b=1}]->(v2);" +
+        "(v1)-[{b=2}]->(v2);" +
+        "(v2)-[{b=3}]->(v3);" +
+        "(v2)-[{b=1}]->(v3);" +
+        "(v3)-[{b=3}]->(v4);" +
+        "(v4)-[{b=1}]->(v5);" +
+        "(v5)-[{b=1}]->(v3);" +
+        "]");
+
+    LogicalGraph<GraphHeadPojo, VertexPojo, EdgePojo> input = loader
+      .getLogicalGraphByVariable("input");
+
+    loader.appendToDatabaseFromString("expected[" +
+      "(v00:Blue);" +
+      "(v01:Red);" +
+      "(v00)-->(v00);" +
+      "(v00)-->(v01);" +
+      "(v01)-->(v01);" +
+      "]");
+
+    LogicalGraph<GraphHeadPojo, VertexPojo, EdgePojo> output =
+      new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
+        .useVertexLabel(true)
+        .setStrategy(getStrategy())
+        .build()
+        .execute(input);
+
+    collectAndAssertTrue(
+      output.equalsByElementData(loader.getLogicalGraphByVariable("expected")));
+  }
 
   @Test
   public void testCount() throws Exception {
@@ -897,8 +939,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
     LogicalGraph<GraphHeadPojo, VertexPojo, EdgePojo> output =
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .useVertexLabel(true)
-        .setVertexValueAggregator(new CountAggregator("count"))
-        .setEdgeValueAggregator(new CountAggregator("count"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -941,8 +983,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
     LogicalGraph<GraphHeadPojo, VertexPojo, EdgePojo> output =
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .useVertexLabel(true)
-        .setVertexValueAggregator(new SumAggregator("a", "sumA"))
-        .setEdgeValueAggregator(new SumAggregator("b", "sumB"))
+        .addVertexAggregator(new SumAggregator("a", "sumA"))
+        .addEdgeAggregator(new SumAggregator("b", "sumB"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -985,8 +1027,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
     LogicalGraph<GraphHeadPojo, VertexPojo, EdgePojo> output =
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .useVertexLabel(true)
-        .setVertexValueAggregator(new SumAggregator("a", "sumA"))
-        .setEdgeValueAggregator(new SumAggregator("b", "sumB"))
+        .addVertexAggregator(new SumAggregator("a", "sumA"))
+        .addEdgeAggregator(new SumAggregator("b", "sumB"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -1029,8 +1071,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
     LogicalGraph<GraphHeadPojo, VertexPojo, EdgePojo> output =
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .useVertexLabel(true)
-        .setVertexValueAggregator(new SumAggregator("a", "sumA"))
-        .setEdgeValueAggregator(new SumAggregator("b", "sumB"))
+        .addVertexAggregator(new SumAggregator("a", "sumA"))
+        .addEdgeAggregator(new SumAggregator("b", "sumB"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -1073,8 +1115,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
     LogicalGraph<GraphHeadPojo, VertexPojo, EdgePojo> output =
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .useVertexLabel(true)
-        .setVertexValueAggregator(new MinAggregator("a", "minA"))
-        .setEdgeValueAggregator(new MinAggregator("b", "minB"))
+        .addVertexAggregator(new MinAggregator("a", "minA"))
+        .addEdgeAggregator(new MinAggregator("b", "minB"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -1117,8 +1159,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
     LogicalGraph<GraphHeadPojo, VertexPojo, EdgePojo> output =
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .useVertexLabel(true)
-        .setVertexValueAggregator(new MinAggregator("a", "minA"))
-        .setEdgeValueAggregator(new MinAggregator("b", "minB"))
+        .addVertexAggregator(new MinAggregator("a", "minA"))
+        .addEdgeAggregator(new MinAggregator("b", "minB"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -1161,8 +1203,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
     LogicalGraph<GraphHeadPojo, VertexPojo, EdgePojo> output =
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .useVertexLabel(true)
-        .setVertexValueAggregator(new MinAggregator("a", "minA"))
-        .setEdgeValueAggregator(new MinAggregator("b", "minB"))
+        .addVertexAggregator(new MinAggregator("a", "minA"))
+        .addEdgeAggregator(new MinAggregator("b", "minB"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -1205,8 +1247,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
     LogicalGraph<GraphHeadPojo, VertexPojo, EdgePojo> output =
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .useVertexLabel(true)
-        .setVertexValueAggregator(new MaxAggregator("a", "maxA"))
-        .setEdgeValueAggregator(new MaxAggregator("b", "maxB"))
+        .addVertexAggregator(new MaxAggregator("a", "maxA"))
+        .addEdgeAggregator(new MaxAggregator("b", "maxB"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -1249,8 +1291,8 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
     LogicalGraph<GraphHeadPojo, VertexPojo, EdgePojo> output =
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .useVertexLabel(true)
-        .setVertexValueAggregator(new MaxAggregator("a", "maxA"))
-        .setEdgeValueAggregator(new MaxAggregator("b", "maxB"))
+        .addVertexAggregator(new MaxAggregator("a", "maxA"))
+        .addEdgeAggregator(new MaxAggregator("b", "maxB"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);
@@ -1293,8 +1335,58 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
     LogicalGraph<GraphHeadPojo, VertexPojo, EdgePojo> output =
       new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
         .useVertexLabel(true)
-        .setVertexValueAggregator(new MaxAggregator("a", "maxA"))
-        .setEdgeValueAggregator(new MaxAggregator("b", "maxB"))
+        .addVertexAggregator(new MaxAggregator("a", "maxA"))
+        .addEdgeAggregator(new MaxAggregator("b", "maxB"))
+        .setStrategy(getStrategy())
+        .build()
+        .execute(input);
+
+    collectAndAssertTrue(
+      output.equalsByElementData(loader.getLogicalGraphByVariable("expected")));
+  }
+
+  @Test
+  public void testMultipleAggregators() throws Exception {
+    FlinkAsciiGraphLoader<GraphHeadPojo, VertexPojo, EdgePojo> loader =
+      getLoaderFromString("input[" +
+        "(v0:Blue {a=3});" +
+        "(v1:Blue {a=2});" +
+        "(v2:Blue {a=4});" +
+        "(v3:Red  {a=4});" +
+        "(v4:Red  {a=2});" +
+        "(v5:Red  {a=4});" +
+        "(v0)-[{b=2}]->(v1);" +
+        "(v0)-[{b=1}]->(v2);" +
+        "(v1)-[{b=2}]->(v2);" +
+        "(v2)-[{b=3}]->(v3);" +
+        "(v2)-[{b=1}]->(v3);" +
+        "(v3)-[{b=3}]->(v4);" +
+        "(v4)-[{b=1}]->(v5);" +
+        "(v5)-[{b=1}]->(v3);" +
+        "]");
+
+    LogicalGraph<GraphHeadPojo, VertexPojo, EdgePojo> input = loader
+      .getLogicalGraphByVariable("input");
+
+    loader.appendToDatabaseFromString("expected[" +
+      "(v00:Blue {minA=2,maxA=4,sumA=9,count=3L});" +
+      "(v01:Red  {minA=2,maxA=4,sumA=10,count=3L});" +
+      "(v00)-[{minB=1,maxB=2,sumB=5,count=3L}]->(v00);" +
+      "(v00)-[{minB=1,maxB=3,sumB=4,count=2L}]->(v01);" +
+      "(v01)-[{minB=1,maxB=3,sumB=5,count=3L}]->(v01);" +
+      "]");
+
+    LogicalGraph<GraphHeadPojo, VertexPojo, EdgePojo> output =
+      new GroupingBuilder<GraphHeadPojo, VertexPojo, EdgePojo>()
+        .useVertexLabel(true)
+        .addVertexAggregator(new MinAggregator("a", "minA"))
+        .addVertexAggregator(new MaxAggregator("a", "maxA"))
+        .addVertexAggregator(new SumAggregator("a", "sumA"))
+        .addVertexAggregator(new CountAggregator("count"))
+        .addEdgeAggregator(new MinAggregator("b", "minB"))
+        .addEdgeAggregator(new MaxAggregator("b", "maxB"))
+        .addEdgeAggregator(new SumAggregator("b", "sumB"))
+        .addEdgeAggregator(new CountAggregator("count"))
         .setStrategy(getStrategy())
         .build()
         .execute(input);


### PR DESCRIPTION
Aggregate properties are managed using `PropertyValueList`, which is analogous to grouping properties.

Fixes #128