### PR TITLE
Implemented operator ApplySubgraph, #161

### DIFF
--- a/gradoop-algorithms/src/main/java/org/gradoop/model/impl/algorithms/btgs/BusinessTransactionGraphs.java
+++ b/gradoop-algorithms/src/main/java/org/gradoop/model/impl/algorithms/btgs/BusinessTransactionGraphs.java
@@ -117,7 +117,7 @@ public class BusinessTransactionGraphs
       .map(new ComponentToNewBtgId());
 
     DataSet<Tuple2<GradoopId, GradoopId>> vertexBtgMap = btgVerticesMap
-      .flatMap(new ExpandGradoopIds())
+      .flatMap(new ExpandGradoopIds<GradoopId>())
       .map(new SwitchPair<GradoopId, GradoopId>());
 
     DataSet<G> graphHeads = btgVerticesMap

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/functions/epgm/ElementIdUpdater.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/functions/epgm/ElementIdUpdater.java
@@ -14,36 +14,33 @@
  * You should have received a copy of the GNU General Public License
  * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
  */
+
 package org.gradoop.model.impl.functions.epgm;
 
-import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.util.Collector;
+import org.gradoop.model.api.EPGMVertex;
 import org.gradoop.model.impl.id.GradoopId;
-import org.gradoop.model.impl.id.GradoopIdSet;
+
 
 /**
- * Takes a tuple 2, containing an object and a gradoop id set, and creates one
- * new tuple 2 of the object and a gradoop id for each gradoop id in the set.
+ * Updates the id of an EPGM element in a Tuple2 by the GradoopId in the
+ * second field.
  *
- * @param <T> f0 type
+ * @param <EL> EPGM element type
  */
