### PR TITLE
[#561] Add meta data reuse option CSV data sink

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVBase.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVBase.java
@@ -17,6 +17,9 @@
 
 package org.gradoop.flink.io.impl.csv;
 
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.flink.util.GradoopFlinkConfig;
 
 import java.io.File;
@@ -65,7 +68,7 @@ public abstract class CSVBase {
    * @param csvPath directory to the CSV files
    * @param config Gradoop Flink configuration
    */
-  public CSVBase(String csvPath, GradoopFlinkConfig config) {
+  CSVBase(String csvPath, GradoopFlinkConfig config) {
     Objects.requireNonNull(csvPath);
     Objects.requireNonNull(config);
     this.vertexCSVPath = csvPath + File.separator + VERTEX_FILE;
@@ -88,5 +91,21 @@ public abstract class CSVBase {
 
   GradoopFlinkConfig getConfig() {
     return config;
+  }
+
+  /**
+   * Reads the meta data from the specified file.
+   *
+   * @param path path to meta data csv file
+   * @return meta data information
+   */
+  DataSet<Tuple2<String, String>> readMetaData(String path) {
+    return getConfig().getExecutionEnvironment()
+      .readTextFile(path)
+      .map(line -> {
+          String[] tokens = line.split(CSVConstants.TOKEN_DELIMITER, 2);
+          return Tuple2.of(tokens[0], tokens[1]);
+        })
+      .returns(new TypeHint<Tuple2<String, String>>() { });
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVDataSource.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVDataSource.java
@@ -17,7 +17,6 @@
 
 package org.gradoop.flink.io.impl.csv;
 
-import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.pojo.Edge;
@@ -49,7 +48,7 @@ public class CSVDataSource extends CSVBase implements DataSource {
 
   @Override
   public LogicalGraph getLogicalGraph() throws IOException {
-    DataSet<Tuple2<String, String>> metaData = readMetaData();
+    DataSet<Tuple2<String, String>> metaData = readMetaData(getMetaDataPath());
 
     DataSet<Vertex> vertices = getConfig().getExecutionEnvironment()
       .readTextFile(getVertexCSVPath())
@@ -72,20 +71,5 @@ public class CSVDataSource extends CSVBase implements DataSource {
   @Override
   public GraphTransactions getGraphTransactions() throws IOException {
     return getGraphCollection().toTransactions();
-  }
-
-  /**
-   * Reads the meta data for the specified data source.
-   *
-   * @return meta data information
-   */
-  private DataSet<Tuple2<String, String>> readMetaData() {
-    return getConfig().getExecutionEnvironment()
-      .readTextFile(getMetaDataPath())
-      .map(line -> {
-          String[] tokens = line.split(CSVConstants.TOKEN_DELIMITER, 2);
-          return Tuple2.of(tokens[0], tokens[1]);
-        })
-      .returns(new TypeHint<Tuple2<String, String>>() { });
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSinkTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSinkTest.java
@@ -2,6 +2,7 @@ package org.gradoop.flink.io.impl.csv;
 
 import org.gradoop.flink.io.api.DataSink;
 import org.gradoop.flink.io.api.DataSource;
+import org.gradoop.flink.io.impl.edgelist.VertexLabeledEdgeListDataSourceTest;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
 import org.gradoop.flink.model.impl.LogicalGraph;
 import org.junit.Rule;
@@ -22,6 +23,31 @@ public class CSVDataSinkTest extends GradoopFlinkTestBase {
       .getDatabaseGraph(true);
 
     DataSink csvDataSink = new CSVDataSink(tmpPath, getConfig());
+    csvDataSink.write(input, true);
+
+    getExecutionEnvironment().execute();
+
+    DataSource csvDataSource = new CSVDataSource(tmpPath, getConfig());
+    LogicalGraph output = csvDataSource.getLogicalGraph();
+
+    collectAndAssertTrue(input.equalsByElementData(output));
+  }
+
+  @Test
+  public void testWriteWithExistingMetaData() throws Exception {
+    String tmpPath = temporaryFolder.getRoot().getPath();
+
+    String csvPath = VertexLabeledEdgeListDataSourceTest.class
+      .getResource("/data/csv/input")
+      .getPath();
+
+    String gdlPath = CSVDataSourceTest.class
+      .getResource("/data/csv/expected/expected.gdl")
+      .getPath();
+
+    LogicalGraph input = getLoaderFromFile(gdlPath).getLogicalGraphByVariable("expected");
+
+    DataSink csvDataSink = new CSVDataSink(tmpPath, csvPath + "/metadata.csv", getConfig());
     csvDataSink.write(input, true);
 
     getExecutionEnvironment().execute();


### PR DESCRIPTION
 * CSV DataSink now either computes the meta data from the specified graph or loads it from a file
 * fixes #561