### PR TITLE
Changed Split operator to enable preservation of inter graph edges.

### DIFF
--- a/gradoop-examples/src/main/java/org/gradoop/examples/sna/SNABenchmark2.java
+++ b/gradoop-examples/src/main/java/org/gradoop/examples/sna/SNABenchmark2.java
@@ -226,7 +226,7 @@ public class SNABenchmark2
         new GellyLabelPropagation<GraphHeadPojo, VertexPojo, EdgePojo>(
           maxIterations, label))
       // 3b) separate communities
-      .splitBy(label)
+      .splitBy(label, false)
       // 4) compute vertex count per community
       .apply(new ApplyAggregation<>(
         vertexCount,

--- a/gradoop-flink/src/main/java/org/gradoop/model/api/operators/LogicalGraphOperators.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/api/operators/LogicalGraphOperators.java
@@ -407,9 +407,12 @@ public interface LogicalGraphOperators
    * not have this property will be removed from the resulting collection.
    *
    * @param propertyKey split property key
+   * @param preserveInterEdges if edges between created graphs should be
+   *                           preserved in an additional graph
    * @return graph collection
    */
-  GraphCollection<G, V, E> splitBy(String propertyKey);
+  GraphCollection<G, V, E> splitBy(
+    String propertyKey, boolean preserveInterEdges);
 
   /**
    * Creates a logical graph using the given unary graph operator.

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/LogicalGraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/LogicalGraph.java
@@ -705,10 +705,12 @@ public class LogicalGraph
    * {@inheritDoc}
    */
   @Override
-  public GraphCollection<G, V, E> splitBy(String propertyKey) {
+  public GraphCollection<G, V, E> splitBy(
+    String propertyKey, boolean preserveInterEdges) {
     return callForCollection(
       new Split<G, V, E>(
-        new PropertyGetter<V>(Lists.newArrayList(propertyKey))));
+        new PropertyGetter<V>(Lists.newArrayList(propertyKey)),
+        preserveInterEdges));
   }
 
   //----------------------------------------------------------------------------

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/split/functions/AddInterGraphToEdges.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/split/functions/AddInterGraphToEdges.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.gradoop.model.impl.operators.split.functions;
+
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+import org.gradoop.model.api.EPGMEdge;
+import org.gradoop.model.impl.id.GradoopId;
+import org.gradoop.model.impl.id.GradoopIdSet;
+
+/**
+ * Adds the id of the graph containing edges between the newly created graphs
+ * to the these edges.
+ *
+ * @param <E> EPGM edge Type
+ */
+public class AddInterGraphToEdges<E extends EPGMEdge>
+  extends RichFlatMapFunction<Tuple3<E, GradoopIdSet, GradoopIdSet>, E> {
+
+  /**
+   * constant string for accessing broadcast variable "inter graph id"
+   */
+  public static final String INTER_GRAPH_ID = "inter graph id";
+
+  /**
+   * Id of the graph that contains the edges between the newly created graphs.
+   */
+  private Tuple1<GradoopId> interGraphId;
+
+  @Override
+  public void open(Configuration parameters) throws Exception {
+    super.open(parameters);
+    interGraphId = getRuntimeContext()
+      .<Tuple1<GradoopId>>getBroadcastVariable(INTER_GRAPH_ID).get(0);
+  }
+
+  @Override
+  public void flatMap(Tuple3<E, GradoopIdSet, GradoopIdSet> triple,
+    Collector<E> collector) throws Exception {
+
+    GradoopIdSet sourceGraphs = triple.f1;
+    GradoopIdSet targetGraphs = triple.f2;
+
+    boolean filter = false;
+    for (GradoopId id : sourceGraphs) {
+      if (targetGraphs.contains(id)) {
+        filter = true;
+      }
+    }
+
+    if (!filter) {
+      E edge = triple.f0;
+      edge.getGraphIds().add(interGraphId.f0);
+      collector.collect(edge);
+    }
+  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/split/functions/AddInterGraphToVertices.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/split/functions/AddInterGraphToVertices.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.gradoop.model.impl.operators.split.functions;
+
+import org.apache.flink.api.common.functions.RichCoGroupFunction;
+import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+import org.gradoop.model.api.EPGMVertex;
+import org.gradoop.model.impl.id.GradoopId;
+
+/**
+ * Adds the id of the graph containing edges between the newly created graphs
+ * to the vertices of this edges.
+ *
+ * @param <V> EPGM vertex type
+ */
+public class AddInterGraphToVertices<V extends EPGMVertex> extends
+  RichCoGroupFunction<Tuple1<GradoopId>, V, V> {
+
+  /**
+   * constant string for accessing broadcast variable "inter graph id"
+   */
+  public static final String INTER_GRAPH_ID = "inter graph id";
+
+  /**
+   * Id of the graph that contains the edges between the newly created graphs.
+   */
+  private Tuple1<GradoopId> interGraphId;
+
+  @Override
+  public void open(Configuration parameters) throws Exception {
+    super.open(parameters);
+    interGraphId = getRuntimeContext()
+        .<Tuple1<GradoopId>>getBroadcastVariable(INTER_GRAPH_ID).get(0);
+  }
+
+  @Override
+  public void coGroup(Iterable<Tuple1<GradoopId>> first, Iterable<V> second,
+    Collector<V> collector) throws Exception {
+    for (V vertex : second) {
+      if (first.iterator().hasNext()) {
+        vertex.getGraphIds().add(interGraphId.f0);
+        collector.collect(vertex);
+      } else {
+        collector.collect(vertex);
+      }
+    }
+  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/split/functions/InitGraphHead.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/split/functions/InitGraphHead.java
@@ -61,7 +61,7 @@ public class InitGraphHead<G extends EPGMGraphHead>
   @SuppressWarnings("unchecked")
   @Override
   public TypeInformation<G> getProducedType() {
-    return (TypeInformation<G>) TypeExtractor
+    return TypeExtractor
       .createTypeInfo(graphHeadFactory.getType());
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/split/functions/SourceAndTargetId.java
+++ b/gradoop-flink/src/main/java/org/gradoop/model/impl/operators/split/functions/SourceAndTargetId.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.gradoop.model.impl.operators.split.functions;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.util.Collector;
+import org.gradoop.model.api.EPGMEdge;
+import org.gradoop.model.impl.id.GradoopId;
+
+/**
+ * Returns the source and target ids of an edge as tuple1.
+ *
+ * @param <E> EPGM edge type
+ */
+public class SourceAndTargetId<E extends EPGMEdge>
+  implements FlatMapFunction<E, Tuple1<GradoopId>> {
+
+  /**
+   * Reduce object instantiation.
+   */
+  private Tuple1<GradoopId> reuseTuple = new Tuple1<>();
+
+  @Override
+  public void flatMap(E edge, Collector<Tuple1<GradoopId>> collector) {
+    reuseTuple.f0 = edge.getSourceId();
+    collector.collect(reuseTuple);
+
+    reuseTuple.f0 = edge.getTargetId();
+    collector.collect(reuseTuple);
+  }
+}


### PR DESCRIPTION
Added boolean flag to split operator. If this flag is set true, a new graph is created that contains all edges between the other graphs, that would be deleted otherwise.

Fixes #159.