### PR TITLE
#158 ApplyAggregation does not return any value for LogicalGraphs without vertices

### DIFF
--- a/gradoop-examples/src/main/java/org/gradoop/examples/biiig/CategoryCharacteristicPatterns.java
+++ b/gradoop-examples/src/main/java/org/gradoop/examples/biiig/CategoryCharacteristicPatterns.java
@@ -75,12 +75,15 @@ public class CategoryCharacteristicPatterns implements ProgramDescription {
         new BusinessTransactionGraphs<GraphHeadPojo, VertexPojo, EdgePojo>());
 
     btgs = btgs.apply(new ApplyAggregation<>(
-      "isClosed", new IsClosedAggregateFunction()));
+      "isClosed", PropertyValue.create(0),
+      new IsClosedAggregateFunction
+      ()));
 
     btgs = btgs.select(new IsClosedPredicateFunction());
 
     btgs = btgs.apply(new ApplyAggregation<>(
-      "soCount", new CountSalesOrdersAggregateFunction()));
+      "soCount", PropertyValue.create(0),
+      new CountSalesOrdersAggregateFunction()));
 
     out.add("Business Transaction Graphs with Measures", btgs);
 

--- a/gradoop-examples/src/main/java/org/gradoop/examples/sna/SNABenchmark2.java
+++ b/gradoop-examples/src/main/java/org/gradoop/examples/sna/SNABenchmark2.java
@@ -35,6 +35,7 @@ import org.gradoop.model.impl.operators.combination.ReduceCombination;
 import org.gradoop.model.impl.pojo.EdgePojo;
 import org.gradoop.model.impl.pojo.GraphHeadPojo;
 import org.gradoop.model.impl.pojo.VertexPojo;
+import org.gradoop.model.impl.properties.PropertyValue;
 import org.gradoop.util.FlinkAsciiGraphLoader;
 import org.gradoop.util.GradoopFlinkConfig;
 
@@ -255,7 +256,9 @@ public class SNABenchmark2 implements ProgramDescription {
       .splitBy(label)
       // 4) compute vertex count per community
       .apply(new ApplyAggregation<>(
-          vertexCount, new VertexCount<GraphHeadPojo, VertexPojo, EdgePojo>()))
+        vertexCount,
+        PropertyValue.create(0L),
+        new VertexCount<GraphHeadPojo, VertexPojo, EdgePojo>()))
       // 5) select graphs with more than minClusterSize vertices
       .select(new FilterFunction<GraphHeadPojo>() {
         @Override

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/aggregation/functions/LeftOuterPropertySetter.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/aggregation/functions/LeftOuterPropertySetter.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.gradoop.model.impl.operators.aggregation.functions;
+
+import org.apache.flink.api.common.functions.CoGroupFunction;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.util.Collector;
+import org.gradoop.model.api.EPGMElement;
+import org.gradoop.model.impl.id.GradoopId;
+import org.gradoop.model.impl.properties.PropertyValue;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Performs a left outer join between an epgm element and a tuple of gradoop id
+ * and property value. The property values are set as new properties on each
+ * element with the specified property key.
+ * @param <G> epgm element type
+ */
+public class LeftOuterPropertySetter<G extends EPGMElement> implements
+  CoGroupFunction<G, Tuple2<GradoopId, PropertyValue>, G> {
+
+  /**
+   * Property key
+   */
+  private final String propertyKey;
+
+  /**
+   * User defined default value
+   */
+  private final PropertyValue defaultValue;
+
+  /**
+   * Constructor
+   *
+   * @param propertyKey property key to set value
+   * @param defaultValue user defined default value for left groups without
+   *                     matching right group
+   */
+  public LeftOuterPropertySetter(final String propertyKey,
+    PropertyValue defaultValue) {
+    this.propertyKey = checkNotNull(propertyKey);
+    this.defaultValue = defaultValue;
+  }
+
+  @Override
+  public void coGroup(Iterable<G> left,
+    Iterable<Tuple2<GradoopId, PropertyValue>> right, Collector<G> out) throws
+    Exception {
+    for (G leftElem : left) {
+      boolean rightEmpty = true;
+      for (Tuple2<GradoopId, PropertyValue> rightElem : right) {
+        leftElem.setProperty(propertyKey, rightElem.f1);
+        out.collect(leftElem);
+        rightEmpty = false;
+      }
+      if (rightEmpty) {
+        leftElem.setProperty(propertyKey, defaultValue);
+        out.collect(leftElem);
+      }
+    }
+  }
+}


### PR DESCRIPTION
When given a GraphCollection with at least one LogicalGraph that has no vertices or edges, ApplyAggregation does not return any new value. The reason is that the Co-Grouping of the AggregationFunctions returns empty groups for these graphs. A possible fix is a left outer join, setting the new property to a user-defined default element.

Using a left outer join makes the aggregation of empty graphs (without vertices and/or edges) possible.
It is now necessary to provide a default property value for these graphs.