### PR TITLE
Improved transactional matching preprocessing.

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/TransactionalPatternMatching.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/TransactionalPatternMatching.java
@@ -18,7 +18,6 @@
 package org.gradoop.flink.model.impl.operators.matching.transactional;
 
 import org.apache.flink.api.java.DataSet;
-import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.gradoop.common.model.impl.id.GradoopId;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/BuildGraphWithCandidates.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/BuildGraphWithCandidates.java
@@ -29,7 +29,7 @@ import org.gradoop.flink.model.impl.operators.matching.transactional.tuples.Grap
  * Constructs GraphWithCandidates from sets of vertices and edges with their
  * candidates.
  */
-public class ConstructGraphs implements
+public class BuildGraphWithCandidates implements
   CoGroupFunction<Tuple2<GradoopId, IdWithCandidates<GradoopId>>,
     Tuple2<GradoopId, TripleWithCandidates<GradoopId>>, GraphWithCandidates> {
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/BuildIdWithCandidatesAndGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/BuildIdWithCandidatesAndGraphs.java
@@ -34,6 +34,8 @@ import static org.gradoop.common.util.GConstants.DEFAULT_VERTEX_LABEL;
  * Converts an EPGM vertex to a Tuple2 with its graph ids in field 0 and a
  * {@link IdWithCandidates} in field 1.
  *
+ * (vId,props,graphs) -> {(graphId, (vid,candidates)}
+ *
  * @param <V> EPGM vertex type
  */
 public class BuildIdWithCandidatesAndGraphs<V extends Vertex>

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/ExpandFirstField.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/ExpandFirstField.java
@@ -38,9 +38,9 @@ public class ExpandFirstField<T>
   private Tuple2<GradoopId, T> reuseTuple = new Tuple2<>();
 
   @Override
-  public void flatMap(
-    Tuple2<GradoopIdSet, T> tuple2,
-    Collector<Tuple2<GradoopId, T>> collector) throws Exception {
+  public void flatMap(Tuple2<GradoopIdSet, T> tuple2, Collector<Tuple2<GradoopId, T>> collector)
+    throws Exception {
+
     reuseTuple.f1 = tuple2.f1;
     for (GradoopId id : tuple2.f0) {
       reuseTuple.f0 = id;


### PR DESCRIPTION
Now it uses a join instead of broadcast to remove unnecessary transactions.