### PR TITLE
[#221] Add variable binding to matching

### DIFF
--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/GraphHead.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/GraphHead.java
@@ -25,6 +25,8 @@ import org.gradoop.common.model.impl.properties.Properties;
  * POJO Implementation of an EPGM graph head.
  */
 public class GraphHead extends Element implements EPGMGraphHead {
+  public static transient final String VERTEX_VARIABLE_MAPPING_KEY = "__vertex_variable_mapping";
+  public static transient final String EDGE_VARIABLE_MAPPING_KEY = "__edge_variable_mapping";
 
   /**
    * Default constructor.

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/GraphHead.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/GraphHead.java
@@ -25,8 +25,6 @@ import org.gradoop.common.model.impl.properties.Properties;
  * POJO Implementation of an EPGM graph head.
  */
 public class GraphHead extends Element implements EPGMGraphHead {
-  public static transient final String VERTEX_VARIABLE_MAPPING_KEY = "__vertex_variable_mapping";
-  public static transient final String EDGE_VARIABLE_MAPPING_KEY = "__edge_variable_mapping";
 
   /**
    * Default constructor.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/functions/AddGraphElementToNewGraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/functions/AddGraphElementToNewGraph.java
@@ -23,6 +23,10 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.pojo.GraphElement;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.GraphHeadFactory;
+import org.gradoop.common.model.impl.properties.PropertyValue;
+import org.gradoop.flink.model.impl.operators.matching.single.PatternMatching;
+
+import java.util.HashMap;
 
 /**
  * (GE) -> (GE (+ GraphHead), GraphHead)
@@ -41,24 +45,44 @@ public class AddGraphElementToNewGraph<GE extends GraphElement>
    */
   private final GraphHeadFactory graphHeadFactory;
   /**
+   * Variable assigned to the query vertex
+   */
+  private final String variable;
+  /**
    * Reduce instantiations
    */
   private final Tuple2<GE, GraphHead> reuseTuple;
+  /**
+   * Reuse map for variable mapping
+   */
+  private final HashMap<PropertyValue, PropertyValue> reuseVariableMapping;
 
   /**
    * Constructor
    *
    * @param graphHeadFactory EPGM graph head factory
+   * @param variable Variable assigned to the only query vertex
    */
-  public AddGraphElementToNewGraph(GraphHeadFactory graphHeadFactory) {
+  public AddGraphElementToNewGraph(GraphHeadFactory graphHeadFactory, String variable) {
     this.graphHeadFactory = graphHeadFactory;
+    this.variable = variable;
     reuseTuple = new Tuple2<>();
+    reuseVariableMapping = new HashMap<>();
   }
 
   @Override
   public Tuple2<GE, GraphHead> map(GE value) throws Exception {
+    reuseVariableMapping.clear();
+    reuseVariableMapping.put(
+      PropertyValue.create(this.variable),
+      PropertyValue.create(value.getId())
+    );
+
     GraphHead graphHead = graphHeadFactory.createGraphHead();
+    graphHead.setProperty(PatternMatching.VARIABLE_MAPPING_KEY, reuseVariableMapping);
+
     value.addGraphId(graphHead.getId());
+
     reuseTuple.f0 = value;
     reuseTuple.f1 = graphHead;
     return reuseTuple;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/functions/ElementsFromEmbedding.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/functions/ElementsFromEmbedding.java
@@ -18,30 +18,34 @@
 package org.gradoop.flink.model.impl.operators.matching.common.functions;
 
 import com.google.common.collect.Maps;
-import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Collector;
+import org.gradoop.common.model.impl.id.GradoopId;
 import org.gradoop.common.model.impl.pojo.Edge;
+import org.gradoop.common.model.impl.pojo.EdgeFactory;
 import org.gradoop.common.model.impl.pojo.Element;
 import org.gradoop.common.model.impl.pojo.GraphHead;
-import org.gradoop.flink.model.impl.operators.matching.common.query.Step;
-import org.gradoop.flink.model.impl.operators.matching.common.query
-  .TraversalCode;
-import org.gradoop.common.model.impl.pojo.EdgeFactory;
 import org.gradoop.common.model.impl.pojo.GraphHeadFactory;
 import org.gradoop.common.model.impl.pojo.Vertex;
 import org.gradoop.common.model.impl.pojo.VertexFactory;
-import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.common.model.impl.properties.PropertyValue;
+import org.gradoop.flink.model.impl.operators.matching.common.query.QueryHandler;
+import org.gradoop.flink.model.impl.operators.matching.common.query.Step;
+import org.gradoop.flink.model.impl.operators.matching.common.query.TraversalCode;
 import org.gradoop.flink.model.impl.operators.matching.common.tuples.Embedding;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Extracts {@link Element} instances from an {@link Embedding}.
  */
 public class ElementsFromEmbedding
-  implements FlatMapFunction<Tuple1<Embedding<GradoopId>>, Element> {
+  extends RichFlatMapFunction<Tuple1<Embedding<GradoopId>>, Element> {
 
   /**
    * Maps edge candidates to the step in which they are traversed
@@ -60,6 +64,12 @@ public class ElementsFromEmbedding
    */
   private final EdgeFactory edgeFactory;
 
+  private final Map<Long, String> queryVertexMapping;
+
+  private final Map<Long, String> queryEdgeMapping;
+
+  private Map<PropertyValue, PropertyValue> reuseVertexVariableMapping;
+  private Map<PropertyValue, PropertyValue> reuseEdgeVariableMapping;
   /**
    * Constructor
    *
@@ -71,10 +81,19 @@ public class ElementsFromEmbedding
   public ElementsFromEmbedding(TraversalCode traversalCode,
     GraphHeadFactory graphHeadFactory,
     VertexFactory vertexFactory,
-    EdgeFactory edgeFactory) {
+    EdgeFactory edgeFactory,
+    QueryHandler query) {
     this.graphHeadFactory = graphHeadFactory;
     this.vertexFactory = vertexFactory;
     this.edgeFactory = edgeFactory;
+
+    this.queryVertexMapping = query.getVertices()
+      .stream()
+      .collect(Collectors.toMap(v -> v.getId(), v -> v.getVariable()));
+
+    this.queryEdgeMapping = query.getEdges()
+      .stream()
+      .collect(Collectors.toMap(e -> e.getId(), e -> e.getVariable()));
 
     List<Step> steps = traversalCode.getSteps();
     edgeToStep = Maps.newHashMapWithExpectedSize(steps.size());
@@ -85,14 +104,39 @@ public class ElementsFromEmbedding
   }
 
   @Override
+  public void open(Configuration conf) {
+    this.reuseVertexVariableMapping = new HashMap<>();
+    this.reuseEdgeVariableMapping = new HashMap<>();
+  }
+
+  @Override
   public void flatMap(Tuple1<Embedding<GradoopId>> embedding, Collector<Element> out)
     throws Exception {
 
     GradoopId[] vertexMapping = embedding.f0.getVertexMapping();
     GradoopId[] edgeMapping = embedding.f0.getEdgeMapping();
 
+    reuseVertexVariableMapping.clear();
+    reuseEdgeVariableMapping.clear();
+
+    for (int i = 0; i < vertexMapping.length; i++) {
+      reuseVertexVariableMapping.put(
+        PropertyValue.create(queryVertexMapping.get((long) i)),
+        PropertyValue.create(vertexMapping[i])
+      );
+    }
+
+    for (int i = 0; i < edgeMapping.length; i++) {
+      reuseEdgeVariableMapping.put(
+        PropertyValue.create(queryEdgeMapping.get((long) i)),
+        PropertyValue.create(edgeMapping[i])
+      );
+    }
+
     // create graph head for this embedding
     GraphHead graphHead = graphHeadFactory.createGraphHead();
+    graphHead.setProperty(GraphHead.VERTEX_VARIABLE_MAPPING_KEY, reuseVertexVariableMapping);
+    graphHead.setProperty(GraphHead.EDGE_VARIABLE_MAPPING_KEY, reuseEdgeVariableMapping);
     out.collect(graphHead);
 
     // collect vertices (and assign to graph head)

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/functions/ElementsFromEmbedding.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/functions/ElementsFromEmbedding.java
@@ -122,26 +122,9 @@ public class ElementsFromEmbedding
     GradoopId[] vertexMapping = embedding.f0.getVertexMapping();
     GradoopId[] edgeMapping = embedding.f0.getEdgeMapping();
 
-    reuseVariableMapping.clear();
-
-    for (int i = 0; i < vertexMapping.length; i++) {
-      reuseVariableMapping.put(
-        PropertyValue.create(queryVertexMapping.get((long) i)),
-        PropertyValue.create(vertexMapping[i])
-      );
-    }
-
-    for (int i = 0; i < edgeMapping.length; i++) {
-      reuseVariableMapping.put(
-        PropertyValue.create(queryEdgeMapping.get((long) i)),
-        PropertyValue.create(edgeMapping[i])
-      );
-    }
 
     // create graph head for this embedding
     GraphHead graphHead = graphHeadFactory.createGraphHead();
-    graphHead.setProperty(PatternMatching.VARIABLE_MAPPING_KEY, reuseVariableMapping);
-    out.collect(graphHead);
 
     // collect vertices (and assign to graph head)
     for (int i = 0; i < vertexMapping.length; i++) {
@@ -150,6 +133,11 @@ public class ElementsFromEmbedding
         v.addGraphId(graphHead.getId());
         out.collect(v);
       }
+
+      reuseVariableMapping.put(
+        PropertyValue.create(queryVertexMapping.get((long) i)),
+        PropertyValue.create(vertexMapping[i])
+      );
     }
 
     // collect edges (and assign to graph head)
@@ -165,7 +153,15 @@ public class ElementsFromEmbedding
         e.addGraphId(graphHead.getId());
         out.collect(e);
       }
+
+      reuseVariableMapping.put(
+        PropertyValue.create(queryEdgeMapping.get((long) i)),
+        PropertyValue.create(edgeMapping[i])
+      );
     }
+
+    graphHead.setProperty(PatternMatching.VARIABLE_MAPPING_KEY, reuseVariableMapping);
+    out.collect(graphHead);
   }
 
   /**

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/PatternMatching.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/PatternMatching.java
@@ -40,6 +40,12 @@ import org.gradoop.flink.model.impl.operators.matching.common.tuples.TripleWithC
  */
 public abstract class PatternMatching implements
   UnaryGraphToCollectionOperator {
+
+  /**
+   * The property key used to stored the variable mappings inside the GraphHead properties
+   */
+  public static final transient String VARIABLE_MAPPING_KEY = "__vertex_variable_mapping";
+
   /**
    * GDL based query string
    */

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativePatternMatching.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativePatternMatching.java
@@ -52,18 +52,12 @@ import org.gradoop.flink.model.impl.operators.matching.common.tuples.Embedding;
 import org.gradoop.flink.model.impl.operators.matching.common.tuples.IdWithCandidates;
 import org.gradoop.flink.model.impl.operators.matching.common.tuples.TripleWithCandidates;
 import org.gradoop.flink.model.impl.operators.matching.single.PatternMatching;
-import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser
-  .SetPairBulkTraverser;
-import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser
-  .SetPairForLoopTraverser;
-import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser
-  .SetPairTraverser;
-import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser
-  .TraverserStrategy;
-import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser
-  .TripleForLoopTraverser;
-import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser
-  .TripleTraverser;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser.SetPairBulkTraverser;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser.SetPairForLoopTraverser;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser.SetPairTraverser;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser.TraverserStrategy;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser.TripleForLoopTraverser;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser.TripleTraverser;
 import org.gradoop.flink.util.GradoopFlinkConfig;
 
 import java.util.Objects;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativePatternMatching.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativePatternMatching.java
@@ -38,8 +38,6 @@ import org.gradoop.flink.model.impl.functions.epgm.VertexFromId;
 import org.gradoop.flink.model.impl.functions.tuple.ObjectTo1;
 import org.gradoop.flink.model.impl.functions.tuple.Value0Of2;
 import org.gradoop.flink.model.impl.functions.tuple.Value1Of2;
-import org.gradoop.flink.model.impl.operators.matching.common.query.Traverser;
-import org.gradoop.flink.model.impl.operators.matching.single.PatternMatching;
 import org.gradoop.flink.model.impl.operators.matching.common.MatchStrategy;
 import org.gradoop.flink.model.impl.operators.matching.common.PostProcessor;
 import org.gradoop.flink.model.impl.operators.matching.common.PreProcessor;
@@ -49,25 +47,29 @@ import org.gradoop.flink.model.impl.operators.matching.common.functions.Matching
 import org.gradoop.flink.model.impl.operators.matching.common.query.DFSTraverser;
 import org.gradoop.flink.model.impl.operators.matching.common.query.QueryHandler;
 import org.gradoop.flink.model.impl.operators.matching.common.query.TraversalCode;
+import org.gradoop.flink.model.impl.operators.matching.common.query.Traverser;
 import org.gradoop.flink.model.impl.operators.matching.common.tuples.Embedding;
 import org.gradoop.flink.model.impl.operators.matching.common.tuples.IdWithCandidates;
 import org.gradoop.flink.model.impl.operators.matching.common.tuples.TripleWithCandidates;
+import org.gradoop.flink.model.impl.operators.matching.single.PatternMatching;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser
-  .TraverserStrategy;
-import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser.TripleForLoopTraverser;
-import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser.SetPairBulkTraverser;
-
-import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser.SetPairForLoopTraverser;
-
+  .SetPairBulkTraverser;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser
+  .SetPairForLoopTraverser;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser
   .SetPairTraverser;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser
+  .TraverserStrategy;
+import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser
+  .TripleForLoopTraverser;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser
   .TripleTraverser;
 import org.gradoop.flink.util.GradoopFlinkConfig;
 
 import java.util.Objects;
 
-import static org.apache.flink.api.common.operators.base.JoinOperatorBase.JoinHint.OPTIMIZER_CHOOSES;
+import static org.apache.flink.api.common.operators.base.JoinOperatorBase.JoinHint
+  .OPTIMIZER_CHOOSES;
 
 /**
  * Algorithm detects subgraphs by traversing the search graph according to a
@@ -229,7 +231,9 @@ public class ExplorativePatternMatching
       .flatMap(new ElementsFromEmbedding(traversalCode,
         graph.getConfig().getGraphHeadFactory(),
         graph.getConfig().getVertexFactory(),
-        graph.getConfig().getEdgeFactory()));
+        graph.getConfig().getEdgeFactory(),
+        getQueryHandler()
+      ));
 
     return doAttachData() ?
       PostProcessor.extractGraphCollectionWithData(elements, graph, true) :

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativePatternMatching.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativePatternMatching.java
@@ -140,6 +140,7 @@ public class ExplorativePatternMatching
     GradoopFlinkConfig config = graph.getConfig();
     GraphHeadFactory graphHeadFactory = config.getGraphHeadFactory();
     VertexFactory vertexFactory = config.getVertexFactory();
+    String variable = getQueryHandler().getVertices().iterator().next().getVariable();
 
     DataSet<Vertex> matchingVertices = graph.getVertices()
       .filter(new MatchingVertices<>(getQuery()));
@@ -152,7 +153,7 @@ public class ExplorativePatternMatching
     }
 
     DataSet<Tuple2<Vertex, GraphHead>> pairs = matchingVertices
-      .map(new AddGraphElementToNewGraph<>(graphHeadFactory))
+      .map(new AddGraphElementToNewGraph<>(graphHeadFactory, variable))
       .returns(new TupleTypeInfo<>(
         TypeExtractor.getForClass(vertexFactory.getType()),
         TypeExtractor.getForClass(graphHeadFactory.getType())));

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/common/functions/AddGraphElementToNewGraphTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/common/functions/AddGraphElementToNewGraphTest.java
@@ -1,3 +1,16 @@
+package org.gradoop.flink.model.impl.operators.matching.common.functions;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.gradoop.common.model.impl.pojo.GraphHead;
+import org.gradoop.common.model.impl.pojo.GraphHeadFactory;
+import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.pojo.VertexFactory;
+import org.gradoop.common.model.impl.properties.PropertyValue;
+import org.gradoop.flink.model.impl.operators.matching.single.PatternMatching;
+import org.junit.Test;
+
+import java.util.Map;
+
 import static org.junit.Assert.*;
 /*
  * This file is part of Gradoop.
@@ -17,5 +30,18 @@ import static org.junit.Assert.*;
  */
 
 public class AddGraphElementToNewGraphTest {
+  @Test
+  public void testVariableMappingCreation() throws Exception {
+    AddGraphElementToNewGraph<Vertex> udf =
+      new AddGraphElementToNewGraph<>(new GraphHeadFactory(), "a");
 
+    Vertex vertex = new VertexFactory().createVertex();
+    Tuple2<Vertex, GraphHead> result = udf.map(vertex);
+
+    assertTrue(result.f1.hasProperty(PatternMatching.VARIABLE_MAPPING_KEY));
+    Map<PropertyValue, PropertyValue> variableMapping =
+      result.f1.getPropertyValue(PatternMatching.VARIABLE_MAPPING_KEY).getMap();
+
+    assertEquals(vertex.getId(), variableMapping.get(PropertyValue.create("a")).getGradoopId());
+  }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/common/functions/AddGraphElementToNewGraphTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/common/functions/AddGraphElementToNewGraphTest.java
@@ -1,0 +1,21 @@
+import static org.junit.Assert.*;
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+public class AddGraphElementToNewGraphTest {
+
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/common/functions/ElementsFromEmbeddingTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/common/functions/ElementsFromEmbeddingTest.java
@@ -1,0 +1,107 @@
+package org.gradoop.flink.model.impl.operators.matching.common.functions;
+
+import org.apache.flink.api.common.functions.util.ListCollector;
+import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.configuration.Configuration;
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.common.model.impl.pojo.EdgeFactory;
+import org.gradoop.common.model.impl.pojo.Element;
+import org.gradoop.common.model.impl.pojo.GraphHead;
+import org.gradoop.common.model.impl.pojo.GraphHeadFactory;
+import org.gradoop.common.model.impl.pojo.VertexFactory;
+import org.gradoop.common.model.impl.properties.PropertyValue;
+import org.gradoop.flink.model.impl.operators.matching.common.query.DFSTraverser;
+import org.gradoop.flink.model.impl.operators.matching.common.query.QueryHandler;
+import org.gradoop.flink.model.impl.operators.matching.common.query.TraversalCode;
+import org.gradoop.flink.model.impl.operators.matching.common.query.Traverser;
+import org.gradoop.flink.model.impl.operators.matching.common.tuples.Embedding;
+import org.junit.Test;
+import org.s1ck.gdl.model.Edge;
+import org.s1ck.gdl.model.Vertex;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.Math.toIntExact;
+import static org.junit.Assert.*;
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+public class ElementsFromEmbeddingTest {
+
+  @Test
+  public void variableMappingTest() throws Exception{
+    GradoopId v1 = GradoopId.get();
+    GradoopId v2 = GradoopId.get();
+    GradoopId v3 = GradoopId.get();
+    GradoopId e1 = GradoopId.get();
+    GradoopId e2 = GradoopId.get();
+
+    QueryHandler query = new QueryHandler("(a)-[e]->(b)-[f]->(c)");
+
+    Traverser traverser = new DFSTraverser();
+    traverser.setQueryHandler(query);
+
+    TraversalCode traversalCode = traverser.traverse();
+
+    ElementsFromEmbedding udf = new ElementsFromEmbedding(
+      traversalCode, new GraphHeadFactory(), new VertexFactory(), new EdgeFactory(), query
+    );
+    udf.open(new Configuration());
+
+    GradoopId[] vertexMapping = new GradoopId[]{v1,v2,v3};
+    GradoopId[] edgeMapping = new GradoopId[]{e1,e2};
+
+    Embedding<GradoopId> embedding = new Embedding<>();
+    embedding.setVertexMapping(vertexMapping);
+    embedding.setEdgeMapping(edgeMapping);
+
+    List<Element> result = new ArrayList<>();
+
+    udf.flatMap(Tuple1.of(embedding), new ListCollector<>(result));
+
+    GraphHead graphHead = (GraphHead) result
+      .stream()
+      .filter(e -> e instanceof GraphHead)
+      .findFirst()
+      .get();
+
+    assertTrue(graphHead.hasProperty(GraphHead.VERTEX_VARIABLE_MAPPING_KEY));
+    assertTrue(graphHead.hasProperty(GraphHead.EDGE_VARIABLE_MAPPING_KEY));
+
+    Map<PropertyValue, PropertyValue> vertexVariableMapping
+      = graphHead.getPropertyValue(GraphHead.VERTEX_VARIABLE_MAPPING_KEY).getMap();
+
+    for (Vertex queryVertex : query.getVertices()) {
+      assertEquals(
+        vertexVariableMapping.get(PropertyValue.create(queryVertex.getVariable())),
+        PropertyValue.create(vertexMapping[toIntExact(queryVertex.getId())])
+      );
+    }
+
+    Map<PropertyValue, PropertyValue> edgeVariableMapping
+      = graphHead.getPropertyValue(GraphHead.EDGE_VARIABLE_MAPPING_KEY).getMap();
+
+    for (Edge queryEdge : query.getEdges()) {
+      assertEquals(
+        edgeVariableMapping.get(PropertyValue.create(queryEdge.getVariable())),
+        PropertyValue.create(edgeMapping[toIntExact(queryEdge.getId())])
+      );
+    }
+  }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/common/functions/ElementsFromEmbeddingTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/common/functions/ElementsFromEmbeddingTest.java
@@ -15,6 +15,7 @@ import org.gradoop.flink.model.impl.operators.matching.common.query.QueryHandler
 import org.gradoop.flink.model.impl.operators.matching.common.query.TraversalCode;
 import org.gradoop.flink.model.impl.operators.matching.common.query.Traverser;
 import org.gradoop.flink.model.impl.operators.matching.common.tuples.Embedding;
+import org.gradoop.flink.model.impl.operators.matching.single.PatternMatching;
 import org.junit.Test;
 import org.s1ck.gdl.model.Edge;
 import org.s1ck.gdl.model.Vertex;
@@ -81,26 +82,22 @@ public class ElementsFromEmbeddingTest {
       .findFirst()
       .get();
 
-    assertTrue(graphHead.hasProperty(GraphHead.VERTEX_VARIABLE_MAPPING_KEY));
-    assertTrue(graphHead.hasProperty(GraphHead.EDGE_VARIABLE_MAPPING_KEY));
+    assertTrue(graphHead.hasProperty(PatternMatching.VARIABLE_MAPPING_KEY));
 
-    Map<PropertyValue, PropertyValue> vertexVariableMapping
-      = graphHead.getPropertyValue(GraphHead.VERTEX_VARIABLE_MAPPING_KEY).getMap();
+    Map<PropertyValue, PropertyValue> variableMapping
+      = graphHead.getPropertyValue(PatternMatching.VARIABLE_MAPPING_KEY).getMap();
 
     for (Vertex queryVertex : query.getVertices()) {
       assertEquals(
-        vertexVariableMapping.get(PropertyValue.create(queryVertex.getVariable())),
-        PropertyValue.create(vertexMapping[toIntExact(queryVertex.getId())])
+        variableMapping.get(PropertyValue.create(queryVertex.getVariable())),
+        PropertyValue.create(vertexMapping[(int) queryVertex.getId()])
       );
     }
 
-    Map<PropertyValue, PropertyValue> edgeVariableMapping
-      = graphHead.getPropertyValue(GraphHead.EDGE_VARIABLE_MAPPING_KEY).getMap();
-
     for (Edge queryEdge : query.getEdges()) {
       assertEquals(
-        edgeVariableMapping.get(PropertyValue.create(queryEdge.getVariable())),
-        PropertyValue.create(edgeMapping[toIntExact(queryEdge.getId())])
+        variableMapping.get(PropertyValue.create(queryEdge.getVariable())),
+        PropertyValue.create(edgeMapping[(int) queryEdge.getId()])
       );
     }
   }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/PatternMatchingTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/PatternMatchingTest.java
@@ -1,19 +1,12 @@
 package org.gradoop.flink.model.impl.operators.matching.single;
 
-import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
 import org.gradoop.flink.model.impl.LogicalGraph;
 import org.gradoop.flink.model.impl.operators.matching.TestData;
-import org.gradoop.flink.model.impl.operators.matching.single.simulation.dual.DualSimulation;
 import org.gradoop.flink.util.FlinkAsciiGraphLoader;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import java.util.List;
-
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
 
 /**
  * Base class for Pattern Matching Tests.
@@ -21,15 +14,15 @@ import static org.junit.Assume.assumeTrue;
 @RunWith(Parameterized.class)
 public abstract class  PatternMatchingTest extends GradoopFlinkTestBase {
 
-  private final String testName;
+  protected final String testName;
 
-  private final String dataGraph;
+  protected final String dataGraph;
 
-  private final String queryGraph;
+  protected final String queryGraph;
 
-  private final String[] expectedGraphVariables;
+  protected final String[] expectedGraphVariables;
 
-  private final String expectedCollection;
+  protected final String expectedCollection;
 
   public PatternMatchingTest(String testName, String dataGraph, String queryGraph,
     String expectedGraphVariables, String expectedCollection) {
@@ -74,26 +67,5 @@ public abstract class  PatternMatchingTest extends GradoopFlinkTestBase {
         .getGraphCollectionByVariables(expectedGraphVariables)));
   }
 
-  @Test
-  public void testVariableMappingExists() throws Exception {
-    PatternMatching implementation = getImplementation(queryGraph, false);
-    assumeTrue(!(implementation instanceof DualSimulation));
 
-    FlinkAsciiGraphLoader loader = getLoaderFromString(dataGraph);
-
-    // initialize with data graph
-    LogicalGraph db = loader.getLogicalGraphByVariable(TestData.DATA_GRAPH_VARIABLE);
-
-    // append the expected result
-    loader.appendToDatabaseFromString(expectedCollection);
-
-    // execute and validate
-    List<GraphHead> graphHeads = implementation.execute(db).
-      getGraphHeads().collect();
-
-    for(GraphHead graphHead : graphHeads) {
-      assertTrue(graphHead.hasProperty(PatternMatching.VARIABLE_MAPPING_KEY));
-    }
-
-  }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/PatternMatchingWithBindingTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/PatternMatchingWithBindingTest.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.gradoop.flink.model.impl.operators.matching.single;
+
+import org.gradoop.common.model.impl.pojo.GraphHead;
+import org.gradoop.flink.model.impl.LogicalGraph;
+import org.gradoop.flink.model.impl.operators.matching.TestData;
+import org.gradoop.flink.util.FlinkAsciiGraphLoader;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * This is a test class used for all Patter Matching Algorithms that attach a variable mapping to
+ * the resulting graph heads.
+ * It contains an additional test that check the presents of these mappings
+ */
+public abstract class PatternMatchingWithBindingTest extends PatternMatchingTest {
+
+  public PatternMatchingWithBindingTest(String testName, String dataGraph, String queryGraph,
+    String expectedGraphVariables, String expectedCollection) {
+    super(testName,dataGraph,queryGraph,expectedGraphVariables,expectedCollection);
+  }
+
+  @Test
+  public void testVariableMappingExists() throws Exception {
+    FlinkAsciiGraphLoader loader = getLoaderFromString(this.dataGraph);
+
+    // initialize with data graph
+    LogicalGraph db = loader.getLogicalGraphByVariable(TestData.DATA_GRAPH_VARIABLE);
+
+    // append the expected result
+    loader.appendToDatabaseFromString(expectedCollection);
+
+    // execute and validate
+    List<GraphHead> graphHeads = getImplementation(queryGraph, false).execute(db).
+      getGraphHeads().collect();
+
+    for(GraphHead graphHead : graphHeads) {
+      assertTrue(graphHead.hasProperty(PatternMatching.VARIABLE_MAPPING_KEY));
+    }
+
+  }
+
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/SubgraphHomomorphismTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/SubgraphHomomorphismTest.java
@@ -1,6 +1,6 @@
 package org.gradoop.flink.model.impl.operators.matching.single.preserving;
 
-import org.gradoop.flink.model.impl.operators.matching.single.PatternMatchingTest;
+import org.gradoop.flink.model.impl.operators.matching.single.PatternMatchingWithBindingTest;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
@@ -11,7 +11,7 @@ import static org.gradoop.flink.model.impl.operators.matching.TestData.*;
  * Test data for pattern matching tests. The graphs are visualized in
  * dev-support/pattern_matching_testcases.pdf
  */
-public abstract class SubgraphHomomorphismTest extends PatternMatchingTest {
+public abstract class SubgraphHomomorphismTest extends PatternMatchingWithBindingTest {
 
   public SubgraphHomomorphismTest(String testName, String dataGraph,
     String queryGraph, String expectedGraphVariables,

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/SubgraphIsomorphismTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/SubgraphIsomorphismTest.java
@@ -1,6 +1,6 @@
 package org.gradoop.flink.model.impl.operators.matching.single.preserving;
 
-import org.gradoop.flink.model.impl.operators.matching.single.PatternMatchingTest;
+import org.gradoop.flink.model.impl.operators.matching.single.PatternMatchingWithBindingTest;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
@@ -11,7 +11,7 @@ import static org.gradoop.flink.model.impl.operators.matching.TestData.*;
  * Test data for pattern matching tests. The graphs are visualized in
  * dev-support/pattern_matching_testcases.pdf
  */
-public abstract class SubgraphIsomorphismTest extends PatternMatchingTest {
+public abstract class SubgraphIsomorphismTest extends PatternMatchingWithBindingTest {
 
   public SubgraphIsomorphismTest(String testName, String dataGraph,
     String queryGraph, String expectedGraphVariables,


### PR DESCRIPTION
Fixes #221 

This adds binding information to the matched subgraphs.
Every `GraphHead` contains a property representing the variable mapping for the matched sub graph

```java
LogicalGraph graph = //....
GraphCollection matches = graph.match("(a)-[e]->(b)");
Map<PropertyValue, PropertyValue> variableMapping = 
  matches.getGraphHeads().collect().get(0)
    .getPropertyValue(PatternMatching.VARIABLE_MAPPING_KEY).getMap();
variableMapping.get(PropertyValue.create("a") //-> Id of the vertex mapped to (a)
```