### PR TITLE
Extend QueryHandler

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/query/QueryHandler.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/query/QueryHandler.java
@@ -18,7 +18,6 @@
 package org.gradoop.flink.model.impl.operators.matching.common.query;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.gradoop.common.util.GConstants;
 import org.s1ck.gdl.GDLHandler;
@@ -28,10 +27,11 @@ import org.s1ck.gdl.model.Vertex;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Wraps a {@link GDLHandler} and adds functionality needed for query
@@ -158,6 +158,26 @@ public class QueryHandler {
   }
 
   /**
+   * Checks if the given variable points to a vertex.
+   *
+   * @param variable the elements variable
+   * @return True if the variable points to a vertex
+   */
+  public boolean isVertex(String variable) {
+    return gdlHandler.getVertexCache().containsKey(variable);
+  }
+
+  /**
+   * Checks if the given variable points to an edge.
+   *
+   * @param variable the elements variable
+   * @return True if the variable points to an edge
+   */
+  public boolean isEdge(String variable) {
+    return gdlHandler.getEdgeCache().containsKey(variable);
+  }
+
+  /**
    * Returns the vertex associated with the given id or {@code null} if the
    * vertex does not exist.
    *
@@ -166,7 +186,7 @@ public class QueryHandler {
    */
   public Vertex getVertexById(Long id) {
     if (idToVertexCache == null) {
-      idToVertexCache = initIdToElementCache(gdlHandler.getVertices());
+      idToVertexCache = initCache(getVertices(), Vertex::getId, Function.identity());
     }
     return idToVertexCache.get(id);
   }
