### PR TITLE
[#359] Added for-loop traverser implementation

### DIFF
--- a/gradoop-examples/src/main/java/org/gradoop/benchmark/grouping/GroupingBenchmark.java
+++ b/gradoop-examples/src/main/java/org/gradoop/benchmark/grouping/GroupingBenchmark.java
@@ -41,8 +41,8 @@ import java.util.regex.Pattern;
 /**
  * A dedicated program for parametrized graph grouping benchmark.
  */
-public class GroupingBenchmark extends AbstractRunner implements
-  ProgramDescription {
+public class GroupingBenchmark extends AbstractRunner
+  implements ProgramDescription {
 
   /**
    * Option to declare path to input graph

--- a/gradoop-examples/src/main/java/org/gradoop/benchmark/patternmatching/Queries.java
+++ b/gradoop-examples/src/main/java/org/gradoop/benchmark/patternmatching/Queries.java
@@ -87,6 +87,15 @@ public class Queries {
    *
    * (0)<-0-(1)-1->(2)
    *
+   * static:
+   * TraversalCode{steps=[(1,0,0,true), (1,1,2,true)]}
+   * embeddingCount = 67.833.471
+   *
+   * GDL:
+   * TraversalCode{steps=[(0,0,1,false), (1,1,2,true)]}
+   * embeddingCount = 62.728.432
+   *
+   *
    * @return query q2
    */
   public static Query q2() {

--- a/gradoop-examples/src/main/java/org/gradoop/benchmark/patternmatching/Queries.java
+++ b/gradoop-examples/src/main/java/org/gradoop/benchmark/patternmatching/Queries.java
@@ -1,0 +1,175 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.gradoop.benchmark.patternmatching;
+
+import org.gradoop.flink.model.impl.operators.matching.common.query.Step;
+import org.gradoop.flink.model.impl.operators.matching.common.query.TraversalCode;
+
+/**
+ * Set of benchmark queries
+ */
+public class Queries {
+
+  /**
+   * Query representation
+   */
+  public static class Query {
+    /**
+     * {@link TraversalCode} for the query
+     */
+    private TraversalCode traversalCode;
+    /**
+     * Number of query vertices
+     */
+    private int vertexCount;
+    /**
+     * Number of query edges
+     */
+    private int edgeCount;
+
+    /**
+     * Constructor
+     *
+     * @param traversalCode traversal code
+     * @param vertexCount   number of query vertices
+     * @param edgeCount     number of query edges
+     */
+    Query(TraversalCode traversalCode, int vertexCount, int edgeCount) {
+      this.traversalCode = traversalCode;
+      this.vertexCount = vertexCount;
+      this.edgeCount = edgeCount;
+    }
+
+    public TraversalCode getTraversalCode() {
+      return traversalCode;
+    }
+
+    public int getVertexCount() {
+      return vertexCount;
+    }
+
+    public int getEdgeCount() {
+      return edgeCount;
+    }
+  }
+
+  /**
+   * (a)-->(b)-->(a)
+   *
+   * (0)-0->(1)-1->(0)
+   *
+   * @return query q1
+   */
+  public static Query q1() {
+    TraversalCode tc = new TraversalCode();
+    tc.add(new Step(0L, 0L, 1L, true)); // (a)-->(b)
+    tc.add(new Step(1L, 1L, 0L, true)); // (b)-->(a)
+    return new Query(tc, 2, 2);
+  }
+
+  /**
+   * (c)<--(a)-->(b)
+   *
+   * (0)<-0-(1)-1->(2)
+   *
+   * @return query q2
+   */
+  public static Query q2() {
+    TraversalCode tc = new TraversalCode();
+    tc.add(new Step(1L, 0L, 0L, true)); // (a)-->(c)
+    tc.add(new Step(1L, 1L, 2L, true)); // (a)-->(b)
+    return new Query(tc, 3, 2);
+  }
+
+  /**
+   * (a)<--(b)-->(c)-->(a)
+   *
+   * (0)<-0-(1)-1->(2)-2->(0)
+   *
+   * @return query q3
+   */
+  public static Query q3() {
+    TraversalCode tc = new TraversalCode();
+    tc.add(new Step(1L, 1L, 2L, true)); // (b)-->(c)
+    tc.add(new Step(2L, 2L, 0L, true)); // (c)-->(a)
+    tc.add(new Step(1L, 0L, 0L, true)); // (b)-->(a)
+    return new Query(tc, 3, 3);
+  }
+
+  /**
+   * (a)-->(b)-->(c)-->(a)
+   *
+   * (0)-0->(1)-1->(2)-2->(0)
+   *
+   * @return query q4
+   */
+  public static Query q4() {
+    TraversalCode tc = new TraversalCode();
+    tc.add(new Step(0L, 0L, 1L, true)); // (a)-->(b)
+    tc.add(new Step(1L, 1L, 2L, true)); // (b)-->(c)
+    tc.add(new Step(2L, 2L, 0L, true)); // (c)-->(a)
+    return new Query(tc, 3, 3);
+  }
+
+  /**
+   * (a)-->(b)-->(a)<--(c)
+   *
+   * (0)-0->(1)-1->(0)<-2-(2)
+   *
+   * @return query q5
+   */
+  public static Query q5() {
+    TraversalCode tc = new TraversalCode();
+    tc.add(new Step(0L, 0L, 1L, true));  // (a)-->(b)
+    tc.add(new Step(1L, 1L, 0L, true));  // (b)-->(a)
+    tc.add(new Step(0L, 2L, 2L, false)); // (a)<--(c)
+    return new Query(tc, 3, 3);
+  }
+
+  /**
+   * (d)-->(a)-->(b)-->(a)<--(c)
+   *
+   * (0)-0->(1)-1->(2)-2->(1)<-3-(3)
+   *
+   * @return query q6
+   */
+  public static Query q6() {
+    TraversalCode tc = new TraversalCode();
+    tc.add(new Step(1L, 1L, 2L, true));  // (a)-->(b)
+    tc.add(new Step(2L, 2L, 1L, true));  // (b)-->(a)
+    tc.add(new Step(1L, 0L, 0L, false)); // (a)<--(d)
+    tc.add(new Step(1L, 3L, 3L, false)); // (a)<--(c)
+    return new Query(tc, 4, 4);
+  }
+
+  /**
+   * (c)<--(a)-->(d)<--(b)-->(c)
+   *
+   * (0)<-0-(1)-1->(2)<-2-(3)-3->(0)
+   *
+   * @return query q7
+   */
+  public static Query q7() {
+    TraversalCode tc = new TraversalCode();
+    tc.add(new Step(1L, 0L, 0L, true));  // (a)-->(c)
+    tc.add(new Step(1L, 1L, 2L, true));  // (a)-->(d)
+    tc.add(new Step(2L, 2L, 3L, false)); // (d)<--(b)
+    tc.add(new Step(0L, 3L, 3L, false)); // (c)<--(b)
+    return new Query(tc, 4, 4);
+  }
+}

--- a/gradoop-examples/src/main/java/org/gradoop/benchmark/patternmatching/TraverserBenchmark.java
+++ b/gradoop-examples/src/main/java/org/gradoop/benchmark/patternmatching/TraverserBenchmark.java
@@ -44,6 +44,9 @@ public class TraverserBenchmark implements ProgramDescription {
    * args[0] - Path to edge list
    * args[1] - Query (q1, q2, ..., q7)
    * args[2] - Iteration strategy (bulk/loop)
+   *
+   * e.g. ... patternmatching.TraverserBenchmark web-Google.txt q2 bulk
+   *
    * @param args program arguments
    */
   public static void main(String[] args) throws Exception {
@@ -84,7 +87,6 @@ public class TraverserBenchmark implements ProgramDescription {
     DataSet<TripleWithCandidates<Long>> edges = DataSetUtils
       .zipWithUniqueId(edgeList)
       .map(new GetTriplesWithCandidates(edgeCount));
-    // read edge list graph
 
     // create distributed traverser
     DistributedTraverser<Long> distributedTraverser;

--- a/gradoop-examples/src/main/java/org/gradoop/benchmark/patternmatching/TraverserBenchmark.java
+++ b/gradoop-examples/src/main/java/org/gradoop/benchmark/patternmatching/TraverserBenchmark.java
@@ -1,0 +1,219 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.gradoop.benchmark.patternmatching;
+
+import org.apache.flink.api.common.ProgramDescription;
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.utils.DataSetUtils;
+import org.apache.flink.util.Collector;
+import org.gradoop.flink.model.impl.operators.matching.common.query.TraversalCode;
+import org.gradoop.flink.model.impl.operators.matching.common.tuples.IdWithCandidates;
+import org.gradoop.flink.model.impl.operators.matching.common.tuples.TripleWithCandidates;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.IterationStrategy;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser.BulkTraverser;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser.DistributedTraverser;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser.ForLoopTraverser;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Used to benchmark different {@link DistributedTraverser} implementations.
+ */
+public class TraverserBenchmark implements ProgramDescription {
+
+  /**
+   * args[0] - Path to edge list
+   * args[1] - Query (q1, q2, ..., q7)
+   * args[2] - Iteration strategy (bulk/loop)
+   * @param args program arguments
+   */
+  public static void main(String[] args) throws Exception {
+    String inputPath   = args[0];
+    String queryString = args[1];
+    String itStrategy  = args[2];
+
+    IterationStrategy iterationStrategy = (itStrategy.equals("bulk")) ?
+      IterationStrategy.BULK_ITERATION : IterationStrategy.LOOP_UNROLLING;
+
+    ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+    // parse query
+    Queries.Query query = getQuery(queryString);
+    int vertexCount  = query.getVertexCount();
+    int edgeCount    = query.getEdgeCount();
+    TraversalCode tc = query.getTraversalCode();
+
+    // read edge list graph
+    DataSet<Tuple2<Long, Long>> edgeList = env.readCsvFile(inputPath)
+      .fieldDelimiter("\t")
+      .ignoreComments("#")
+      .types(Long.class, Long.class);
+
+    DataSet<IdWithCandidates<Long>> vertices = edgeList
+      .flatMap(new GetVertexIds())
+      .distinct()
+      .map(new GetIdWithCandidates(vertexCount));
+
+    DataSet<TripleWithCandidates<Long>> edges = DataSetUtils
+      .zipWithUniqueId(edgeList)
+      .map(new GetTriplesWithCandidates(edgeCount));
+
+    // create distributed traverser
+    DistributedTraverser<Long> distributedTraverser;
+    if (iterationStrategy == IterationStrategy.BULK_ITERATION) {
+      distributedTraverser = new BulkTraverser<>(tc,
+        vertexCount, edgeCount, Long.class);
+    } else {
+      distributedTraverser = new ForLoopTraverser<>(tc,
+        vertexCount, edgeCount, Long.class);
+    }
+
+    // print embedding count
+    long embeddingCount = distributedTraverser
+      .traverse(vertices, edges).count();
+    System.out.println("embeddingCount = " + embeddingCount);
+
+    long duration = env.getLastJobExecutionResult()
+      .getNetRuntime(TimeUnit.SECONDS);
+    System.out.println("duration = " + duration);
+  }
+
+  /**
+   * Returns the query based on the input string
+   *
+   * @param queryString query identifier (q1, q2, ..., q7)
+   * @return query
+   */
+  private static Queries.Query getQuery(String queryString) {
+    Queries.Query query;
+    switch (queryString) {
+    case "q1":
+      query = Queries.q1();
+      break;
+    case "q2":
+      query = Queries.q2();
+      break;
+    case "q3":
+      query = Queries.q3();
+      break;
+    case "q4":
+      query = Queries.q4();
+      break;
+    case "q5":
+      query = Queries.q5();
+      break;
+    case "q6":
+      query = Queries.q6();
+      break;
+    case "q7":
+      query = Queries.q7();
+      break;
+    default:
+      throw new IllegalArgumentException("unsupported query: " + queryString);
+    }
+    return query;
+  }
+
+  /**
+   * Returns the vertex identifiers from an edge tuple
+   */
+  public static class GetVertexIds
+    implements FlatMapFunction<Tuple2<Long, Long>, Long> {
+
+    @Override
+    public void flatMap(Tuple2<Long, Long> value, Collector<Long> out)
+      throws Exception {
+      out.collect(value.f0);
+      out.collect(value.f1);
+    }
+  }
+
+  /**
+   * Initializes {@link IdWithCandidates}
+   */
+  public static class GetIdWithCandidates
+    implements MapFunction<Long, IdWithCandidates<Long>> {
+    /**
+     * Reduce object instantiations
+     */
+    private final IdWithCandidates<Long> reuseTuple;
+
+    /**
+     * Constructor
+     *
+     * @param vertexCount number of query vertices
+     */
+    public GetIdWithCandidates(int vertexCount) {
+      reuseTuple = new IdWithCandidates<>();
+      boolean[] candidates = new boolean[vertexCount];
+      for (int i = 0; i < vertexCount; i++) {
+        candidates[i] = true;
+      }
+      reuseTuple.setCandidates(candidates);
+    }
+
+    @Override
+    public IdWithCandidates<Long> map(Long value) throws Exception {
+      reuseTuple.setId(value);
+      return reuseTuple;
+    }
+  }
+
+  /**
+   * Initializes {@link IdWithCandidates}
+   */
+  public static class GetTriplesWithCandidates implements MapFunction<
+      Tuple2<Long, Tuple2<Long, Long>>, TripleWithCandidates<Long>> {
+    /**
+     * Reduce object instantiations
+     */
+    private final TripleWithCandidates<Long> reuseTuple;
+
+    /**
+     * Constructor
+     *
+     * @param edgeCount number of query edges
+     */
+    public GetTriplesWithCandidates(int edgeCount) {
+      reuseTuple = new TripleWithCandidates<>();
+      boolean[] candidates = new boolean[edgeCount];
+      for (int i = 0; i < edgeCount; i++) {
+        candidates[i] = true;
+      }
+      reuseTuple.setCandidates(candidates);
+    }
+
+    @Override
+    public TripleWithCandidates<Long> map(
+      Tuple2<Long, Tuple2<Long, Long>> value) throws Exception {
+      reuseTuple.setEdgeId(value.f0);
+      reuseTuple.setSourceId(value.f1.f0);
+      reuseTuple.setTargetId(value.f1.f1);
+      return reuseTuple;
+    }
+  }
+
+  @Override
+  public String getDescription() {
+    return TraverserBenchmark.class.getName();
+  }
+}

--- a/gradoop-examples/src/main/java/org/gradoop/benchmark/patternmatching/TraverserBenchmark.java
+++ b/gradoop-examples/src/main/java/org/gradoop/benchmark/patternmatching/TraverserBenchmark.java
@@ -57,10 +57,18 @@ public class TraverserBenchmark implements ProgramDescription {
     ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
     // parse query
+    // Q?
     Queries.Query query = getQuery(queryString);
-    int vertexCount  = query.getVertexCount();
-    int edgeCount    = query.getEdgeCount();
-    TraversalCode tc = query.getTraversalCode();
+    int vertexCount     = query.getVertexCount();
+    int edgeCount       = query.getEdgeCount();
+    TraversalCode tc    = query.getTraversalCode();
+    // GDL
+//    QueryHandler query  = new QueryHandler(queryString);
+//    int vertexCount     = query.getVertexCount();
+//    int edgeCount       = query.getEdgeCount();
+//    Traverser traverser = new DFSTraverser();
+//    traverser.setQueryHandler(query);
+//    TraversalCode tc    = traverser.traverse();
 
     // read edge list graph
     DataSet<Tuple2<Long, Long>> edgeList = env.readCsvFile(inputPath)
@@ -76,6 +84,7 @@ public class TraverserBenchmark implements ProgramDescription {
     DataSet<TripleWithCandidates<Long>> edges = DataSetUtils
       .zipWithUniqueId(edgeList)
       .map(new GetTriplesWithCandidates(edgeCount));
+    // read edge list graph
 
     // create distributed traverser
     DistributedTraverser<Long> distributedTraverser;

--- a/gradoop-examples/src/main/java/org/gradoop/benchmark/patternmatching/package-info.java
+++ b/gradoop-examples/src/main/java/org/gradoop/benchmark/patternmatching/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Contains benchmark programs related to pattern matching.
+ */
+package org.gradoop.benchmark.patternmatching;

--- a/gradoop-examples/src/main/java/org/gradoop/examples/patternmatching/PatternMatchingRunner.java
+++ b/gradoop-examples/src/main/java/org/gradoop/examples/patternmatching/PatternMatchingRunner.java
@@ -26,7 +26,6 @@ import org.gradoop.flink.model.impl.GraphCollection;
 import org.gradoop.flink.model.impl.LogicalGraph;
 import org.gradoop.flink.model.impl.operators.matching.single.PatternMatching;
 import org.gradoop.flink.model.impl.operators.matching.common.MatchStrategy;
-import org.gradoop.flink.model.impl.operators.matching.common.query.DFSTraverser;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.ExplorativePatternMatching;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.IterationStrategy;
 import org.gradoop.flink.model.impl.operators.matching.single.simulation.dual.DualSimulation;
@@ -183,13 +182,21 @@ public class PatternMatchingRunner extends AbstractRunner
       op = new DualSimulation(query, attachData, false);
       break;
     case ALGO_ISO_EXP:
-      op = new ExplorativePatternMatching(query, attachData,
-        MatchStrategy.ISOMORPHISM, IterationStrategy.BULK_ITERATION);
+      op = new ExplorativePatternMatching.Builder()
+        .setQuery(query)
+        .setAttachData(attachData)
+        .setMatchStrategy(MatchStrategy.ISOMORPHISM)
+        .build();
       break;
     case ALGO_ISO_EXP_BC_HASH_FIRST:
-      op = new ExplorativePatternMatching(query, attachData,
-        MatchStrategy.ISOMORPHISM, IterationStrategy.BULK_ITERATION,
-        new DFSTraverser(), BROADCAST_HASH_FIRST, BROADCAST_HASH_FIRST);
+      op = new ExplorativePatternMatching.Builder()
+        .setQuery(query)
+        .setAttachData(attachData)
+        .setMatchStrategy(MatchStrategy.ISOMORPHISM)
+        .setIterationStrategy(IterationStrategy.BULK_ITERATION)
+        .setEdgeStepJoinStrategy(BROADCAST_HASH_FIRST)
+        .setVertexStepJoinStrategy(BROADCAST_HASH_FIRST)
+        .build();
       break;
     default :
       throw new IllegalArgumentException(algorithm + " not supported");

--- a/gradoop-examples/src/main/java/org/gradoop/examples/patternmatching/PatternMatchingRunner.java
+++ b/gradoop-examples/src/main/java/org/gradoop/examples/patternmatching/PatternMatchingRunner.java
@@ -28,6 +28,7 @@ import org.gradoop.flink.model.impl.operators.matching.single.PatternMatching;
 import org.gradoop.flink.model.impl.operators.matching.common.MatchStrategy;
 import org.gradoop.flink.model.impl.operators.matching.common.query.DFSTraverser;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.ExplorativePatternMatching;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.IterationStrategy;
 import org.gradoop.flink.model.impl.operators.matching.single.simulation.dual.DualSimulation;
 
 import java.util.concurrent.TimeUnit;
@@ -183,11 +184,11 @@ public class PatternMatchingRunner extends AbstractRunner
       break;
     case ALGO_ISO_EXP:
       op = new ExplorativePatternMatching(query, attachData,
-              MatchStrategy.ISOMORPHISM);
+        MatchStrategy.ISOMORPHISM, IterationStrategy.BULK_ITERATION);
       break;
     case ALGO_ISO_EXP_BC_HASH_FIRST:
       op = new ExplorativePatternMatching(query, attachData,
-              MatchStrategy.ISOMORPHISM,
+        MatchStrategy.ISOMORPHISM, IterationStrategy.BULK_ITERATION,
         new DFSTraverser(), BROADCAST_HASH_FIRST, BROADCAST_HASH_FIRST);
       break;
     default :

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/operators/LogicalGraphOperators.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/operators/LogicalGraphOperators.java
@@ -28,6 +28,8 @@ import org.gradoop.flink.model.impl.GraphCollection;
 import org.gradoop.flink.model.impl.LogicalGraph;
 import org.gradoop.flink.model.impl.operators.grouping.Grouping;
 import org.gradoop.flink.model.impl.operators.matching.common.MatchStrategy;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving
+  .explorative.IterationStrategy;
 
 import java.util.List;
 
@@ -81,13 +83,14 @@ public interface LogicalGraphOperators extends GraphBaseOperators {
    * if vertices and edges can be matched to multiple vertices/edges in the
    * query.
    *
-   * @param pattern     GDL graph pattern
-   * @param attachData  attach original vertex and edge data to the result
-   * @param matchStrategy choose wich strategy is used for the matching
+   * @param pattern           GDL graph pattern
+   * @param attachData        attach original vertex and edge data to the result
+   * @param matchStrategy     strategy for vertex and edge mappings
+   * @param iterationStrategy strategy for internal iteration
    * @return subgraphs of the input graph that match the given graph pattern
    */
   GraphCollection match(String pattern, boolean attachData,
-    MatchStrategy matchStrategy);
+    MatchStrategy matchStrategy, IterationStrategy iterationStrategy);
 
   /**
    * Creates a copy of the logical graph.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/LogicalGraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/LogicalGraph.java
@@ -46,9 +46,7 @@ import org.gradoop.flink.model.impl.operators.grouping.functions.aggregation.Cou
 import org.gradoop.flink.model.impl.operators.matching.common.MatchStrategy;
 import org.gradoop.flink.model.impl.operators.matching.common.query.DFSTraverser;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.ExplorativePatternMatching;
-
-import org.gradoop.flink.model.impl.operators.matching.single.preserving
-  .explorative.IterationStrategy;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.IterationStrategy;
 import org.gradoop.flink.model.impl.operators.overlap.Overlap;
 import org.gradoop.flink.model.impl.operators.sampling.RandomNodeSampling;
 import org.gradoop.flink.model.impl.operators.split.Split;
@@ -271,8 +269,15 @@ public class LogicalGraph extends GraphBase implements LogicalGraphOperators {
   @Override
   public GraphCollection match(String pattern, boolean attachData,
     MatchStrategy matchStrategy, IterationStrategy iterationStrategy) {
-    return callForCollection(new ExplorativePatternMatching(pattern, attachData,
-      matchStrategy, iterationStrategy, new DFSTraverser()));
+
+    ExplorativePatternMatching op = new ExplorativePatternMatching.Builder()
+      .setQuery(pattern)
+      .setAttachData(attachData)
+      .setMatchStrategy(matchStrategy)
+      .setIterationStrategy(iterationStrategy)
+      .setTraverser(new DFSTraverser()).build();
+
+    return callForCollection(op);
   }
 
   /**

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/LogicalGraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/LogicalGraph.java
@@ -46,6 +46,9 @@ import org.gradoop.flink.model.impl.operators.grouping.functions.aggregation.Cou
 import org.gradoop.flink.model.impl.operators.matching.common.MatchStrategy;
 import org.gradoop.flink.model.impl.operators.matching.common.query.DFSTraverser;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.ExplorativePatternMatching;
+
+import org.gradoop.flink.model.impl.operators.matching.single.preserving
+  .explorative.IterationStrategy;
 import org.gradoop.flink.model.impl.operators.overlap.Overlap;
 import org.gradoop.flink.model.impl.operators.sampling.RandomNodeSampling;
 import org.gradoop.flink.model.impl.operators.split.Split;
@@ -250,7 +253,7 @@ public class LogicalGraph extends GraphBase implements LogicalGraphOperators {
    */
   @Override
   public GraphCollection match(String pattern) {
-    return match(pattern, true, MatchStrategy.ISOMORPHISM);
+    return match(pattern, true);
   }
 
   /**
@@ -258,7 +261,8 @@ public class LogicalGraph extends GraphBase implements LogicalGraphOperators {
    */
   @Override
   public GraphCollection match(String pattern, boolean attachData) {
-    return match(pattern, attachData, MatchStrategy.ISOMORPHISM);
+    return match(pattern, attachData, MatchStrategy.ISOMORPHISM,
+      IterationStrategy.BULK_ITERATION);
   }
 
   /**
@@ -266,10 +270,9 @@ public class LogicalGraph extends GraphBase implements LogicalGraphOperators {
    */
   @Override
   public GraphCollection match(String pattern, boolean attachData,
-                               MatchStrategy matchStrategy) {
-    return callForCollection(new ExplorativePatternMatching(
-      pattern, attachData,
-      matchStrategy, new DFSTraverser()));
+    MatchStrategy matchStrategy, IterationStrategy iterationStrategy) {
+    return callForCollection(new ExplorativePatternMatching(pattern, attachData,
+      matchStrategy, iterationStrategy, new DFSTraverser()));
   }
 
   /**

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/functions/ElementHasCandidate.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/functions/ElementHasCandidate.java
@@ -45,8 +45,8 @@ public class ElementHasCandidate<K>
    *
    * @param candidate candidate to test on
    */
-  public ElementHasCandidate(long candidate) {
-    this.candidate = (int) candidate;
+  public ElementHasCandidate(int candidate) {
+    this.candidate = candidate;
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/query/Step.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/query/Step.java
@@ -58,7 +58,7 @@ public class Step implements Serializable {
    * @param to target vertex id
    * @param isOutgoing if traversed edge was outgoing from starting vertex
    */
-  Step(long from, long via, long to, boolean isOutgoing) {
+  public Step(long from, long via, long to, boolean isOutgoing) {
     this.from = from;
     this.via = via;
     this.to = to;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/query/TraversalCode.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/query/TraversalCode.java
@@ -40,7 +40,7 @@ public class TraversalCode implements Serializable {
   /**
    * Initialize a new traversal code
    */
-  TraversalCode() {
+  public TraversalCode() {
     this.steps = Lists.newArrayList();
   }
 
@@ -49,7 +49,7 @@ public class TraversalCode implements Serializable {
    *
    * @param step new step
    */
-  void add(Step step) {
+  public void add(Step step) {
     steps.add(step);
   }
 
@@ -70,5 +70,13 @@ public class TraversalCode implements Serializable {
    */
   public Step getStep(int i) {
     return steps.get(i);
+  }
+
+  @Override
+  public String toString() {
+    final StringBuffer sb = new StringBuffer("TraversalCode{");
+    sb.append("steps=").append(steps);
+    sb.append('}');
+    return sb.toString();
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/IterationStrategy.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/IterationStrategy.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative;
+
+/**
+ * Defines the iteration mode for the distributed traverser.
+ */
+public enum IterationStrategy {
+  /**
+   * Traverse the graph using bulk iteration.
+   */
+  BULK_ITERATION,
+  /**
+   * Traverse the graph using loop unrolling
+   */
+  LOOP_UNROLLING
+}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/functions/BuildEdgeStep.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/functions/BuildEdgeStep.java
@@ -18,25 +18,20 @@
 package org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.functions;
 
 import org.apache.flink.api.common.functions.RichMapFunction;
-import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.configuration.Configuration;
 import org.gradoop.flink.model.impl.operators.matching.common.query.TraversalCode;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.tuples.EdgeStep;
 import org.gradoop.flink.model.impl.operators.matching.common.tuples.TripleWithCandidates;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.ExplorativePatternMatching;
 
-
-
 /**
  * Converts an edge into a step edge according to the traversal.
  *
- * Forwarded fields:
- *
- * f0: edge id
+ * Note that forwarded fields annotations need to be declared at the calling
+ * site for this function.
  *
  * @param <K> key type
  */
-@FunctionAnnotation.ForwardedFields("f0")
 public class BuildEdgeStep<K>
   extends RichMapFunction<TripleWithCandidates<K>, EdgeStep<K>> {
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/functions/BuildEmbeddingWithTiePoint.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/functions/BuildEmbeddingWithTiePoint.java
@@ -19,12 +19,9 @@ package org.gradoop.flink.model.impl.operators.matching.single.preserving.explor
 
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
-import org.gradoop.flink.model.impl.operators.matching.common.query.TraversalCode;
 import org.gradoop.flink.model.impl.operators.matching.common.tuples.IdWithCandidates;
 import org.gradoop.flink.model.impl.operators.matching.common.tuples.Embedding;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.tuples.EmbeddingWithTiePoint;
-
-
 
 import java.lang.reflect.Array;
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/functions/BuildEmbeddingWithTiePoint.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/functions/BuildEmbeddingWithTiePoint.java
@@ -58,13 +58,13 @@ public class BuildEmbeddingWithTiePoint<K>
    * Constructor
    *
    * @param keyClazz      key type is needed for array initialization
-   * @param traversalCode traversal code for the current exploration
+   * @param candidate     initial query candidate each vertex is mapped to
    * @param vertexCount   number of vertices in the query graph
    * @param edgeCount     number of edges in the query graph
    */
-  public BuildEmbeddingWithTiePoint(Class<K> keyClazz,
-    TraversalCode traversalCode, long vertexCount, long edgeCount) {
-    this.candidate              = (int) traversalCode.getStep(0).getFrom();
+  public BuildEmbeddingWithTiePoint(Class<K> keyClazz, int candidate,
+    long vertexCount, long edgeCount) {
+    this.candidate              = candidate;
     reuseEmbedding              = new Embedding<>();
     reuseEmbeddingWithTiePoint  = new EmbeddingWithTiePoint<>();
     //noinspection unchecked

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/functions/UpdateEdgeMappings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/functions/UpdateEdgeMappings.java
@@ -22,6 +22,9 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Collector;
 import org.gradoop.flink.model.impl.operators.matching.common.query.TraversalCode;
+
+import org.gradoop.flink.model.impl.operators.matching.single.preserving
+  .explorative.ExplorativePatternMatching;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.tuples.EdgeStep;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.tuples.EmbeddingWithTiePoint;
 
@@ -74,8 +77,9 @@ public class UpdateEdgeMappings<K> extends RichFlatJoinFunction
   @Override
   public void open(Configuration parameters) throws Exception {
     super.open(parameters);
-    candidate = (int) traversalCode.getStep(
-      getIterationRuntimeContext().getSuperstepNumber() - 1).getVia();
+    int currentStep = (int) getRuntimeContext()
+      .getBroadcastVariable(ExplorativePatternMatching.BC_SUPERSTEP).get(0) - 1;
+    candidate = (int) traversalCode.getStep(currentStep).getVia();
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/functions/UpdateEdgeMappings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/functions/UpdateEdgeMappings.java
@@ -22,11 +22,8 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Collector;
 import org.gradoop.flink.model.impl.operators.matching.common.query.TraversalCode;
-
-import org.gradoop.flink.model.impl.operators.matching.single.preserving
-  .explorative.ExplorativePatternMatching;
-import org.gradoop.flink.model.impl.operators.matching.single.preserving
-  .explorative.IterationStrategy;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.ExplorativePatternMatching;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.IterationStrategy;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.tuples.EdgeStep;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.tuples.EmbeddingWithTiePoint;
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/functions/UpdateVertexMappings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/functions/UpdateVertexMappings.java
@@ -24,14 +24,10 @@ import org.apache.flink.util.Collector;
 import org.gradoop.flink.model.impl.operators.matching.common.MatchStrategy;
 import org.gradoop.flink.model.impl.operators.matching.common.query.Step;
 import org.gradoop.flink.model.impl.operators.matching.common.query.TraversalCode;
-
-import org.gradoop.flink.model.impl.operators.matching.single.preserving
-  .explorative.ExplorativePatternMatching;
-import org.gradoop.flink.model.impl.operators.matching.single.preserving
-  .explorative.IterationStrategy;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.ExplorativePatternMatching;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.IterationStrategy;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.tuples.EmbeddingWithTiePoint;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.tuples.VertexStep;
-
 
 /**
  * Extends an embedding with a vertex if possible.
@@ -167,15 +163,13 @@ public class UpdateVertexMappings<K>
    * @return true, if visited before
    */
   private boolean seenBefore(K[] vertexMappings, K id) {
-    if (matchStrategy == MatchStrategy.HOMOMORPHISM) {
-      return false;
-    }
-
     boolean result = false;
-    for (int i = 0; i <= currentStep; i++) {
-      if (vertexMappings[previousFroms[i]].equals(id)) {
-        result = true;
-        break;
+    if (matchStrategy == MatchStrategy.ISOMORPHISM) {
+      for (int i = 0; i <= currentStep; i++) {
+        if (vertexMappings[previousFroms[i]].equals(id)) {
+          result = true;
+          break;
+        }
       }
     }
     return result;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/functions/UpdateVertexMappings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/functions/UpdateVertexMappings.java
@@ -24,6 +24,9 @@ import org.apache.flink.util.Collector;
 import org.gradoop.flink.model.impl.operators.matching.common.MatchStrategy;
 import org.gradoop.flink.model.impl.operators.matching.common.query.Step;
 import org.gradoop.flink.model.impl.operators.matching.common.query.TraversalCode;
+
+import org.gradoop.flink.model.impl.operators.matching.single.preserving
+  .explorative.ExplorativePatternMatching;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.tuples.EmbeddingWithTiePoint;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.tuples.VertexStep;
 
@@ -95,7 +98,9 @@ public class UpdateVertexMappings<K>
   @Override
   public void open(Configuration parameters) throws Exception {
     super.open(parameters);
-    currentStep = getIterationRuntimeContext().getSuperstepNumber() - 1;
+//    currentStep = getIterationRuntimeContext().getSuperstepNumber() - 1;
+    currentStep = (int) getRuntimeContext()
+      .getBroadcastVariable(ExplorativePatternMatching.BC_SUPERSTEP).get(0) - 1;
     candidate = (int) traversalCode.getStep(currentStep).getTo();
 
     if (hasMoreSteps()) {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/traverser/DistributedTraverser.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/traverser/DistributedTraverser.java
@@ -1,0 +1,174 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser;
+
+import org.apache.flink.api.common.operators.base.JoinOperatorBase;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.gradoop.common.model.impl.properties.PropertyValue;
+import org.gradoop.flink.model.impl.operators.matching.common.MatchStrategy;
+import org.gradoop.flink.model.impl.operators.matching.common.functions.ElementHasCandidate;
+import org.gradoop.flink.model.impl.operators.matching.common.query.TraversalCode;
+import org.gradoop.flink.model.impl.operators.matching.common.tuples.Embedding;
+import org.gradoop.flink.model.impl.operators.matching.common.tuples.IdWithCandidates;
+import org.gradoop.flink.model.impl.operators.matching.common.tuples.TripleWithCandidates;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.debug.PrintEmbeddingWithTiePoint;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.functions.BuildEmbeddingWithTiePoint;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.tuples.EmbeddingWithTiePoint;
+
+import java.util.Objects;
+
+import static org.gradoop.flink.model.impl.operators.matching.common.debug.Printer.log;
+
+/**
+ * A distributed traverser extracts embeddings from a given graph.
+ *
+ * @param <K> key type
+ */
+public abstract class DistributedTraverser<K> {
+  /**
+   * Strategy for vertex and edge mappings
+   */
+  private final MatchStrategy matchStrategy;
+  /**
+   * Controls the graph traversal
+   */
+  private final TraversalCode traversalCode;
+  /**
+   * Number of vertices in the query graph.
+   */
+  private final int vertexCount;
+  /**
+   * Number of edges in the query graph.
+   */
+  private final int edgeCount;
+  /**
+   * Needed to build initial embeddings
+   */
+  private final Class<K> keyClazz;
+  /**
+   * Join strategy used for the join between embeddings and edges
+   */
+  private final JoinOperatorBase.JoinHint edgeStepJoinStrategy;
+  /**
+   * Join strategy used for the join between embeddings and vertices
+   */
+  private final JoinOperatorBase.JoinHint vertexStepJoinStrategy;
+  /**
+   * Vertex mapping used for debug
+   */
+  private final DataSet<Tuple2<K, PropertyValue>> vertexMapping;
+  /**
+   * Edge mapping used for debug
+   */
+  private final DataSet<Tuple2<K, PropertyValue>> edgeMapping;
+
+  /**
+   * Creates a new distributed traverser.
+   *
+   * @param traversalCode          describes the graph traversal
+   * @param matchStrategy          matching strategy for vertices and edges
+   * @param vertexCount            number of query vertices
+   * @param edgeCount              number of query edges
+   * @param keyClazz               key type for embedding initialization
+   * @param edgeStepJoinStrategy   Join strategy for edge extension
+   * @param vertexStepJoinStrategy Join strategy for vertex extension
+   * @param vertexMapping          used for debug
+   * @param edgeMapping            used for debug
+   */
+  DistributedTraverser(TraversalCode traversalCode,
+    MatchStrategy matchStrategy,
+    int vertexCount, int edgeCount,
+    Class<K> keyClazz,
+    JoinOperatorBase.JoinHint edgeStepJoinStrategy,
+    JoinOperatorBase.JoinHint vertexStepJoinStrategy,
+    DataSet<Tuple2<K, PropertyValue>> vertexMapping,
+    DataSet<Tuple2<K, PropertyValue>> edgeMapping) {
+
+    Objects.requireNonNull(traversalCode);
+    Objects.requireNonNull(matchStrategy);
+    Objects.requireNonNull(keyClazz);
+    Objects.requireNonNull(edgeStepJoinStrategy);
+    Objects.requireNonNull(vertexStepJoinStrategy);
+
+    this.traversalCode          = traversalCode;
+    this.matchStrategy          = matchStrategy;
+    this.vertexCount            = vertexCount;
+    this.edgeCount              = edgeCount;
+    this.keyClazz               = keyClazz;
+    this.edgeStepJoinStrategy   = edgeStepJoinStrategy;
+    this.vertexStepJoinStrategy = vertexStepJoinStrategy;
+    this.vertexMapping          = vertexMapping;
+    this.edgeMapping            = edgeMapping;
+  }
+
+  /**
+   * Traverses the graph, thereby extracting embeddings of a given pattern.
+   *
+   * @param vertices  vertices including their query candidates
+   * @param edges     edges including their query candidates
+   * @return embeddings contained in the graph
+   */
+  public abstract DataSet<Tuple1<Embedding<K>>> traverse(
+    DataSet<IdWithCandidates<K>> vertices,
+    DataSet<TripleWithCandidates<K>> edges);
+
+  TraversalCode getTraversalCode() {
+    return traversalCode;
+  }
+
+  MatchStrategy getMatchStrategy() {
+    return matchStrategy;
+  }
+
+  JoinOperatorBase.JoinHint getEdgeStepJoinStrategy() {
+    return edgeStepJoinStrategy;
+  }
+
+  JoinOperatorBase.JoinHint getVertexStepJoinStrategy() {
+    return vertexStepJoinStrategy;
+  }
+
+  DataSet<Tuple2<K, PropertyValue>> getVertexMapping() {
+    return vertexMapping;
+  }
+
+  DataSet<Tuple2<K, PropertyValue>> getEdgeMapping() {
+    return edgeMapping;
+  }
+
+  /**
+   * Builds the initial embeddings from the given vertices.
+   *
+   * @param vertices vertices and their query candidates
+   * @return initial embeddings
+   */
+  DataSet<EmbeddingWithTiePoint<K>> buildInitialEmbeddings(
+    DataSet<IdWithCandidates<K>> vertices) {
+
+    DataSet<EmbeddingWithTiePoint<K>> initialEmbeddings = vertices
+      .filter(new ElementHasCandidate<>(
+        getTraversalCode().getStep(0).getFrom()))
+      .map(new BuildEmbeddingWithTiePoint<>(keyClazz, getTraversalCode(),
+        vertexCount, edgeCount));
+
+    return log(initialEmbeddings, new PrintEmbeddingWithTiePoint<>(),
+      getVertexMapping(), getEdgeMapping());
+  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/traverser/ForLoopTraverser.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/traverser/ForLoopTraverser.java
@@ -1,0 +1,155 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser;
+
+import org.apache.flink.api.common.operators.base.JoinOperatorBase;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.gradoop.common.model.impl.properties.PropertyValue;
+import org.gradoop.flink.model.impl.operators.matching.common.MatchStrategy;
+import org.gradoop.flink.model.impl.operators.matching.common.query.Step;
+import org.gradoop.flink.model.impl.operators.matching.common.query.TraversalCode;
+import org.gradoop.flink.model.impl.operators.matching.common.tuples.Embedding;
+import org.gradoop.flink.model.impl.operators.matching.common.tuples.IdWithCandidates;
+import org.gradoop.flink.model.impl.operators.matching.common.tuples.TripleWithCandidates;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.ExplorativePatternMatching;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.debug.PrintEdgeStep;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.debug.PrintEmbeddingWithTiePoint;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.debug.PrintVertexStep;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.functions.BuildEdgeStep;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.functions.BuildVertexStep;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.functions.EdgeHasCandidate;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.functions.UpdateEdgeMappings;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.functions.UpdateVertexMappings;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.functions.VertexHasCandidate;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.tuples.EdgeStep;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.tuples.EmbeddingWithTiePoint;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.tuples.VertexStep;
+
+import static org.gradoop.flink.model.impl.operators.matching.common.debug.Printer.log;
+
+/**
+ * Extracts {@link Embedding}s iteratively from a given graph by traversing the
+ * graph according to a given {@link TraversalCode}.
+ *
+ * For the iteration the traverser uses a basic for loop.
+ *
+ * @param <K> key type
+ */
+public class ForLoopTraverser<K> extends DistributedTraverser<K> {
+
+  /**
+   * Creates a new distributed traverser.
+   *
+   * @param traversalCode          describes the graph traversal
+   * @param matchStrategy          matching strategy for vertex and edge mapping
+   * @param vertexCount            number of query vertices
+   * @param edgeCount              number of query edges
+   * @param keyClazz               key type for embedding initialization
+   * @param edgeStepJoinStrategy   Join strategy for edge extension
+   * @param vertexStepJoinStrategy Join strategy for vertex extension
+   * @param vertexMapping          used for debug
+   * @param edgeMapping            used for debug
+   */
+  public ForLoopTraverser(TraversalCode traversalCode,
+    MatchStrategy matchStrategy,
+    int vertexCount, int edgeCount,
+    Class<K> keyClazz,
+    JoinOperatorBase.JoinHint edgeStepJoinStrategy,
+    JoinOperatorBase.JoinHint vertexStepJoinStrategy,
+    DataSet<Tuple2<K, PropertyValue>> vertexMapping,
+    DataSet<Tuple2<K, PropertyValue>> edgeMapping) {
+    super(traversalCode, matchStrategy, vertexCount, edgeCount, keyClazz,
+      edgeStepJoinStrategy, vertexStepJoinStrategy, vertexMapping, edgeMapping);
+  }
+
+  @Override
+  public DataSet<Tuple1<Embedding<K>>> traverse(
+    DataSet<IdWithCandidates<K>> vertices,
+    DataSet<TripleWithCandidates<K>> edges) {
+    return iterate(vertices, edges, buildInitialEmbeddings(vertices))
+      .project(1);
+  }
+
+  /**
+   * Explores the data graph iteratively using the provided traversal code.
+   *
+   * @param vertices   vertex candidates
+   * @param edges      edge candidates
+   * @param embeddings initial embeddings which are extended in each iteration
+   * @return final embeddings
+   */
+  private DataSet<EmbeddingWithTiePoint<K>> iterate(
+    DataSet<IdWithCandidates<K>> vertices,
+    DataSet<TripleWithCandidates<K>> edges,
+    DataSet<EmbeddingWithTiePoint<K>> embeddings) {
+
+    TraversalCode traversalCode = getTraversalCode();
+
+    for (int i = 0; i < traversalCode.getSteps().size(); i++) {
+      Step step = traversalCode.getStep(i);
+
+      DataSet<Integer> superstep = vertices.getExecutionEnvironment()
+        .fromElements(i + 1);
+
+      DataSet<EdgeStep<K>> edgeSteps = edges
+        .filter(new EdgeHasCandidate<>(getTraversalCode()))
+        .withBroadcastSet(superstep, ExplorativePatternMatching.BC_SUPERSTEP)
+        .map(new BuildEdgeStep<>(getTraversalCode()))
+        .withBroadcastSet(superstep, ExplorativePatternMatching.BC_SUPERSTEP);
+
+      edgeSteps = log(edgeSteps,
+        new PrintEdgeStep<>(true, "post-filter-map-edge"),
+        getVertexMapping(), getEdgeMapping());
+
+      embeddings = embeddings
+        .join(edgeSteps, getEdgeStepJoinStrategy())
+        .where(0).equalTo(1) // tiePointId == sourceId/targetId tie point
+        .with(new UpdateEdgeMappings<>(getTraversalCode()))
+        .withBroadcastSet(superstep, ExplorativePatternMatching.BC_SUPERSTEP);
+
+      embeddings = log(embeddings,
+        new PrintEmbeddingWithTiePoint<>(true, "post-edge-update"),
+        getVertexMapping(), getEdgeMapping());
+
+      // traverse to vertices
+      DataSet<VertexStep<K>> vertexSteps = vertices
+        .filter(new VertexHasCandidate<>(getTraversalCode()))
+        .withBroadcastSet(superstep, ExplorativePatternMatching.BC_SUPERSTEP)
+        .map(new BuildVertexStep<>());
+
+      vertexSteps = log(vertexSteps,
+        new PrintVertexStep<>(true, "post-filter-project-vertex"),
+        getVertexMapping(), getEdgeMapping());
+
+      embeddings = embeddings
+        .join(vertexSteps, getVertexStepJoinStrategy())
+        .where(0).equalTo(0) // tiePointId == vertexId
+        .with(new UpdateVertexMappings<>(
+          getTraversalCode(), getMatchStrategy()))
+        .withBroadcastSet(superstep, ExplorativePatternMatching.BC_SUPERSTEP);
+
+      embeddings = log(embeddings,
+        new PrintEmbeddingWithTiePoint<>(true, "post-vertex-update"),
+        getVertexMapping(), getEdgeMapping());
+    }
+
+    return embeddings;
+  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/traverser/ForLoopTraverser.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/traverser/ForLoopTraverser.java
@@ -17,8 +17,6 @@
 
 package org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser;
 
-
-
 import org.apache.flink.api.common.operators.base.JoinOperatorBase;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.tuple.Tuple1;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/traverser/package-info.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/traverser/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Contains implementations for distributed graph traversal.
+ */
+package org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser;

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativeHomomorphismBulkTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativeHomomorphismBulkTest.java
@@ -15,7 +15,11 @@ public class ExplorativeHomomorphismBulkTest extends SubgraphHomomorphismTest {
 
   @Override
   public PatternMatching getImplementation(String queryGraph, boolean attachData) {
-    return new ExplorativePatternMatching(queryGraph, attachData,
-      MatchStrategy.HOMOMORPHISM, IterationStrategy.BULK_ITERATION);
+    return new ExplorativePatternMatching.Builder()
+      .setQuery(queryGraph)
+      .setAttachData(attachData)
+      .setMatchStrategy(MatchStrategy.HOMOMORPHISM)
+      .setIterationStrategy(IterationStrategy.BULK_ITERATION)
+      .build();
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativeHomomorphismBulkTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativeHomomorphismBulkTest.java
@@ -1,0 +1,21 @@
+package org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative;
+
+import org.gradoop.flink.model.impl.operators.matching.single.PatternMatching;
+import org.gradoop.flink.model.impl.operators.matching.common.MatchStrategy;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.SubgraphHomomorphismTest;
+
+public class ExplorativeHomomorphismBulkTest extends SubgraphHomomorphismTest {
+
+  public ExplorativeHomomorphismBulkTest(String testName,
+    String dataGraph, String queryGraph, String[] expectedGraphVariables,
+    String expectedCollection) {
+    super(testName, dataGraph, queryGraph, expectedGraphVariables,
+      expectedCollection);
+  }
+
+  @Override
+  public PatternMatching getImplementation(String queryGraph, boolean attachData) {
+    return new ExplorativePatternMatching(queryGraph, attachData,
+      MatchStrategy.HOMOMORPHISM, IterationStrategy.BULK_ITERATION);
+  }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativeHomomorphismLoopUnrollingTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativeHomomorphismLoopUnrollingTest.java
@@ -1,11 +1,9 @@
 package org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative;
 
-
 import org.gradoop.flink.model.impl.operators.matching.common.MatchStrategy;
 import org.gradoop.flink.model.impl.operators.matching.single.PatternMatching;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving
   .SubgraphHomomorphismTest;
-
 
 public class ExplorativeHomomorphismLoopUnrollingTest extends SubgraphHomomorphismTest {
 
@@ -18,7 +16,11 @@ public class ExplorativeHomomorphismLoopUnrollingTest extends SubgraphHomomorphi
 
   @Override
   public PatternMatching getImplementation(String queryGraph, boolean attachData) {
-    return new ExplorativePatternMatching(queryGraph, attachData,
-      MatchStrategy.HOMOMORPHISM, IterationStrategy.LOOP_UNROLLING);
+    return new ExplorativePatternMatching.Builder()
+      .setQuery(queryGraph)
+      .setAttachData(attachData)
+      .setMatchStrategy(MatchStrategy.HOMOMORPHISM)
+      .setIterationStrategy(IterationStrategy.LOOP_UNROLLING)
+      .build();
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativeHomomorphismLoopUnrollingTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativeHomomorphismLoopUnrollingTest.java
@@ -1,13 +1,15 @@
 package org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative;
 
-import org.gradoop.flink.model.impl.operators.matching.single.PatternMatching;
+
 import org.gradoop.flink.model.impl.operators.matching.common.MatchStrategy;
-import org.gradoop.flink.model.impl.operators.matching.single.preserving.SubgraphHomomorphismTest;
+import org.gradoop.flink.model.impl.operators.matching.single.PatternMatching;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving
+  .SubgraphHomomorphismTest;
 
 
-public class ExplorativeSubgraphHomomorphismTest extends SubgraphHomomorphismTest {
+public class ExplorativeHomomorphismLoopUnrollingTest extends SubgraphHomomorphismTest {
 
-  public ExplorativeSubgraphHomomorphismTest(String testName,
+  public ExplorativeHomomorphismLoopUnrollingTest(String testName,
     String dataGraph, String queryGraph, String[] expectedGraphVariables,
     String expectedCollection) {
     super(testName, dataGraph, queryGraph, expectedGraphVariables,
@@ -16,6 +18,7 @@ public class ExplorativeSubgraphHomomorphismTest extends SubgraphHomomorphismTes
 
   @Override
   public PatternMatching getImplementation(String queryGraph, boolean attachData) {
-    return new ExplorativePatternMatching(queryGraph, attachData, MatchStrategy.HOMOMORPHISM );
+    return new ExplorativePatternMatching(queryGraph, attachData,
+      MatchStrategy.HOMOMORPHISM, IterationStrategy.LOOP_UNROLLING);
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativeIsomorphismBulkTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativeIsomorphismBulkTest.java
@@ -4,10 +4,9 @@ import org.gradoop.flink.model.impl.operators.matching.single.PatternMatching;
 import org.gradoop.flink.model.impl.operators.matching.common.MatchStrategy;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.SubgraphIsomorphismTest;
 
+public class ExplorativeIsomorphismBulkTest extends SubgraphIsomorphismTest {
 
-public class ExplorativePatternMatchingTest extends SubgraphIsomorphismTest {
-
-  public ExplorativePatternMatchingTest(String testName, String dataGraph,
+  public ExplorativeIsomorphismBulkTest(String testName, String dataGraph,
     String queryGraph, String[] expectedGraphVariables,
     String expectedCollection) {
     super(testName, dataGraph, queryGraph, expectedGraphVariables,
@@ -17,6 +16,7 @@ public class ExplorativePatternMatchingTest extends SubgraphIsomorphismTest {
   @Override
   public PatternMatching getImplementation(String queryGraph,
     boolean attachData) {
-    return new ExplorativePatternMatching(queryGraph, attachData, MatchStrategy.ISOMORPHISM);
+    return new ExplorativePatternMatching(queryGraph, attachData,
+      MatchStrategy.ISOMORPHISM, IterationStrategy.BULK_ITERATION);
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativeIsomorphismBulkTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativeIsomorphismBulkTest.java
@@ -14,9 +14,13 @@ public class ExplorativeIsomorphismBulkTest extends SubgraphIsomorphismTest {
   }
 
   @Override
-  public PatternMatching getImplementation(String queryGraph,
-    boolean attachData) {
-    return new ExplorativePatternMatching(queryGraph, attachData,
-      MatchStrategy.ISOMORPHISM, IterationStrategy.BULK_ITERATION);
+  public PatternMatching getImplementation(String queryGraph, boolean attachData) {
+
+    return new ExplorativePatternMatching.Builder()
+      .setQuery(queryGraph)
+      .setAttachData(attachData)
+      .setMatchStrategy(MatchStrategy.ISOMORPHISM)
+      .setIterationStrategy(IterationStrategy.BULK_ITERATION)
+      .build();
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativeIsomorphismLoopUnrollingTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativeIsomorphismLoopUnrollingTest.java
@@ -1,0 +1,23 @@
+package org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative;
+
+import org.gradoop.flink.model.impl.operators.matching.common.MatchStrategy;
+import org.gradoop.flink.model.impl.operators.matching.single.PatternMatching;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving
+  .SubgraphIsomorphismTest;
+
+public class ExplorativeIsomorphismLoopUnrollingTest extends SubgraphIsomorphismTest {
+
+  public ExplorativeIsomorphismLoopUnrollingTest(String testName, String dataGraph,
+    String queryGraph, String[] expectedGraphVariables,
+    String expectedCollection) {
+    super(testName, dataGraph, queryGraph, expectedGraphVariables,
+      expectedCollection);
+  }
+
+  @Override
+  public PatternMatching getImplementation(String queryGraph,
+    boolean attachData) {
+    return new ExplorativePatternMatching(queryGraph, attachData,
+      MatchStrategy.ISOMORPHISM, IterationStrategy.LOOP_UNROLLING);
+  }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativeIsomorphismLoopUnrollingTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativeIsomorphismLoopUnrollingTest.java
@@ -15,9 +15,12 @@ public class ExplorativeIsomorphismLoopUnrollingTest extends SubgraphIsomorphism
   }
 
   @Override
-  public PatternMatching getImplementation(String queryGraph,
-    boolean attachData) {
-    return new ExplorativePatternMatching(queryGraph, attachData,
-      MatchStrategy.ISOMORPHISM, IterationStrategy.LOOP_UNROLLING);
+  public PatternMatching getImplementation(String queryGraph, boolean attachData) {
+    return new ExplorativePatternMatching.Builder()
+      .setQuery(queryGraph)
+      .setAttachData(attachData)
+      .setMatchStrategy(MatchStrategy.ISOMORPHISM)
+      .setIterationStrategy(IterationStrategy.LOOP_UNROLLING)
+      .build();
   }
 }


### PR DESCRIPTION
* adds an alternative implementation of `DistributedTraverser` in `ExplorativePatternMatching`
* for-loop iteration offers the advantage to set additional field forwarding informations to distributed joins