### PR TITLE
Properties mapping class for EPGMElement implemented

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/GraphHeadProperties.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/GraphHeadProperties.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Gradoop.
+ *
+ * Gradoop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gradoop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gradoop. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.gradoop.flink.model.impl.functions.epgm;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.functions.FunctionAnnotation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.gradoop.common.model.api.entities.EPGMGraphHead;
+import org.gradoop.common.model.api.entities.EPGMLabeled;
+import org.gradoop.common.model.impl.properties.Properties;
+
+/**
+ * EPGMGraphHead with properties => properties
+ *
+ * @param <L> EPGMGraphHead type having properties
+ */
+@FunctionAnnotation.ForwardedFields("label->*")
+public class GraphHeadProperties<L extends EPGMGraphHead>
+  implements MapFunction<L, Properties>, KeySelector<L, Properties> {
+
+  @Override
+  public Properties map(L l) throws Exception {
+    return l.getProperties();
+  }
+
+  @Override
+  public Properties getKey(L l) throws Exception {
+    return l.getProperties();
+  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/Properties.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/Properties.java
@@ -20,26 +20,23 @@ package org.gradoop.flink.model.impl.functions.epgm;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.functions.KeySelector;
-import org.gradoop.common.model.api.entities.EPGMGraphHead;
-import org.gradoop.common.model.api.entities.EPGMLabeled;
-import org.gradoop.common.model.impl.properties.Properties;
-
+import org.gradoop.common.model.api.entities.EPGMElement;
 /**
  * EPGMGraphHead with properties => properties
  *
  * @param <L> EPGMGraphHead type having properties
  */
 @FunctionAnnotation.ForwardedFields("label->*")
-public class GraphHeadProperties<L extends EPGMGraphHead>
-  implements MapFunction<L, Properties>, KeySelector<L, Properties> {
+public class Properties<L extends EPGMElement>
+  implements MapFunction<L, org.gradoop.common.model.impl.properties.Properties>, KeySelector<L, org.gradoop.common.model.impl.properties.Properties> {
 
   @Override
-  public Properties map(L l) throws Exception {
+  public org.gradoop.common.model.impl.properties.Properties map(L l) throws Exception {
     return l.getProperties();
   }
 
   @Override
-  public Properties getKey(L l) throws Exception {
+  public org.gradoop.common.model.impl.properties.Properties getKey(L l) throws Exception {
     return l.getProperties();
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/Properties.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/Properties.java
@@ -26,7 +26,7 @@ import org.gradoop.common.model.api.entities.EPGMElement;
  *
  * @param <L> EPGMGraphHead type having properties
  */
-@FunctionAnnotation.ForwardedFields("label->*")
+@FunctionAnnotation.ForwardedFields("properties->*")
 public class Properties<L extends EPGMElement>
   implements MapFunction<L, org.gradoop.common.model.impl.properties.Properties>, KeySelector<L, org.gradoop.common.model.impl.properties.Properties> {
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/Properties.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/Properties.java
@@ -22,9 +22,9 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.gradoop.common.model.api.entities.EPGMElement;
 /**
- * EPGMGraphHead with properties => properties
+ * EPGMElement with properties => properties
  *
- * @param <L> EPGMGraphHead type having properties
+ * @param <L> EPGMElement type having properties
  */
 @FunctionAnnotation.ForwardedFields("properties->*")
 public class Properties<L extends EPGMElement>

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/Properties.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/Properties.java
@@ -28,7 +28,8 @@ import org.gradoop.common.model.api.entities.EPGMElement;
  */
 @FunctionAnnotation.ForwardedFields("properties->*")
 public class Properties<L extends EPGMElement>
-  implements MapFunction<L, org.gradoop.common.model.impl.properties.Properties>, KeySelector<L, org.gradoop.common.model.impl.properties.Properties> {
+  implements MapFunction<L, org.gradoop.common.model.impl.properties.Properties>,
+             KeySelector<L, org.gradoop.common.model.impl.properties.Properties> {
 
   @Override
   public org.gradoop.common.model.impl.properties.Properties map(L l) throws Exception {


### PR DESCRIPTION
This class uses an EPGMElement to extract the properties (e.g.) from the GraphHead, as required in #491 . 