@@ -180,9 +200,32 @@ public class QueryHandler {
    */
   public Edge getEdgeById(Long id) {
     if (idToEdgeCache == null) {
-      idToEdgeCache = initIdToElementCache(gdlHandler.getEdges());
+      idToEdgeCache = initCache(getEdges(), Edge::getId, Function.identity());
     }
     return idToEdgeCache.get(id);
+  }
+
+  /**
+   * Returns the Vertex assiciated with the given variable or {@code null} if the variable does
+   * not exist
+   *
+   * @param variable variable
+   * @return vertex or {@code null}
+   */
+  public Vertex getVertexByVariable(String variable) {
+    return gdlHandler.getVertexCache().get(variable);
+  }
+
+
+  /**
+   * Returns the Edge assiciated with the given variable or {@code null} if the variable does
+   * not exist
+   *
+   * @param variable variable
+   * @return edge or {@code null}
+   */
+  public Edge getEdgeByVariable(String variable) {
+    return gdlHandler.getEdgeCache().get(variable);
   }
 
   /**
@@ -194,7 +237,7 @@ public class QueryHandler {
    */
   public Collection<Vertex> getVerticesByLabel(String label) {
     if (labelToVertexCache == null) {
-      initLabelToVertexCache();
+      labelToVertexCache = initSetCache(getVertices(), Vertex::getLabel, Function.identity());
     }
     return labelToVertexCache.get(label);
   }
@@ -208,7 +251,7 @@ public class QueryHandler {
    */
   public Collection<Edge> getEdgesByLabel(String label) {
     if (labelToEdgeCache == null) {
-      initLabelToEdgeCache();
+      labelToEdgeCache = initSetCache(getEdges(), Edge::getLabel, Function.identity());
     }
     return labelToEdgeCache.get(label);
   }
@@ -240,7 +283,7 @@ public class QueryHandler {
    */
   public Collection<Edge> getEdgesBySourceVertexId(Long vertexId) {
     if (sourceIdToEdgeCache == null) {
-      initSourceIdToEdgeCache();
+      sourceIdToEdgeCache = initSetCache(getEdges(), Edge::getSourceVertexId, Function.identity());
     }
     return sourceIdToEdgeCache.get(vertexId);
   }
@@ -265,7 +308,7 @@ public class QueryHandler {
    */
   public Collection<Edge> getEdgesByTargetVertexId(Long vertexId) {
     if (targetIdToEdgeCache == null) {
-      initTargetIdToEdgeCache();
+      targetIdToEdgeCache = initSetCache(getEdges(), Edge::getTargetVertexId, Function.identity());
     }
     return targetIdToEdgeCache.get(vertexId);
   }
@@ -429,90 +472,49 @@ public class QueryHandler {
   }
 
   /**
-   * Initializes the identifier to graph element (vertex/edge) cache.
+   * Initializes a cache for the given data where every key maps to exactly one element (injective).
+   * Key selector will be called on every element to extract the caches key.
+   * Value selector will be called on every element to extract the value.
+   * Returns a cache of type
+   * KT -> VT
    *
-   * @param elements graph elements
-   * @param <EL> element type
-   * @return id to element cache
+   * @param elements elements the cache will be build from
+   * @param keySelector key selector function extraction cache keys from elements
+   * @param valueSelector value selector function extraction cache values from elements
+   * @param <EL> the element type
+   * @param <KT> the cache key type
+   * @param <VT> the cache value type
+   * @return cache KT -> VT
    */
-  private <EL extends GraphElement> Map<Long, EL>
-  initIdToElementCache(Collection<EL> elements) {
-    Map<Long, EL> cache = Maps.newHashMap();
-    for (EL el : elements) {
-      cache.put(el.getId(), el);
-    }
-    return cache;
+  private <EL, KT, VT> Map<KT, VT> initCache(Collection<EL> elements,
+    Function<EL, KT> keySelector, Function<EL, VT> valueSelector) {
+
+    return elements.stream().collect(Collectors.toMap(keySelector, valueSelector));
   }
 
   /**
-   * Initializes {@link QueryHandler#labelToVertexCache}.
-   */
-  private void initLabelToVertexCache() {
-    labelToVertexCache = initLabelToGraphElementCache(getVertices());
-  }
-
-  /**
-   * Initializes {@link QueryHandler#labelToEdgeCache}.
-   */
-  private void initLabelToEdgeCache() {
-    labelToEdgeCache = initLabelToGraphElementCache(getEdges());
-  }
-
-  /**
-   * Initializes {@link QueryHandler#sourceIdToEdgeCache}.
-   */
-  private void initSourceIdToEdgeCache() {
-    sourceIdToEdgeCache = initVertexToEdgeCache(gdlHandler.getEdges(), true);
-  }
-
-  /**
-   * Initializes {@link QueryHandler#targetIdToEdgeCache}.
-   */
-  private void initTargetIdToEdgeCache() {
-    targetIdToEdgeCache = initVertexToEdgeCache(gdlHandler.getEdges(), false);
-  }
-
-  /**
-   * Initializes vertex id to edge cache.
+   * Initializes a cache for the given elements where every key maps to multiple elements.
+   * Key selector will be called on every element to extract the caches key.
+   * Value selector will be called on every element to extract the value.
+   * Returns a cache of the form
+   * KT -> Set<VT>
    *
-   * @param edges query edges
-   * @param useSource use source (true) or target (false) vertex for caching
-   * @return vertex id to edge cache
+   * @param elements elements the cache will be build from
+   * @param keySelector key selector function extraction cache keys from elements
+   * @param valueSelector value selector function extraction cache values from elements
+   * @param <EL> the element type
+   * @param <KT> the cache key type
+   * @param <VT> the cache value type
+   * @return cache KT -> Set<VT>
    */
-  private Map<Long, Set<Edge>>
-  initVertexToEdgeCache(Collection<Edge> edges, boolean useSource) {
-    Map<Long, Set<Edge>> cache = Maps.newHashMap();
-    for (Edge e : edges) {
-      Long vId = useSource ? e.getSourceVertexId() : e.getTargetVertexId();
+  private <EL, KT, VT> Map<KT, Set<VT>> initSetCache(Collection<EL> elements,
+    Function<EL, KT> keySelector, Function<EL, VT> valueSelector) {
 
-      if (cache.containsKey(vId)) {
-        cache.get(vId).add(e);
-      } else {
-        cache.put(vId, Sets.newHashSet(e));
-      }
-    }
-    return cache;
-  }
-
-  /**
-   * Initializes label to graph element (vertex/edge) cache.
-   *
-   * @param elements graph elements
-   * @param <EL> element type
-   * @return label to element cache
-   */
-  private <EL extends GraphElement> Map<String, Set<EL>>
-  initLabelToGraphElementCache(Collection<EL> elements) {
-    Map<String, Set<EL>> cache = Maps.newHashMap();
-    for (EL el : elements) {
-      if (cache.containsKey(el.getLabel())) {
-        cache.get(el.getLabel()).add(el);
-      } else {
-        Set<EL> set = new HashSet<>();
-        set.add(el);
-        cache.put(el.getLabel(), set);
-      }
-    }
-    return cache;
+    return elements.stream()
+      .collect(
+        Collectors.groupingBy(
+          keySelector,
+          Collectors.mapping(valueSelector, Collectors.toSet())
+      ));
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/common/query/QueryHandlerTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/common/query/QueryHandlerTest.java
@@ -61,6 +61,18 @@ public class QueryHandlerTest {
   }
 
   @Test
+  public void testIsVertex() {
+    assertTrue(QUERY_HANDLER.isVertex("v1"));
+    assertFalse(QUERY_HANDLER.isVertex("e1"));
+  }
+
+  @Test
+  public void testIsedge() {
+    assertTrue(QUERY_HANDLER.isEdge("e1"));
+    assertFalse(QUERY_HANDLER.isEdge("v1"));
+  }
+
+  @Test
   public void testGetVertexById() throws Exception {
     Vertex expected = GDL_HANDLER.getVertexCache().get("v1");
     assertTrue(QUERY_HANDLER.getVertexById(expected.getId()).equals(expected));
@@ -70,6 +82,20 @@ public class QueryHandlerTest {
   public void testGetEdgeById() throws Exception {
     Edge expected = GDL_HANDLER.getEdgeCache().get("e1");
     assertTrue(QUERY_HANDLER.getEdgeById(expected.getId()).equals(expected));
+  }
+
+  @Test
+  public void testGetVertexByVariable() throws Exception {
+    Vertex expected = GDL_HANDLER.getVertexCache().get("v1");
+    assertEquals(QUERY_HANDLER.getVertexByVariable("v1"), expected);
+    assertNotEquals(QUERY_HANDLER.getVertexByVariable("v2"), expected);
+  }
+
+  @Test
+  public void testGetEdgeByVariable() throws Exception {
+    Edge expected = GDL_HANDLER.getEdgeCache().get("e1");
+    assertEquals(QUERY_HANDLER.getEdgeByVariable("e1"), expected);
+    assertNotEquals(QUERY_HANDLER.getEdgeByVariable("e2"), expected);
   }
 
   @Test


### PR DESCRIPTION
Fixes #501 

- [X] Add `QueryHandler.getVertexByVariable(String variable)` and  `QueryHandler.getEdgeByVariable(String variable)`
- [X] Add  `QueryHandler.isVertex(String variable)` and  `QueryHandler.isEdge(String variable)`
- [X] Use Java8 Streaming API to improve cache creation for `QueryHandler`