-@FunctionAnnotation.ReadFields("f1")
-@FunctionAnnotation.ForwardedFields("f0->f0")
-public class ExpandGradoopIds<T> implements FlatMapFunction
-  <Tuple2<T, GradoopIdSet>, Tuple2<T, GradoopId>> {
+@FunctionAnnotation.ForwardedFieldsFirst("graphIds;label;properties")
+@FunctionAnnotation.ForwardedFieldsSecond("*->id")
+public class ElementIdUpdater<EL extends EPGMVertex>
+  implements MapFunction<Tuple2<EL, GradoopId>, EL> {
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
-  public void flatMap(
-    Tuple2<T, GradoopIdSet> pair,
-    Collector<Tuple2<T, GradoopId>> collector) throws Exception {
-
-    T firstField = pair.f0;
-
-    for (GradoopId toId : pair.f1) {
-      collector.collect(new Tuple2<>(firstField, toId));
-    }
-
+  public EL map(Tuple2<EL, GradoopId> tuple2) {
+    tuple2.f0.setId(tuple2.f1);
+    return tuple2.f0;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/functions/tuple/Value0Of4.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/functions/tuple/Value0Of4.java
@@ -15,32 +15,34 @@
  * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.gradoop.model.impl.operators.cloning.functions;
+package org.gradoop.model.impl.functions.tuple;
 
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
-import org.apache.flink.api.java.tuple.Tuple2;
-import org.gradoop.model.api.EPGMVertex;
-import org.gradoop.model.impl.id.GradoopId;
-
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple4;
 
 /**
- * Updates the id of an EPGM element in a Tuple2 by the GradoopId in the
- * second field.
+ * (f0,f1,f2) => f0
  *
- * @param <EL> EPGM element type
+ * @param <T0> f0 type
+ * @param <T1> f1 type
+ * @param <T2> f2 type
+ * @param <T3> f3 type
  */
-@FunctionAnnotation.ForwardedFieldsFirst("graphIds;label;properties")
-@FunctionAnnotation.ForwardedFieldsSecond("*->id")
-public class ElementIdUpdater<EL extends EPGMVertex>
-  implements MapFunction<Tuple2<EL, GradoopId>, EL> {
+@FunctionAnnotation.ForwardedFields("f0->*")
+public class Value0Of4<T0, T1, T2, T3>
+  implements
+  MapFunction<Tuple4<T0, T1, T2, T3>, T0>,
+  KeySelector<Tuple4<T0, T1, T2, T3>, T0> {
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
-  public EL map(Tuple2<EL, GradoopId> tuple2) {
-    tuple2.f0.setId(tuple2.f1);
-    return tuple2.f0;
+  public T0 map(Tuple4<T0, T1, T2, T3> quadruple) throws Exception {
+    return quadruple.f0;
+  }
+
+  @Override
+  public T0 getKey(Tuple4<T0, T1, T2, T3> quadruple) throws Exception {
+    return quadruple.f0;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/cloning/Cloning.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/cloning/Cloning.java
@@ -34,7 +34,7 @@ import org.gradoop.model.impl.operators.cloning.functions.EdgeSourceUpdateJoin;
 import org.gradoop.model.impl.operators.cloning.functions.EdgeTargetUpdateJoin;
 import org.gradoop.model.impl.operators.cloning.functions.Value0Of2ToId;
 import org.gradoop.model.impl.operators.cloning.functions.ElementGraphUpdater;
-import org.gradoop.model.impl.operators.cloning.functions.ElementIdUpdater;
+import org.gradoop.model.impl.functions.epgm.ElementIdUpdater;
 
 /**
  * Creates a copy of the logical graph with new ids for the graph head,

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/ApplySubgraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/ApplySubgraph.java
@@ -1,0 +1,360 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.gradoop.model.impl.operators.subgraph;
+
+import org.apache.flink.api.common.functions.FilterFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.gradoop.model.api.EPGMEdge;
+import org.gradoop.model.api.EPGMGraphHead;
+import org.gradoop.model.api.EPGMGraphHeadFactory;
+import org.gradoop.model.api.EPGMVertex;
+import org.gradoop.model.api.operators.ApplicableUnaryGraphToGraphOperator;
+import org.gradoop.model.impl.GraphCollection;
+import org.gradoop.model.impl.functions.epgm.Id;
+import org.gradoop.model.impl.functions.epgm.PairElementWithNewId;
+import org.gradoop.model.impl.functions.tuple.Project2To1;
+import org.gradoop.model.impl.functions.tuple.Value0Of4;
+import org.gradoop.model.impl.id.GradoopId;
+import org.gradoop.model.impl.id.GradoopIdSet;
+import org.gradoop.model.impl.operators.split.functions.InitGraphHead;
+import org.gradoop.model.impl.operators.subgraph.functions.AddGraphsToElements;
+import org.gradoop.model.impl.operators.subgraph.functions.AddGraphsToElementsCoGroup;
+import org.gradoop.model.impl.operators.subgraph.functions.EdgesWithNewGraphsTuple;
+import org.gradoop.model.impl.operators.subgraph.functions.ElementIdGraphIdTuple;
+import org.gradoop.model.impl.operators.subgraph.functions.FilterEdgeGraphs;
+import org.gradoop.model.impl.operators.subgraph.functions.IdSourceTargetGraphTuple;
+import org.gradoop.model.impl.operators.subgraph.functions.JoinTuplesWithNewGraphs;
+import org.gradoop.model.impl.operators.subgraph.functions.JoinWithSourceGraphIdSet;
+import org.gradoop.model.impl.operators.subgraph.functions.JoinWithTargetGraphIdSet;
+import org.gradoop.model.impl.operators.subgraph.functions.MergeEdgeGraphs;
+import org.gradoop.model.impl.operators.subgraph.functions.MergeTupleGraphs;
+import org.gradoop.model.impl.operators.subgraph.functions.SourceTargetIdGraphsTuple;
+
+/**
+ * Takes a collection of logical graphs and a user defined aggregate function as
+ * input. The aggregate function is applied on each logical graph contained in
+ * the collection and the aggregate is stored as an additional property at the
+ * graphs.
+ *
+ * @param <G> EPGM graph head type
+ * @param <V> EPGM vertex type
+ * @param <E> EPGM edge type
+ */
+public class ApplySubgraph<G extends EPGMGraphHead, V extends EPGMVertex, E
+  extends EPGMEdge> implements
+  ApplicableUnaryGraphToGraphOperator<G, V, E> {
+  /**
+   * Used to filter vertices from the logical graph.
+   */
+  private final FilterFunction<V> vertexFilterFunction;
+  /**
+   * Used to filter edges from the logical graph.
+   */
+  private final FilterFunction<E> edgeFilterFunction;
+
+  /**
+   * Creates a new sub graph operator instance.
+   * <p/>
+   * If both parameters are not {@code null}, the operator returns the subgraph
+   * defined by filtered vertices and edges.
+   * <p/>
+   * If the {@code edgeFilterFunction} is {@code null}, the operator returns the
+   * vertex-induced subgraph.
+   * <p/>
+   * If the {@code vertexFilterFunction} is {@code null}, the operator returns
+   * the edge-induced subgraph.
+   *
+   * @param vertexFilterFunction vertex filter function
+   * @param edgeFilterFunction   edge filter function
+   */
+  public ApplySubgraph(FilterFunction<V> vertexFilterFunction,
+    FilterFunction<E> edgeFilterFunction) {
+    if (vertexFilterFunction == null && edgeFilterFunction == null) {
+      throw new IllegalArgumentException("No filter functions was given.");
+    }
+    this.vertexFilterFunction = vertexFilterFunction;
+    this.edgeFilterFunction = edgeFilterFunction;
+  }
+
+  @Override
+  public GraphCollection<G, V, E> execute(GraphCollection<G, V, E> superGraph) {
+    return vertexFilterFunction != null && edgeFilterFunction != null ?
+      subgraph(superGraph) :
+      vertexFilterFunction != null ? vertexInducedSubgraph(superGraph) :
+        edgeInducedSubgraph(superGraph);
+  }
+
+  /**
+   * Returns one subgraph for each of the given supergraphs.
+   * The subgraphs are defined by the vertices that fulfil the vertex filter
+   * function.
+   *
+   * @param collection collection of supergraphs
+   * @return collection of vertex-induced subgraphs
+   */
+  private GraphCollection<G, V, E> vertexInducedSubgraph(
+    GraphCollection<G, V, E> collection) {
+    //--------------------------------------------------------------------------
+    // compute a dictionary that maps the old graph ids to new ones
+    //--------------------------------------------------------------------------
+
+    DataSet<Tuple2<GradoopId, GradoopId>> graphIdDictionary = collection
+      .getGraphHeads()
+      .map(new Id<G>())
+      .map(new PairElementWithNewId<GradoopId>());
+
+    //--------------------------------------------------------------------------
+    // compute new graphs
+    //--------------------------------------------------------------------------
+
+    EPGMGraphHeadFactory<G> graphFactory =
+      collection.getConfig().getGraphHeadFactory();
+
+    DataSet<G> newGraphHeads = graphIdDictionary
+      .map(new Project2To1<GradoopId, GradoopId>())
+      .map(new InitGraphHead<>(graphFactory));
+
+    //--------------------------------------------------------------------------
+    // compute pairs of a vertex id and the set of new graphs this vertex is
+    // contained in
+    // filter function is applied first to improve performance
+    //--------------------------------------------------------------------------
+
+    DataSet<Tuple2<GradoopId, GradoopIdSet>> vertexIdsWithNewGraphs =
+      collection.getVertices()
+        .filter(vertexFilterFunction)
+        .flatMap(new ElementIdGraphIdTuple<V>())
+        .join(graphIdDictionary)
+        .where(1)
+        .equalTo(0)
+        .with(new JoinTuplesWithNewGraphs())
+        .groupBy(0)
+        .reduceGroup(new MergeTupleGraphs());
+
+    //--------------------------------------------------------------------------
+    // compute new vertices
+    //--------------------------------------------------------------------------
+
+    DataSet<V> newVertices = vertexIdsWithNewGraphs
+        .join(collection.getVertices())
+        .where(0)
+        .equalTo(new Id<V>())
+        .with(new AddGraphsToElements<V>());
+
+    //--------------------------------------------------------------------------
+    // build tuples4 for each edge, containing
+    // edge id, source id, target id, set of new graph ids
+    //--------------------------------------------------------------------------
+
+    DataSet<Tuple4<GradoopId, GradoopId, GradoopId, GradoopIdSet>> edgeTuple =
+      collection.getEdges()
+        .flatMap(new IdSourceTargetGraphTuple<E>())
+        .join(graphIdDictionary)
+        .where(3).equalTo(0)
+        .with(new EdgesWithNewGraphsTuple())
+        .groupBy(new Value0Of4<GradoopId, GradoopId, GradoopId, GradoopId>())
+        .reduceGroup(new MergeEdgeGraphs());
+
+    //--------------------------------------------------------------------------
+    // join the tuple4 with vertex tuples, keeping the graph sets
+    // apply a "filter" by using a flat map function to check for each edge
+    // if a graph exists that this edge, its source and its target are contained
+    // in
+    // the result tuple consists of
+    // edge id, new edge graphs
+    //--------------------------------------------------------------------------
+
+    DataSet<Tuple2<GradoopId, GradoopIdSet>> edgeIdsWithNewGraphs =
+      edgeTuple
+        .join(vertexIdsWithNewGraphs)
+        .where(1).equalTo(0)
+        .with(new JoinWithSourceGraphIdSet())
+        .join(vertexIdsWithNewGraphs)
+        .where(2).equalTo(0)
+        .with(new JoinWithTargetGraphIdSet())
+        .flatMap(new FilterEdgeGraphs());
+
+    //--------------------------------------------------------------------------
+    // compute the new edges
+    //--------------------------------------------------------------------------
+
+    DataSet<E> newEdges = edgeIdsWithNewGraphs
+      .join(collection.getEdges())
+      .where(0)
+      .equalTo(new Id<E>())
+      .with(new AddGraphsToElements<E>());
+
+    return GraphCollection.fromDataSets(newGraphHeads, newVertices, newEdges,
+      collection.getConfig());
+  }
+
+  /**
+   * Returns one subgraph for each of the given supergraphs.
+   * The subgraphs are defined by the edges that fulfil the vertex filter
+   * function.
+   *
+   * @param collection collection of supergraphs
+   * @return collection of edge-induced subgraphs
+   */
+  private GraphCollection<G, V, E> edgeInducedSubgraph(
+    GraphCollection<G, V, E> collection) {
+    //--------------------------------------------------------------------------
+    // compute a dictionary that maps the old graph ids to new ones
+    //--------------------------------------------------------------------------
+
+    DataSet<Tuple2<GradoopId, GradoopId>> graphIdDictionary = collection
+      .getGraphHeads()
+      .map(new Id<G>())
+      .map(new PairElementWithNewId<GradoopId>());
+
+    //--------------------------------------------------------------------------
+    // compute new graphs
+    //--------------------------------------------------------------------------
+
+    EPGMGraphHeadFactory<G> graphFactory =
+      collection.getConfig().getGraphHeadFactory();
+
+    DataSet<G> newGraphHeads = graphIdDictionary
+      .map(new Project2To1<GradoopId, GradoopId>())
+      .map(new InitGraphHead<>(graphFactory));
+
+    //--------------------------------------------------------------------------
+    // compute new edges by applying the filter function,
+    // building tuples containing the edge id and the new graphs this edge is
+    // contained in and finally adding the new graphs to the edges
+    //--------------------------------------------------------------------------
+
+    DataSet<E> newEdges = collection
+      .getEdges()
+      .filter(edgeFilterFunction)
+      .flatMap(new ElementIdGraphIdTuple<E>())
+      .join(graphIdDictionary)
+      .where(1)
+      .equalTo(0)
+      .with(new JoinTuplesWithNewGraphs())
+      .groupBy(0)
+      .reduceGroup(new MergeTupleGraphs())
+      .join(collection.getEdges())
+      .where(0)
+      .equalTo(new Id<E>())
+      .with(new AddGraphsToElements<E>());
+
+    //--------------------------------------------------------------------------
+    // compute the new vertices
+    // first, tuples 2 containing the sources and targets of all new edges in
+    // the first field and the new graphs this edge is contained in is created
+    // this is then joined with the input vertices and the new graphs
+    // are added to the vertices
+    //--------------------------------------------------------------------------
+
+    DataSet<V> newVertices = newEdges
+      .flatMap(new SourceTargetIdGraphsTuple<E>())
+      .distinct(0)
+      .coGroup(collection.getVertices())
+      .where(0)
+      .equalTo(new Id<V>())
+      .with(new AddGraphsToElementsCoGroup<V>());
+
+    return GraphCollection.fromDataSets(newGraphHeads, newVertices, newEdges,
+      collection.getConfig());
+  }
+
+  /**
+   * Returns one subgraph for each of the given supergraphs.
+   * The subgraphs are defined by the vertices that fulfil the vertex filter
+   * function and edges that fulfill the edge filter function.
+   *
+   * Note, that the operator does not verify the consistency of the resulting
+   * graph.
+   *
+   * @param collection collection of supergraphs
+   * @return collection of subgraphs
+   */
+  private GraphCollection<G, V, E> subgraph(
+    GraphCollection<G, V, E> collection) {
+
+    //--------------------------------------------------------------------------
+    // compute a dictionary that maps the old graph ids to new ones
+    //--------------------------------------------------------------------------
+
+    DataSet<Tuple2<GradoopId, GradoopId>> graphIdDictionary = collection
+      .getGraphHeads()
+      .map(new Id<G>())
+      .map(new PairElementWithNewId<GradoopId>());
+
+    //--------------------------------------------------------------------------
+    // compute new graphs
+    //--------------------------------------------------------------------------
+
+    EPGMGraphHeadFactory<G> graphFactory =
+      collection.getConfig().getGraphHeadFactory();
+
+    DataSet<G> newGraphHeads = graphIdDictionary
+      .map(new Project2To1<GradoopId, GradoopId>())
+      .map(new InitGraphHead<>(graphFactory));
+
+    //--------------------------------------------------------------------------
+    // compute pairs of a vertex and the set of new graphs this vertex is
+    // contained in
+    // filter function is applied first to improve performance
+    //--------------------------------------------------------------------------
+
+    DataSet<V> newVertices =
+      collection.getVertices()
+        .filter(vertexFilterFunction)
+        .flatMap(new ElementIdGraphIdTuple<V>())
+        .join(graphIdDictionary)
+        .where(1).equalTo(0)
+        .with(new JoinTuplesWithNewGraphs())
+        .groupBy(0)
+        .reduceGroup(new MergeTupleGraphs())
+        .join(collection.getVertices())
+        .where(0)
+        .equalTo(new Id<V>())
+        .with(new AddGraphsToElements<V>());
+
+    //--------------------------------------------------------------------------
+    // compute pairs of an edge and the set of new graphs this edge is
+    // contained in
+    // filter function is applied first to improve performance
+    //--------------------------------------------------------------------------
+
+    DataSet<E> newEdges = collection.getEdges()
+      .filter(edgeFilterFunction)
+      .flatMap(new ElementIdGraphIdTuple<E>())
+      .join(graphIdDictionary)
+      .where(1)
+      .equalTo(0)
+      .with(new JoinTuplesWithNewGraphs())
+      .groupBy(0)
+      .reduceGroup(new MergeTupleGraphs())
+      .join(collection.getEdges())
+      .where(0)
+      .equalTo(new Id<E>())
+      .with(new AddGraphsToElements<E>());
+
+    return GraphCollection.fromDataSets(newGraphHeads, newVertices, newEdges,
+      collection.getConfig());
+  }
+
+  @Override
+  public String getName() {
+    return ApplySubgraph.class.getName();
+  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/AddGraphsToElementsCoGroup.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/AddGraphsToElementsCoGroup.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.gradoop.model.impl.operators.subgraph.functions;
+
+import org.apache.flink.api.common.functions.CoGroupFunction;
+import org.apache.flink.api.java.functions.FunctionAnnotation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.util.Collector;
+import org.gradoop.model.api.EPGMGraphElement;
+import org.gradoop.model.impl.id.GradoopId;
+import org.gradoop.model.impl.id.GradoopIdSet;
+
+/**
+ * CoGroups tuples containing gradoop ids and gradoop id sets with graph
+ * elements with the same gradoop ids and adds the gradoop id sets to each
+ * element.
+ * @param <EL> epgm graph element type
+ */
+
+@FunctionAnnotation.ReadFieldsFirst("f1")
+@FunctionAnnotation.ForwardedFieldsSecond("id;label;properties")
+public class AddGraphsToElementsCoGroup<EL extends EPGMGraphElement>
+  implements CoGroupFunction<Tuple2<GradoopId, GradoopIdSet>, EL, EL> {
+
+  @Override
+  public void coGroup(
+    Iterable<Tuple2<GradoopId, GradoopIdSet>> graphs,
+    Iterable<EL> elements,
+    Collector<EL> collector) throws Exception {
+    for (EL element : elements) {
+      for (Tuple2<GradoopId, GradoopIdSet> graphSet : graphs) {
+        element.getGraphIds().addAll(graphSet.f1);
+      }
+      collector.collect(element);
+    }
+  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/EdgesWithNewGraphsTuple.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/EdgesWithNewGraphsTuple.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.gradoop.model.impl.operators.subgraph.functions;
+
+import org.apache.flink.api.common.functions.JoinFunction;
+import org.apache.flink.api.java.functions.FunctionAnnotation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.gradoop.model.impl.id.GradoopId;
+
+/**
+ * Join the edge tuples with the new graph ids.
+ */
+
+@FunctionAnnotation.ForwardedFieldsFirst("f0->f0;f1->f1;f2->f2")
+@FunctionAnnotation.ForwardedFieldsSecond("f1->f3")
+public class EdgesWithNewGraphsTuple
+  implements JoinFunction<
+  Tuple4<GradoopId, GradoopId, GradoopId, GradoopId>,
+  Tuple2<GradoopId, GradoopId>,
+  Tuple4<GradoopId, GradoopId, GradoopId, GradoopId>> {
+
+  /**
+   * Reduce object instantiations
+   */
+  private Tuple4<GradoopId, GradoopId, GradoopId, GradoopId> reuseTuple =
+    new Tuple4<>();
+
+  @Override
+  public Tuple4<GradoopId, GradoopId, GradoopId, GradoopId> join(
+    Tuple4<GradoopId, GradoopId, GradoopId, GradoopId> left,
+    Tuple2<GradoopId, GradoopId> right) throws Exception {
+    reuseTuple.f0 = left.f0;
+    reuseTuple.f1 = left.f1;
+    reuseTuple.f2 = left.f2;
+    reuseTuple.f3 = right.f1;
+    return reuseTuple;
+  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/ElementIdGraphIdTuple.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/ElementIdGraphIdTuple.java
@@ -14,36 +14,35 @@
  * You should have received a copy of the GNU General Public License
  * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.gradoop.model.impl.functions.epgm;
+
+package org.gradoop.model.impl.operators.subgraph.functions;
 
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
+import org.gradoop.model.api.EPGMGraphElement;
 import org.gradoop.model.impl.id.GradoopId;
-import org.gradoop.model.impl.id.GradoopIdSet;
 
 /**
- * Takes a tuple 2, containing an object and a gradoop id set, and creates one
- * new tuple 2 of the object and a gradoop id for each gradoop id in the set.
- *
- * @param <T> f0 type
+ * Creates a tuple containing the id of the element and the id of one graph for
+ * each graph the element is contained in.
+ * (id:el{id1, id2}) => (id, id1),(id, id2)
+ * @param <EL> epgm graph element type
  */
-@FunctionAnnotation.ReadFields("f1")
-@FunctionAnnotation.ForwardedFields("f0->f0")
-public class ExpandGradoopIds<T> implements FlatMapFunction
-  <Tuple2<T, GradoopIdSet>, Tuple2<T, GradoopId>> {
+
+@FunctionAnnotation.ReadFields("graphIds")
+@FunctionAnnotation.ForwardedFields("id->f0")
+public class ElementIdGraphIdTuple<EL extends EPGMGraphElement>
+  implements FlatMapFunction<EL, Tuple2<GradoopId, GradoopId>> {
 
   @Override
   public void flatMap(
-    Tuple2<T, GradoopIdSet> pair,
-    Collector<Tuple2<T, GradoopId>> collector) throws Exception {
+    EL element,
+    Collector<Tuple2<GradoopId, GradoopId>> collector) throws Exception {
 
-    T firstField = pair.f0;
-
-    for (GradoopId toId : pair.f1) {
-      collector.collect(new Tuple2<>(firstField, toId));
+    for (GradoopId graph : element.getGraphIds()) {
+      collector.collect(new Tuple2<>(element.getId(), graph));
     }
-
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/FilterEdgeGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/FilterEdgeGraphs.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.gradoop.model.impl.operators.subgraph.functions;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.java.functions.FunctionAnnotation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.apache.flink.util.Collector;
+import org.gradoop.model.impl.id.GradoopId;
+import org.gradoop.model.impl.id.GradoopIdSet;
+
+/**
+ * Filter the edge tuples. Check if each new graph the edge is contained in
+ * also contains the source and target of this edge. Only collect the edge if
+ * it is valid in at least one graph.
+ */
+
+@FunctionAnnotation.ReadFields("f1;f2;f3")
+@FunctionAnnotation.ForwardedFields("f0->f0")
+public class FilterEdgeGraphs
+  implements FlatMapFunction<
+  Tuple4<GradoopId, GradoopIdSet, GradoopIdSet, GradoopIdSet>,
+  Tuple2<GradoopId, GradoopIdSet>> {
+
+  /**
+   * Reduce object instantiations
+   */
+  private Tuple2<GradoopId, GradoopIdSet> reuseTuple = new Tuple2<>();
+
+  @Override
+  public void flatMap(
+    Tuple4<GradoopId, GradoopIdSet, GradoopIdSet, GradoopIdSet> edgeTuple,
+    Collector<Tuple2<GradoopId, GradoopIdSet>> collector) throws Exception {
+    GradoopIdSet set = new GradoopIdSet();
+    for (GradoopId edgeGraph : edgeTuple.f3) {
+      for (GradoopId sourceGraph : edgeTuple.f1) {
+        if (edgeGraph.equals(sourceGraph)) {
+          for (GradoopId targetGraph : edgeTuple.f2) {
+            if (edgeGraph.equals(targetGraph)) {
+              set.add(edgeGraph);
+            }
+          }
+        }
+      }
+    }
+    if (!set.isEmpty()) {
+      reuseTuple.f0 = edgeTuple.f0;
+      reuseTuple.f1 = set;
+      collector.collect(reuseTuple);
+    }
+  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/IdSourceTargetGraphTuple.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/IdSourceTargetGraphTuple.java
@@ -14,35 +14,40 @@
  * You should have received a copy of the GNU General Public License
  * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.gradoop.model.impl.functions.epgm;
+
+package org.gradoop.model.impl.operators.subgraph.functions;
 
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
-import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.util.Collector;
+import org.gradoop.model.api.EPGMEdge;
 import org.gradoop.model.impl.id.GradoopId;
-import org.gradoop.model.impl.id.GradoopIdSet;
 
 /**
- * Takes a tuple 2, containing an object and a gradoop id set, and creates one
- * new tuple 2 of the object and a gradoop id for each gradoop id in the set.
+ * Maps an edge  tuples 4 containing the id of this edge, the id of its
+ * source and target and a graph this edge is contained in. One tuple per graph.
  *
- * @param <T> f0 type
+ * @param <E> epgm edge type
  */
-@FunctionAnnotation.ReadFields("f1")
-@FunctionAnnotation.ForwardedFields("f0->f0")
-public class ExpandGradoopIds<T> implements FlatMapFunction
-  <Tuple2<T, GradoopIdSet>, Tuple2<T, GradoopId>> {
+
+@FunctionAnnotation.ReadFields("graphIds")
+@FunctionAnnotation.ForwardedFields("id->f0;sourceId->f1;targetId->f2")
+public class IdSourceTargetGraphTuple<E extends EPGMEdge>
+  implements FlatMapFunction<
+  E, Tuple4<GradoopId, GradoopId, GradoopId, GradoopId>> {
 
   @Override
   public void flatMap(
-    Tuple2<T, GradoopIdSet> pair,
-    Collector<Tuple2<T, GradoopId>> collector) throws Exception {
+    E edge,
+    Collector<Tuple4<GradoopId, GradoopId, GradoopId, GradoopId>> collector) {
 
-    T firstField = pair.f0;
-
-    for (GradoopId toId : pair.f1) {
-      collector.collect(new Tuple2<>(firstField, toId));
+    for (GradoopId graphId : edge.getGraphIds()) {
+      collector.collect(new Tuple4<>(
+        edge.getId(),
+        edge.getSourceId(),
+        edge.getTargetId(),
+        graphId));
     }
 
   }

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/JoinTuplesWithNewGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/JoinTuplesWithNewGraphs.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.gradoop.model.impl.operators.subgraph.functions;
+
+import org.apache.flink.api.common.functions.JoinFunction;
+import org.apache.flink.api.java.functions.FunctionAnnotation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.gradoop.model.impl.id.GradoopId;
+
+/**
+ * Join a tuple of an element id and a graph id with a dictionary mapping each
+ * graph to a new graph. Result is a tuple of the id of the element and the id
+ * of the new graph.
+ */
+
+@FunctionAnnotation.ForwardedFieldsFirst("f0->f0")
+@FunctionAnnotation.ForwardedFieldsSecond("f1->f1")
+public class JoinTuplesWithNewGraphs
+  implements JoinFunction<
+  Tuple2<GradoopId, GradoopId>, Tuple2<GradoopId, GradoopId>,
+  Tuple2<GradoopId, GradoopId>> {
+
+
+  /**
+   * Reduce object instantiations
+   */
+  private Tuple2<GradoopId, GradoopId> reuseTuple = new Tuple2<>();
+
+  @Override
+  public Tuple2<GradoopId, GradoopId> join(
+    Tuple2<GradoopId, GradoopId> left,
+    Tuple2<GradoopId, GradoopId> right) throws Exception {
+    reuseTuple.f0 = left.f0;
+    reuseTuple.f1 = right.f1;
+    return reuseTuple;
+  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/JoinWithSourceGraphIdSet.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/JoinWithSourceGraphIdSet.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.gradoop.model.impl.operators.subgraph.functions;
+
+import org.apache.flink.api.common.functions.JoinFunction;
+import org.apache.flink.api.java.functions.FunctionAnnotation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.gradoop.model.impl.id.GradoopId;
+import org.gradoop.model.impl.id.GradoopIdSet;
+
+/**
+ * Join an edge tuple with a tuple containing the source vertex id of this edge
+ * and its new graphs.
+ */
+
+@FunctionAnnotation.ForwardedFieldsFirst("f0->f0;f2->f2;f3->f3")
+@FunctionAnnotation.ForwardedFieldsSecond("f1->f1")
+public class JoinWithSourceGraphIdSet
+  implements JoinFunction<
+  Tuple4<GradoopId, GradoopId, GradoopId, GradoopIdSet>,
+  Tuple2<GradoopId, GradoopIdSet>,
+  Tuple4<GradoopId, GradoopIdSet, GradoopId, GradoopIdSet>> {
+
+  /**
+   * Reduce object instantiations
+   */
+  private Tuple4<GradoopId, GradoopIdSet, GradoopId, GradoopIdSet> reuseTuple
+    = new Tuple4<>();
+
+  @Override
+  public Tuple4<GradoopId, GradoopIdSet, GradoopId, GradoopIdSet> join(
+    Tuple4<GradoopId, GradoopId, GradoopId, GradoopIdSet> edge,
+    Tuple2<GradoopId, GradoopIdSet> vertex) throws
+    Exception {
+    reuseTuple.f0 = edge.f0;
+    reuseTuple.f1 = vertex.f1;
+    reuseTuple.f2 = edge.f2;
+    reuseTuple.f3 = edge.f3;
+    return reuseTuple;
+  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/JoinWithTargetGraphIdSet.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/JoinWithTargetGraphIdSet.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.gradoop.model.impl.operators.subgraph.functions;
+
+import org.apache.flink.api.common.functions.JoinFunction;
+import org.apache.flink.api.java.functions.FunctionAnnotation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.gradoop.model.impl.id.GradoopId;
+import org.gradoop.model.impl.id.GradoopIdSet;
+
+/**
+ * Join an edge tuple with a tuple containing the target vertex id of this edge
+ * and its new graphs.
+ */
+
+@FunctionAnnotation.ForwardedFieldsFirst("f0->f0;f1->f1;f3->f3")
+@FunctionAnnotation.ForwardedFieldsSecond("f1->f2")
+public class JoinWithTargetGraphIdSet
+  implements JoinFunction<
+  Tuple4<GradoopId, GradoopIdSet, GradoopId, GradoopIdSet>,
+  Tuple2<GradoopId, GradoopIdSet>,
+  Tuple4<GradoopId, GradoopIdSet, GradoopIdSet, GradoopIdSet>> {
+
+  /**
+   * Reduce object instantiations
+   */
+  private Tuple4<GradoopId, GradoopIdSet, GradoopIdSet, GradoopIdSet> reuseTuple
+    = new Tuple4<>();
+
+  @Override
+  public Tuple4<GradoopId, GradoopIdSet, GradoopIdSet, GradoopIdSet> join(
+    Tuple4<GradoopId, GradoopIdSet, GradoopId, GradoopIdSet> edge,
+    Tuple2<GradoopId, GradoopIdSet> vertex) throws
+    Exception {
+    reuseTuple.f0 = edge.f0;
+    reuseTuple.f1 = edge.f1;
+    reuseTuple.f2 = vertex.f1;
+    reuseTuple.f3 = edge.f3;
+    return reuseTuple;
+  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/MergeEdgeGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/MergeEdgeGraphs.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.gradoop.model.impl.operators.subgraph.functions;
+
+import org.apache.flink.api.common.functions.GroupReduceFunction;
+import org.apache.flink.api.java.functions.FunctionAnnotation;
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.apache.flink.util.Collector;
+import org.gradoop.model.impl.id.GradoopId;
+import org.gradoop.model.impl.id.GradoopIdSet;
+
+/**
+ * Reduces groups of tuples 4 consisting of 4 gradoop ids
+ * into one tuple per group, containing the first three gradoop ids of the
+ * first element in this group and a gradoop id set, containing all gradoop
+ * ids in the fourth slot.
+ */
+
+@FunctionAnnotation.ForwardedFieldsFirst("f0->f0;f2->f2;f3->f3")
+@FunctionAnnotation.ForwardedFieldsSecond("f1->f1")
+public class MergeEdgeGraphs implements
+  GroupReduceFunction<
+    Tuple4<GradoopId, GradoopId, GradoopId, GradoopId>,
+    Tuple4<GradoopId, GradoopId, GradoopId, GradoopIdSet>> {
+
+  @Override
+  public void reduce(
+    Iterable<Tuple4<GradoopId, GradoopId, GradoopId, GradoopId>> iterable,
+    Collector<
+      Tuple4<GradoopId, GradoopId, GradoopId, GradoopIdSet>> collector) {
+
+    GradoopIdSet set = new GradoopIdSet();
+
+    boolean empty = true;
+    GradoopId f0 = null;
+    GradoopId f1 = null;
+    GradoopId f2 = null;
+
+    for (Tuple4<GradoopId, GradoopId, GradoopId, GradoopId> tuple : iterable) {
+      set.add(tuple.f3);
+      empty = false;
+      f0 = tuple.f0;
+      f1 = tuple.f1;
+      f2 = tuple.f2;
+    }
+
+    if (!empty) {
+      collector.collect(new Tuple4<>(f0, f1, f2, set));
+    }
+  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/SourceTargetIdGraphsTuple.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/SourceTargetIdGraphsTuple.java
@@ -14,36 +14,36 @@
  * You should have received a copy of the GNU General Public License
  * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.gradoop.model.impl.functions.epgm;
+
+package org.gradoop.model.impl.operators.subgraph.functions;
 
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
+import org.gradoop.model.api.EPGMEdge;
 import org.gradoop.model.impl.id.GradoopId;
 import org.gradoop.model.impl.id.GradoopIdSet;
 
 /**
- * Takes a tuple 2, containing an object and a gradoop id set, and creates one
- * new tuple 2 of the object and a gradoop id for each gradoop id in the set.
+ * For each edge, collect two tuple 2 containing its source or target id in the
+ * first field and all the graphs this edge is contained in in its second field.
  *
- * @param <T> f0 type
+ * @param <E> epgm edge type
  */
-@FunctionAnnotation.ReadFields("f1")
-@FunctionAnnotation.ForwardedFields("f0->f0")
-public class ExpandGradoopIds<T> implements FlatMapFunction
-  <Tuple2<T, GradoopIdSet>, Tuple2<T, GradoopId>> {
+
+@FunctionAnnotation.ReadFields("sourceId;targetId")
+@FunctionAnnotation.ForwardedFields("graphIds->f1")
+public class SourceTargetIdGraphsTuple<E extends EPGMEdge>
+  implements FlatMapFunction<E, Tuple2<GradoopId, GradoopIdSet>> {
 
   @Override
   public void flatMap(
-    Tuple2<T, GradoopIdSet> pair,
-    Collector<Tuple2<T, GradoopId>> collector) throws Exception {
+    E e,
+    Collector<Tuple2<GradoopId, GradoopIdSet>> collector) throws
+    Exception {
 
-    T firstField = pair.f0;
-
-    for (GradoopId toId : pair.f1) {
-      collector.collect(new Tuple2<>(firstField, toId));
-    }
-
+    collector.collect(new Tuple2<>(e.getSourceId(), e.getGraphIds()));
+    collector.collect(new Tuple2<>(e.getTargetId(), e.getGraphIds()));
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/package-info.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/subgraph/functions/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Contains all user defined functions related to the subgraph operator
+ * implementation.
+ * */
+package org.gradoop.model.impl.operators.subgraph.functions;


### PR DESCRIPTION
Created class ApplySubgraph that implements ApplicableUnaryGraphToGraphOperator. Through this, the subgraph operator is now applicable to GraphCollections.

Implemented various functions in package org.gradoop.model.impl.operators.subgraph.functions used by ApplySubgraph.

Moved ElementIdUpdater to org.gradoop.model.impl.functions.epgm because its now used outside of cloning.

Added Value0Of4 function.

Changed ExpandGradoopIds to be applicable to any Tuple2 containing a GradoopIdSet in its second field. Also added documentation and function annotations.