### PR TITLE
Add more general version to find evaluable disjunctions for given variable set

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/query/predicates/CNF.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/query/predicates/CNF.java
@@ -128,7 +128,7 @@ public class CNF extends PredicateCollection<CNFElement> {
 
   /**
    * Filters all disjunctions that could be evaluated with the given set of variables and removes
-   * them from the embedding. The filtered predicates will be returned in a new CNF
+   * them from the CNF. The filtered predicates will be returned in a new CNF
    *
    * Example:
    * Given myFilter = CNF((a = b) And (b > 5 OR a > 10) AND (c = false) AND (a = c))

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/query/predicates/CNF.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/query/predicates/CNF.java
@@ -107,20 +107,23 @@ public class CNF extends PredicateCollection<CNFElement> {
   }
 
   /**
-   * Creates a new CNF containing only predicates concerning the specified variables
-   * @param variables list of variables
-   * @return sub cnf
+   * Filters all disjunctions that could be evaluated with the given set of variables and returns
+   * them in a new CNF
+   *
+   * Example:
+   * Given myFilter = CNF((a = b) And (b > 5 OR a > 10) AND (c = false) AND (a = c))
+   * myFilter.getSubCNF(a,b) => CNF((a = b) And (b > 5 OR a > 10))
+   *
+   * @param variables set of variables that must be included in the disjunction
+   * @return CNF containing only variables covered by the input list
    */
   public CNF getSubCNF(Set<String> variables) {
-    CNF subCNF = new CNF();
+    List<CNFElement> filtered = predicates
+      .stream()
+      .filter(p -> variables.containsAll(p.getVariables()))
+      .collect(Collectors.toList());
 
-    for (CNFElement cnfElement : predicates) {
-      Set<String> elementVariables = cnfElement.getVariables();
-      if (elementVariables.containsAll(variables) && elementVariables.size() == variables.size()) {
-        subCNF.addPredicate(cnfElement);
-      }
-    }
-    return subCNF;
+    return new CNF(filtered);
   }
 
   /**
@@ -129,13 +132,13 @@ public class CNF extends PredicateCollection<CNFElement> {
    *
    * Example:
    * Given myFilter = CNF((a = b) And (b > 5 OR a > 10) AND (c = false) AND (a = c))
-   * myFilter.removeCovered(a,b) => CNF((a = b) And (b > 5 OR a > 10))
+   * myFilter.removeSubCNF(a,b) => CNF((a = b) And (b > 5 OR a > 10))
    * and myFilter == CNF((c = false) AND (a = c))
    *
    * @param variables set of variables that must be included in the disjunction
    * @return CNF containing only variables covered by the input list
    */
-  public CNF removeCovered(Set<String> variables) {
+  public CNF removeSubCNF(Set<String> variables) {
     Map<Boolean, List<CNFElement>> filtered = predicates
       .stream()
       .collect(Collectors.partitioningBy(p -> variables.containsAll(p.getVariables())));

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/common/query/predicates/CNFTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/common/query/predicates/CNFTest.java
@@ -90,19 +90,16 @@ public class CNFTest {
 
   @Test
   public void createExistingSubCnfTest() {
-    String queryString = "MATCH (a), (b), (c)" +
-      "WHERE a=b AND a.name = \"Alice\" AND c.name = \"Chris\"";
-    QueryHandler query = new QueryHandler(queryString);
-    CNF cnf = query.getPredicates();
+    CNF base = getPredicate(
+      "MATCH (a), (b), (c) WHERE a=b AND a.name = \"Alice\" AND c.name = \"Chris\""
+    );
 
-    Set<String> variables = new HashSet<>();
-    variables.add("a");
-    variables.add("b");
+    CNF expectedReturnValue = getPredicate(
+      "MATCH (a), (b), (c) WHERE a.name = \"Alice\" AND c.name = \"Chris\""
+    );
 
-    assertEquals("((a = b))",cnf.getSubCNF(variables).toString());
-
-    variables.add("c");
-    assertTrue(cnf.getSubCNF(variables).getPredicates().isEmpty());
+    assertEquals(expectedReturnValue, base.getSubCNF(Sets.newHashSet("a","c")));
+    assertEquals(new CNF(), base.getSubCNF(Sets.newHashSet("b")));
   }
 
   @Test
@@ -120,7 +117,7 @@ public class CNFTest {
     );
 
 
-    assertEquals(expectedReturnValue, base.removeCovered(Sets.newHashSet("a","b")));
+    assertEquals(expectedReturnValue, base.removeSubCNF(Sets.newHashSet("a","b")));
     assertEquals(expectedNewBase, base);
   }
 


### PR DESCRIPTION
Fixes #514 
This adds a more general version to find evaluable disjunctions for given variable set
- [X] add CNF.removeCovered
This method matches all disjunctions of the cnf that are covered by the given variable set. The matched disjunctions are removed from the source CNF and returned as a new CNF

- [X] add CNF copy constructor