### PR TITLE
[#459] using byte[] to represent GradoopId internally

### DIFF
--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValue.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValue.java
@@ -306,7 +306,8 @@ public class PropertyValue
    * @return {@code GradoopId} value
    */
   public GradoopId getGradoopId() {
-    return GradoopId.fromBytes(Arrays.copyOfRange(rawBytes, OFFSET, GradoopId.ID_SIZE + OFFSET));
+    return GradoopId.fromByteArray(
+      Arrays.copyOfRange(rawBytes, OFFSET, GradoopId.ID_SIZE + OFFSET));
   }
 
   //----------------------------------------------------------------------------
@@ -420,7 +421,7 @@ public class PropertyValue
    * @param gradoopIdValue value
    */
   public void setGradoopId(GradoopId gradoopIdValue) {
-    byte[] valueBytes = gradoopIdValue.getRawBytes();
+    byte[] valueBytes = gradoopIdValue.toByteArray();
     rawBytes = new byte[OFFSET + GradoopId.ID_SIZE];
     rawBytes[0] = TYPE_GRADOOP_ID;
     Bytes.putBytes(rawBytes, OFFSET, valueBytes, 0, valueBytes.length);

--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/id/GradoopIdTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/id/GradoopIdTest.java
@@ -77,11 +77,11 @@ public class GradoopIdTest {
   @Test
   public void testGetRawBytes() {
     GradoopId originalId = GradoopId.get();
-    assertEquals(GradoopId.ID_SIZE, originalId.getRawBytes().length);
+    assertEquals(GradoopId.ID_SIZE, originalId.toByteArray().length);
     assertEquals(
       "Reconstruction failed",
       originalId,
-      GradoopId.fromBytes(originalId.getRawBytes())
+      GradoopId.fromByteArray(originalId.toByteArray())
     );
   }
 
@@ -115,7 +115,7 @@ public class GradoopIdTest {
     buffer.put(b2);
     buffer.put(b3);
 
-    GradoopId newId = GradoopId.fromBytes(bytes);
+    GradoopId newId = GradoopId.fromByteArray(bytes);
 
     assertEquals(expectedId, newId);
   }


### PR DESCRIPTION
* equals, hashCode and compareTo directly operate on the byte[]
* fixes #459