### PR TITLE
Add support for List and Map property values

### DIFF
--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValue.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValue.java
@@ -17,8 +17,6 @@
 
 package org.gradoop.common.model.impl.properties;
 
-import com.google.common.primitives.Ints;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.io.WritableComparable;
 import org.gradoop.common.model.impl.id.GradoopId;

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValue.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValue.java
@@ -547,9 +547,7 @@ public class PropertyValue
   public void setMap(Map<PropertyValue, PropertyValue> map) {
     int size =
       map.keySet().stream().mapToInt(PropertyValue::byteSize).sum() +
-      map.keySet().size() * Integer.BYTES +
       map.values().stream().mapToInt(PropertyValue::byteSize).sum() +
-      map.values().size() * Integer.BYTES +
       OFFSET;
 
     ByteArrayOutputStream byteStream = new ByteArrayOutputStream(size);
@@ -575,7 +573,6 @@ public class PropertyValue
    */
   public void setList(List<PropertyValue> list) {
     int size = list.stream().mapToInt(PropertyValue::byteSize).sum() +
-      list.size() * Integer.BYTES +
       OFFSET;
 
     ByteArrayOutputStream byteStream = new ByteArrayOutputStream(size);

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValue.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValue.java
@@ -668,10 +668,9 @@ public class PropertyValue
       result = this.getBigDecimal().compareTo(o.getBigDecimal());
     } else if (this.isGradoopId() && o.isGradoopId()) {
       result = this.getGradoopId().compareTo(o.getGradoopId());
-    } else if (this.isMap() && o.isMap()) {
-      result = this.getMap().equals(o.getMap()) ? 0 : 1;
-    } else if (this.isList() && o.isList()) {
-      result = this.getList().equals(o.getList()) ? 0 : 1;
+    } else if (this.isMap() || o.isMap() || this.isList() || o.isList()) {
+      throw new UnsupportedOperationException(String.format(
+        "Method compareTo() is not supported for %s, %s", this.getClass(), o.getClass()));
     } else {
       throw new IllegalArgumentException(String.format(
         "Incompatible types: %s, %s", this.getClass(), o.getClass()));

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValue.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValue.java
@@ -369,7 +369,9 @@ public class PropertyValue
     DataInputStream inputStream = new DataInputStream(byteStream);
 
     try {
-      inputStream.skipBytes(OFFSET);
+      if (inputStream.skipBytes(OFFSET) != OFFSET) {
+        throw new RuntimeException("Malformed entry in PropertyValue List");
+      }
       while (inputStream.available() > 0) {
         key = new PropertyValue();
         key.readFields(inputStream);
@@ -400,7 +402,9 @@ public class PropertyValue
     DataInputStream inputStream = new DataInputStream(byteStream);
 
     try {
-      inputStream.skipBytes(OFFSET);
+      if (inputStream.skipBytes(OFFSET) != OFFSET) {
+        throw new RuntimeException("Malformed entry in PropertyValue List");
+      }
       while (inputStream.available() > 0) {
         entry = new PropertyValue();
         entry.readFields(inputStream);
@@ -444,7 +448,7 @@ public class PropertyValue
     } else if (value instanceof GradoopId) {
       setGradoopId((GradoopId) value);
     } else if (value instanceof Map) {
-      setMap((HashMap) value);
+      setMap((Map) value);
     } else if (value instanceof List) {
       setList((List) value);
     } else {

--- a/gradoop-common/src/test/java/org/gradoop/common/GradoopTestUtils.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/GradoopTestUtils.java
@@ -29,6 +29,7 @@ import org.gradoop.common.model.impl.id.GradoopId;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.properties.PropertyValue;
 import org.gradoop.common.util.AsciiGraphLoader;
 import org.gradoop.common.config.GradoopConfig;
 
@@ -38,9 +39,11 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -64,20 +67,45 @@ public class GradoopTestUtils {
   public static final String KEY_5 = "key5";
   public static final String KEY_6 = "key6";
   public static final String KEY_7 = "key7";
+  public static final String KEY_8 = "key8";
+  public static final String KEY_9 = "key9";
+  public static final String KEY_a = "keya";
 
-  public static final Object      NULL_VAL_0        = null;
-  public static final boolean     BOOL_VAL_1        = true;
-  public static final int         INT_VAL_2         = 23;
-  public static final long        LONG_VAL_3        = 23L;
-  public static final float       FLOAT_VAL_4       = 2.3f;
-  public static final double      DOUBLE_VAL_5      = 2.3;
-  public static final String      STRING_VAL_6      = "23";
-  public static final BigDecimal  BIG_DECIMAL_VAL_7 = new BigDecimal(23);
-  public static final GradoopId   GRADOOP_ID_VAL_8  = GradoopId.get();
+  public static final Object      NULL_VAL_0                        = null;
+  public static final boolean     BOOL_VAL_1                        = true;
+  public static final int         INT_VAL_2                         = 23;
+  public static final long        LONG_VAL_3                        = 23L;
+  public static final float       FLOAT_VAL_4                       = 2.3f;
+  public static final double      DOUBLE_VAL_5                      = 2.3;
+  public static final String      STRING_VAL_6                      = "23";
+  public static final BigDecimal  BIG_DECIMAL_VAL_7                 = new BigDecimal(23);
+  public static final GradoopId   GRADOOP_ID_VAL_8                  = GradoopId.get();
+  public static final Map<PropertyValue, PropertyValue>  MAP_VAL_9  = new HashMap<>();
+  public static final List<PropertyValue> LIST_VAL_A                = new ArrayList<>();
 
   private static Comparator<EPGMIdentifiable> ID_COMPARATOR = new EPGMIdentifiableComparator();
 
   static {
+    MAP_VAL_9.put(PropertyValue.create(KEY_0), PropertyValue.create(NULL_VAL_0));
+    MAP_VAL_9.put(PropertyValue.create(KEY_1), PropertyValue.create(BOOL_VAL_1));
+    MAP_VAL_9.put(PropertyValue.create(KEY_2), PropertyValue.create(INT_VAL_2));
+    MAP_VAL_9.put(PropertyValue.create(KEY_3), PropertyValue.create(LONG_VAL_3));
+    MAP_VAL_9.put(PropertyValue.create(KEY_4), PropertyValue.create(FLOAT_VAL_4));
+    MAP_VAL_9.put(PropertyValue.create(KEY_5), PropertyValue.create(DOUBLE_VAL_5));
+    MAP_VAL_9.put(PropertyValue.create(KEY_6), PropertyValue.create(STRING_VAL_6));
+    MAP_VAL_9.put(PropertyValue.create(KEY_7), PropertyValue.create(BIG_DECIMAL_VAL_7));
+    MAP_VAL_9.put(PropertyValue.create(KEY_8), PropertyValue.create(GRADOOP_ID_VAL_8));
+
+    LIST_VAL_A.add(PropertyValue.create(NULL_VAL_0));
+    LIST_VAL_A.add(PropertyValue.create(BOOL_VAL_1));
+    LIST_VAL_A.add(PropertyValue.create(INT_VAL_2));
+    LIST_VAL_A.add(PropertyValue.create(LONG_VAL_3));
+    LIST_VAL_A.add(PropertyValue.create(FLOAT_VAL_4));
+    LIST_VAL_A.add(PropertyValue.create(DOUBLE_VAL_5));
+    LIST_VAL_A.add(PropertyValue.create(STRING_VAL_6));
+    LIST_VAL_A.add(PropertyValue.create(BIG_DECIMAL_VAL_7));
+    LIST_VAL_A.add(PropertyValue.create(GRADOOP_ID_VAL_8));
+
     SUPPORTED_PROPERTIES = Maps.newTreeMap();
     SUPPORTED_PROPERTIES.put(KEY_0, NULL_VAL_0);
     SUPPORTED_PROPERTIES.put(KEY_1, BOOL_VAL_1);
@@ -87,6 +115,8 @@ public class GradoopTestUtils {
     SUPPORTED_PROPERTIES.put(KEY_5, DOUBLE_VAL_5);
     SUPPORTED_PROPERTIES.put(KEY_6, STRING_VAL_6);
     SUPPORTED_PROPERTIES.put(KEY_7, BIG_DECIMAL_VAL_7);
+    SUPPORTED_PROPERTIES.put(KEY_8, GRADOOP_ID_VAL_8);
+    SUPPORTED_PROPERTIES.put(KEY_9, MAP_VAL_9);
   }
 
   /**

--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/properties/PropertyValueTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/properties/PropertyValueTest.java
@@ -616,6 +616,7 @@ public class PropertyValueTest {
     assertEquals(p, writeAndReadFields(PropertyValue.class, p));
 
     p = create(MAP_VAL_9);
+    assertEquals(p, writeAndReadFields(PropertyValue.class, p));
 
     p = create(LIST_VAL_A);
     assertEquals(p, writeAndReadFields(PropertyValue.class, p));

--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/properties/PropertyValueTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/properties/PropertyValueTest.java
@@ -574,6 +574,18 @@ public class PropertyValueTest {
     create(10).compareTo(create(10L));
   }
 
+  @Test(expected = UnsupportedOperationException.class)
+  public void testCompareToWithMap() {
+    create(MAP_VAL_9).compareTo(create(MAP_VAL_9));
+  }
+
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testCompareToWithList() {
+    create(LIST_VAL_A).compareTo(create(LIST_VAL_A));
+  }
+
+
   @Test
   public void testWriteAndReadFields() throws IOException {
     PropertyValue p = create(NULL_VAL_0);

--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/properties/PropertyValueTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/properties/PropertyValueTest.java
@@ -1,5 +1,6 @@
 package org.gradoop.common.model.impl.properties;
 
+import com.google.common.collect.Lists;
 import org.gradoop.common.model.impl.id.GradoopId;
 import org.gradoop.common.storage.exceptions.UnsupportedTypeException;
 import org.junit.Rule;
@@ -9,6 +10,10 @@ import org.junit.rules.ExpectedException;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 
 import static org.gradoop.common.GradoopTestUtils.*;
 import static org.gradoop.common.model.impl.properties.PropertyValue.create;
@@ -99,6 +104,14 @@ public class PropertyValueTest {
     p = create(GRADOOP_ID_VAL_8);
     assertTrue(p.isGradoopId());
     assertEquals(GRADOOP_ID_VAL_8, p.getGradoopId());
+    //Map
+    p = create(MAP_VAL_9);
+    assertTrue(p.isMap());
+    assertEquals(MAP_VAL_9, p.getMap());
+    //List
+    p = create(LIST_VAL_A);
+    assertTrue(p.isList());
+    assertEquals(LIST_VAL_A, p.getList());
   }
 
   @Test
@@ -140,12 +153,20 @@ public class PropertyValueTest {
     p.setObject(GRADOOP_ID_VAL_8);
     assertTrue(p.isGradoopId());
     assertEquals(GRADOOP_ID_VAL_8, p.getObject());
+    // Map
+    p.setObject(MAP_VAL_9);
+    assertTrue(p.isMap());
+    assertEquals(MAP_VAL_9, p.getObject());
+    // List
+    p.setObject(LIST_VAL_A);
+    assertTrue(p.isList());
+    assertEquals(LIST_VAL_A, p.getObject());
   }
 
   @Test(expected = UnsupportedTypeException.class)
   public void testSetObjectWithUnsupportedType() {
     PropertyValue p = new PropertyValue();
-    p.setObject(new ArrayList<>());
+    p.setObject(new HashSet<>());
   }
 
   @Test
@@ -160,6 +181,8 @@ public class PropertyValueTest {
     assertFalse(p.isString());
     assertFalse(p.isBigDecimal());
     assertFalse(p.isGradoopId());
+    assertFalse(p.isMap());
+    assertFalse(p.isList());
   }
 
   @Test
@@ -174,6 +197,8 @@ public class PropertyValueTest {
     assertFalse(p.isString());
     assertFalse(p.isBigDecimal());
     assertFalse(p.isGradoopId());
+    assertFalse(p.isMap());
+    assertFalse(p.isList());
   }
 
   @Test
@@ -201,6 +226,8 @@ public class PropertyValueTest {
     assertFalse(p.isString());
     assertFalse(p.isBigDecimal());
     assertFalse(p.isGradoopId());
+    assertFalse(p.isMap());
+    assertFalse(p.isList());
   }
 
   @Test
@@ -228,6 +255,8 @@ public class PropertyValueTest {
     assertFalse(p.isString());
     assertFalse(p.isBigDecimal());
     assertFalse(p.isGradoopId());
+    assertFalse(p.isMap());
+    assertFalse(p.isList());
   }
 
   @Test
@@ -255,6 +284,8 @@ public class PropertyValueTest {
     assertFalse(p.isString());
     assertFalse(p.isBigDecimal());
     assertFalse(p.isGradoopId());
+    assertFalse(p.isMap());
+    assertFalse(p.isList());
   }
 
   @Test
@@ -282,6 +313,8 @@ public class PropertyValueTest {
     assertFalse(p.isString());
     assertFalse(p.isBigDecimal());
     assertFalse(p.isGradoopId());
+    assertFalse(p.isMap());
+    assertFalse(p.isList());
   }
 
   @Test
@@ -309,6 +342,8 @@ public class PropertyValueTest {
     assertTrue(p.isString());
     assertFalse(p.isBigDecimal());
     assertFalse(p.isGradoopId());
+    assertFalse(p.isMap());
+    assertFalse(p.isList());
   }
 
   @Test
@@ -336,6 +371,8 @@ public class PropertyValueTest {
     assertFalse(p.isString());
     assertTrue(p.isBigDecimal());
     assertFalse(p.isGradoopId());
+    assertFalse(p.isMap());
+    assertFalse(p.isList());
   }
 
   @Test
@@ -363,6 +400,8 @@ public class PropertyValueTest {
     assertFalse(p.isString());
     assertFalse(p.isBigDecimal());
     assertTrue(p.isGradoopId());
+    assertFalse(p.isMap());
+    assertFalse(p.isList());
   }
 
   @Test
@@ -376,6 +415,64 @@ public class PropertyValueTest {
     PropertyValue p = new PropertyValue();
     p.setGradoopId(GRADOOP_ID_VAL_8);
     assertEquals(GRADOOP_ID_VAL_8, p.getGradoopId());
+  }
+
+  @Test
+  public void testIsMap() throws Exception {
+    PropertyValue p = PropertyValue.create(MAP_VAL_9);
+    assertFalse(p.isNull());
+    assertFalse(p.isBoolean());
+    assertFalse(p.isInt());
+    assertFalse(p.isLong());
+    assertFalse(p.isFloat());
+    assertFalse(p.isDouble());
+    assertFalse(p.isString());
+    assertFalse(p.isBigDecimal());
+    assertFalse(p.isGradoopId());
+    assertTrue(p.isMap());
+    assertFalse(p.isList());
+  }
+
+  @Test
+  public void testGetMap() throws Exception {
+    PropertyValue p = PropertyValue.create(MAP_VAL_9);
+    assertEquals(MAP_VAL_9, p.getMap());
+  }
+
+  @Test
+  public void testSetMap() throws Exception {
+    PropertyValue p = new PropertyValue();
+    p.setMap(MAP_VAL_9);
+    assertEquals(MAP_VAL_9, p.getMap());
+  }
+
+  @Test
+  public void testIsList() throws Exception {
+    PropertyValue p = PropertyValue.create(LIST_VAL_A);
+    assertFalse(p.isNull());
+    assertFalse(p.isBoolean());
+    assertFalse(p.isInt());
+    assertFalse(p.isLong());
+    assertFalse(p.isFloat());
+    assertFalse(p.isDouble());
+    assertFalse(p.isString());
+    assertFalse(p.isBigDecimal());
+    assertFalse(p.isGradoopId());
+    assertFalse(p.isMap());
+    assertTrue(p.isList());
+  }
+
+  @Test
+  public void testGetList() throws Exception {
+    PropertyValue p = PropertyValue.create(LIST_VAL_A);
+    assertEquals(LIST_VAL_A, p.getList());
+  }
+
+  @Test
+  public void testSetList() throws Exception {
+    PropertyValue p = new PropertyValue();
+    p.setList(LIST_VAL_A);
+    assertEquals(LIST_VAL_A, p.getList());
   }
 
   @Test
@@ -403,6 +500,25 @@ public class PropertyValueTest {
       create(GradoopId.fromString("583ff8ffbd7d222690a90999")),
       create(GradoopId.fromString("583ff8ffbd7d222690a9099a"))
     );
+
+    Map<PropertyValue, PropertyValue> map1 = new HashMap<>();
+    map1.put(PropertyValue.create("foo"), PropertyValue.create("bar"));
+    Map<PropertyValue, PropertyValue> map2 = new HashMap<>();
+    map2.put(PropertyValue.create("foo"), PropertyValue.create("bar"));
+    Map<PropertyValue, PropertyValue> map3 = new HashMap<>();
+    map3.put(PropertyValue.create("foo"), PropertyValue.create("baz"));
+    validateEqualsAndHashCode(create(map1), create(map2), create(map3));
+
+    List<PropertyValue> list1 = Lists.newArrayList(
+      PropertyValue.create("foo"), PropertyValue.create("bar")
+    );
+    List<PropertyValue> list2 = Lists.newArrayList(
+      PropertyValue.create("foo"), PropertyValue.create("bar")
+    );
+    List<PropertyValue> list3 = Lists.newArrayList(
+      PropertyValue.create("foo"), PropertyValue.create("baz")
+    );
+    validateEqualsAndHashCode(create(list1), create(list2), create(list3));
   }
 
   /**
@@ -485,6 +601,11 @@ public class PropertyValueTest {
     assertEquals(p, writeAndReadFields(PropertyValue.class, p));
 
     p = create(GRADOOP_ID_VAL_8);
+    assertEquals(p, writeAndReadFields(PropertyValue.class, p));
+
+    p = create(MAP_VAL_9);
+
+    p = create(LIST_VAL_A);
     assertEquals(p, writeAndReadFields(PropertyValue.class, p));
   }
   /**

--- a/gradoop-common/src/test/java/org/gradoop/common/storage/impl/hbase/HBaseGraphStoreTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/storage/impl/hbase/HBaseGraphStoreTest.java
@@ -180,8 +180,8 @@ public class HBaseGraphStoreTest extends GradoopHBaseTestBase {
       new HBaseVertexFactory<>();
     EPGMVertexFactory<Vertex> vertexFactory = new VertexFactory();
 
-    // list is not supported by
-    final List<String> value = Lists.newArrayList();
+    // Set is not supported by
+    final Set<String> value = Sets.newHashSet();
 
     GradoopId vertexID = GradoopId.get();
     final String label = "A";


### PR DESCRIPTION
Fixes #265 

This adds support for `List` and `Map` in `PropertyValue`.
The list and maps must be parameterized as PropertyValue

```java
List<PropertyValue> list = new ArrayList<>();
list.add(PropertyValue.create(42));
list.add(PropertyValue.create("foo"));
PropertyValue listProperty = ProperyValue.create(list);
assertEquals(list, listProperty.getList());

Map<PropertyValue, PropertyValue> map = new HashMap<>();
map.put(PropertyValue.create(42), PropertyValue("42"));
map.put(PropertyValue.create(21), PropertyValue("21"));
PropertyValue mapProperty = ProperyValue.create(map);
assertEquals(map, mapProperty.getMap());
```