### PR TITLE
Add names to cypher pattern matching operators

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/PhysicalOperator.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/PhysicalOperator.java
@@ -32,4 +32,16 @@ public interface PhysicalOperator {
    */
   DataSet<Embedding> evaluate();
 
+  /**
+   * Set the operator description
+   * @param newName operator description
+   */
+  void setName(String newName);
+
+  /**
+   * Get the operator description
+   * @return operator description
+   */
+  String getName();
+
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/PhysicalOperator.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/PhysicalOperator.java
@@ -34,12 +34,14 @@ public interface PhysicalOperator {
 
   /**
    * Set the operator description
+   * This is used for Flink operator naming
    * @param newName operator description
    */
   void setName(String newName);
 
   /**
    * Get the operator description
+   * This is used for Flink operator naming
    * @return operator description
    */
   String getName();

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/cartesian/CartesianProduct.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/cartesian/CartesianProduct.java
@@ -67,4 +67,14 @@ public class CartesianProduct implements PhysicalOperator {
   public DataSet<Embedding> evaluate() {
     return null;
   }
+
+  @Override
+  public void setName(String newName) {
+
+  }
+
+  @Override
+  public String getName() {
+    return null;
+  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/expand/ExpandEmbeddings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/expand/ExpandEmbeddings.java
@@ -85,7 +85,7 @@ public abstract class ExpandEmbeddings implements PhysicalOperator {
   protected DataSet<EdgeWithTiePoint> candidateEdgeTuples;
 
   /**
-   * Operator name
+   * Operator name used for Flink operator description
    */
   protected String name;
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/expand/ExpandEmbeddings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/expand/ExpandEmbeddings.java
@@ -146,7 +146,7 @@ public abstract class ExpandEmbeddings implements PhysicalOperator {
     if (direction == ExpandDirection.IN) {
       candidateEdges = candidateEdges
         .map(new ReverseEdgeEmbedding())
-        .name("Expand - Reverse Edges");
+         .name("Expand - Reverse Edges");
     } else  if (direction == ExpandDirection.ALL) {
       candidateEdges = candidateEdges.union(
         candidateEdges.map(new ReverseEdgeEmbedding()).name("Expand - Reverse Edges")

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/expand/ExpandEmbeddings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/expand/ExpandEmbeddings.java
@@ -152,18 +152,20 @@ public abstract class ExpandEmbeddings implements PhysicalOperator {
     if (direction == ExpandDirection.IN) {
       candidateEdges = candidateEdges
         .map(new ReverseEdgeEmbedding())
-         .name(getName() + " - Reverse Edges");
+        .name(getName() + " - Reverse Edges");
     } else  if (direction == ExpandDirection.ALL) {
       candidateEdges = candidateEdges.union(
-        candidateEdges.map(new ReverseEdgeEmbedding()).name(getName() + "- Reverse Edges")
+        candidateEdges
+          .map(new ReverseEdgeEmbedding())
+          .name(getName() + "- Reverse Edges")
       );
     }
 
     this.candidateEdgeTuples = candidateEdges
       .map(new ExtractKeyedCandidateEdges())
-        .name(getName() + " - Create candidate edge tuples")
+      .name(getName() + " - Create candidate edge tuples")
       .partitionByHash(0)
-        .name(getName() + " - Partition edge tuples");
+      .name(getName() + " - Partition edge tuples");
 
     return input.join(candidateEdgeTuples, joinHint)
       .where(new ExtractExpandColumn(expandColumn)).equalTo(0)
@@ -184,11 +186,12 @@ public abstract class ExpandEmbeddings implements PhysicalOperator {
   private DataSet<Embedding> postProcess(DataSet<ExpandEmbedding> iterationResults) {
     DataSet<Embedding> results = iterationResults
       .flatMap(new PostProcessExpandEmbedding(lowerBound, closingColumn))
-        .name(getName() + " - Post Processing");
+      .name(getName() + " - Post Processing");
 
     if (lowerBound == 0) {
       results = results.union(
-        input.flatMap(new AdoptEmptyPaths(expandColumn, closingColumn))
+        input
+          .flatMap(new AdoptEmptyPaths(expandColumn, closingColumn))
           .name(getName() + " - Append empty paths")
       );
     }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/expand/ExpandEmbeddingsBulk.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/expand/ExpandEmbeddingsBulk.java
@@ -109,12 +109,12 @@ public class ExpandEmbeddingsBulk extends ExpandEmbeddings {
   protected DataSet<ExpandEmbedding> iterate(DataSet<ExpandEmbedding> initialWorkingSet) {
 
     IterativeDataSet<ExpandEmbedding> iteration = initialWorkingSet
-        .iterate(upperBound - 1)
-        .name(getName());
+      .iterate(upperBound - 1)
+      .name(getName());
 
     DataSet<ExpandEmbedding> nextWorkingSet = iteration
       .filter(new FilterPreviousExpandEmbedding())
-        .name(getName() + " - FilterRecent")
+      .name(getName() + " - FilterRecent")
       .join(candidateEdgeTuples, joinHint)
         .where(2).equalTo(0)
         .with(new MergeExpandEmbeddings(
@@ -122,7 +122,7 @@ public class ExpandEmbeddingsBulk extends ExpandEmbeddings {
           distinctEdgeColumns,
           closingColumn
         ))
-        .name(getName() + " - Expansion");
+      .name(getName() + " - Expansion");
 
     DataSet<ExpandEmbedding> solutionSet = nextWorkingSet.union(iteration);
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/expand/ExpandEmbeddingsBulk.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/expand/ExpandEmbeddingsBulk.java
@@ -108,18 +108,21 @@ public class ExpandEmbeddingsBulk extends ExpandEmbeddings {
   @Override
   protected DataSet<ExpandEmbedding> iterate(DataSet<ExpandEmbedding> initialWorkingSet) {
 
-    IterativeDataSet<ExpandEmbedding> iteration =
-      initialWorkingSet.iterate(upperBound - 1);
+    IterativeDataSet<ExpandEmbedding> iteration = initialWorkingSet
+        .iterate(upperBound - 1)
+        .name("Expand - BulkIteration");
 
     DataSet<ExpandEmbedding> nextWorkingSet = iteration
       .filter(new FilterPreviousExpandEmbedding())
+        .name("Expand - FilterRecent")
       .join(candidateEdgeTuples, joinHint)
         .where(2).equalTo(0)
         .with(new MergeExpandEmbeddings(
           distinctVertexColumns,
           distinctEdgeColumns,
           closingColumn
-        ));
+        ))
+        .name("Expand - Expansion");
 
     DataSet<ExpandEmbedding> solutionSet = nextWorkingSet.union(iteration);
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/expand/ExpandEmbeddingsBulk.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/expand/ExpandEmbeddingsBulk.java
@@ -110,11 +110,11 @@ public class ExpandEmbeddingsBulk extends ExpandEmbeddings {
 
     IterativeDataSet<ExpandEmbedding> iteration = initialWorkingSet
         .iterate(upperBound - 1)
-        .name("Expand - BulkIteration");
+        .name(getName());
 
     DataSet<ExpandEmbedding> nextWorkingSet = iteration
       .filter(new FilterPreviousExpandEmbedding())
-        .name("Expand - FilterRecent")
+        .name(getName() + " - FilterRecent")
       .join(candidateEdgeTuples, joinHint)
         .where(2).equalTo(0)
         .with(new MergeExpandEmbeddings(
@@ -122,7 +122,7 @@ public class ExpandEmbeddingsBulk extends ExpandEmbeddings {
           distinctEdgeColumns,
           closingColumn
         ))
-        .name("Expand - Expansion");
+        .name(getName() + " - Expansion");
 
     DataSet<ExpandEmbedding> solutionSet = nextWorkingSet.union(iteration);
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/expand/ExpandEmbeddingsForLoop.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/expand/ExpandEmbeddingsForLoop.java
@@ -113,7 +113,7 @@ public class ExpandEmbeddingsForLoop extends ExpandEmbeddings {
             .where(2).equalTo(0)
             .with(new MergeExpandEmbeddings(distinctVertexColumns, distinctEdgeColumns,
               closingColumn))
-            .name("Expand - Expansion Step " + i);
+            .name(getName() + " - Expansion " + i);
 
       intermediateResults.add(nextResult);
     }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/expand/ExpandEmbeddingsForLoop.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/expand/ExpandEmbeddingsForLoop.java
@@ -112,7 +112,8 @@ public class ExpandEmbeddingsForLoop extends ExpandEmbeddings {
           .join(candidateEdgeTuples, joinHint)
             .where(2).equalTo(0)
             .with(new MergeExpandEmbeddings(distinctVertexColumns, distinctEdgeColumns,
-              closingColumn));
+              closingColumn))
+            .name("Expand - Expansion Step " + i);
 
       intermediateResults.add(nextResult);
     }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectEdges.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectEdges.java
@@ -76,6 +76,6 @@ public class FilterAndProjectEdges implements PhysicalOperator {
   public DataSet<Embedding> evaluate() {
     return input
       .flatMap(new FilterAndProjectEdge(predicates, projectionPropertyKeys))
-      .name("FilterAndProjectEdges( " + predicates + ")");
+        .name("FilterAndProjectEdges( " + predicates + ")");
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectEdges.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectEdges.java
@@ -59,7 +59,7 @@ public class FilterAndProjectEdges implements PhysicalOperator {
   private final List<String> projectionPropertyKeys;
 
   /**
-   * Operator name
+   * Operator name used for Flink operator description
    */
   private String name;
 
@@ -75,7 +75,7 @@ public class FilterAndProjectEdges implements PhysicalOperator {
     this.input = input;
     this.predicates = predicates;
     this.projectionPropertyKeys = projectionPropertyKeys;
-    this.name = "FilterAndProjectEdges";
+    this.setName("FilterAndProjectEdges");
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectEdges.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectEdges.java
@@ -74,6 +74,8 @@ public class FilterAndProjectEdges implements PhysicalOperator {
 
   @Override
   public DataSet<Embedding> evaluate() {
-    return input.flatMap(new FilterAndProjectEdge(predicates, projectionPropertyKeys));
+    return input
+      .flatMap(new FilterAndProjectEdge(predicates, projectionPropertyKeys))
+      .name("FilterAndProjectEdges( " + predicates + ")");
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectEdges.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectEdges.java
@@ -59,6 +59,11 @@ public class FilterAndProjectEdges implements PhysicalOperator {
   private final List<String> projectionPropertyKeys;
 
   /**
+   * Operator name
+   */
+  private String name;
+
+  /**
    * New edge filter operator
    *
    * @param input Candidate edges
@@ -70,12 +75,23 @@ public class FilterAndProjectEdges implements PhysicalOperator {
     this.input = input;
     this.predicates = predicates;
     this.projectionPropertyKeys = projectionPropertyKeys;
+    this.name = "FilterAndProjectEdges";
   }
 
   @Override
   public DataSet<Embedding> evaluate() {
     return input
       .flatMap(new FilterAndProjectEdge(predicates, projectionPropertyKeys))
-        .name("FilterAndProjectEdges( " + predicates + ")");
+        .name(getName());
+  }
+
+  @Override
+  public void setName(String newName) {
+    this.name = newName;
+  }
+
+  @Override
+  public String getName() {
+    return this.name;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectEdges.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectEdges.java
@@ -82,7 +82,7 @@ public class FilterAndProjectEdges implements PhysicalOperator {
   public DataSet<Embedding> evaluate() {
     return input
       .flatMap(new FilterAndProjectEdge(predicates, projectionPropertyKeys))
-        .name(getName());
+      .name(getName());
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectEdgesAlt.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectEdgesAlt.java
@@ -62,6 +62,11 @@ public class FilterAndProjectEdgesAlt implements PhysicalOperator {
   private final List<String> projectionPropertyKeys;
 
   /**
+   * Operator name
+   */
+  private String name;
+
+  /**
    * New edge filter operator
    *
    * @param input Candidate edges
@@ -73,14 +78,25 @@ public class FilterAndProjectEdgesAlt implements PhysicalOperator {
     this.input = input;
     this.predicates = predicates;
     this.projectionPropertyKeys = projectionPropertyKeys;
+    this.setName("FilterAndProjectEdges");
   }
 
   @Override
   public DataSet<Embedding> evaluate() {
     return input.
       filter(new FilterEdge(predicates))
-        .name("FilterEdges(" + predicates + ")")
+        .name(getName())
       .map(new ProjectEdge(projectionPropertyKeys))
-        .name("ProjectEdges(" + projectionPropertyKeys + ")");
+        .name(getName());
+  }
+
+  @Override
+  public void setName(String newName) {
+    this.name = newName;
+  }
+
+  @Override
+  public String getName() {
+    return this.name;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectEdgesAlt.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectEdgesAlt.java
@@ -62,7 +62,7 @@ public class FilterAndProjectEdgesAlt implements PhysicalOperator {
   private final List<String> projectionPropertyKeys;
 
   /**
-   * Operator name
+   * Operator name used for Flink operator description
    */
   private String name;
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectEdgesAlt.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectEdgesAlt.java
@@ -78,7 +78,9 @@ public class FilterAndProjectEdgesAlt implements PhysicalOperator {
   @Override
   public DataSet<Embedding> evaluate() {
     return input.
-      filter(new FilterEdge(predicates)).
-      map(new ProjectEdge(projectionPropertyKeys));
+      filter(new FilterEdge(predicates))
+        .name("FilterEdges(" + predicates + ")")
+      .map(new ProjectEdge(projectionPropertyKeys))
+        .name("ProjectEdges(" + projectionPropertyKeys + ")");
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectEdgesAlt.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectEdgesAlt.java
@@ -85,9 +85,9 @@ public class FilterAndProjectEdgesAlt implements PhysicalOperator {
   public DataSet<Embedding> evaluate() {
     return input.
       filter(new FilterEdge(predicates))
-        .name(getName())
+      .name(getName())
       .map(new ProjectEdge(projectionPropertyKeys))
-        .name(getName());
+      .name(getName());
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectTriples.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectTriples.java
@@ -82,7 +82,7 @@ public class FilterAndProjectTriples implements PhysicalOperator {
   private final MatchStrategy vertexMatchStrategy;
 
   /**
-   * Operator name
+   * Operator name used for Flink operator description
    */
   private String name;
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectTriples.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectTriples.java
@@ -115,6 +115,10 @@ public class FilterAndProjectTriples implements PhysicalOperator {
         projectionPropertyKeys,
         vertexMatchStrategy
       )
+    ).name(
+      "FilterAndProjectTriples(" +
+        sourceVariable + "-[" + targetVariable + "]->" + targetVariable +
+      ")"
     );
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectTriples.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectTriples.java
@@ -82,6 +82,11 @@ public class FilterAndProjectTriples implements PhysicalOperator {
   private final MatchStrategy vertexMatchStrategy;
 
   /**
+   * Operator name
+   */
+  private String name;
+
+  /**
    * New vertex filter operator
    *
    * @param input Candidate vertices
@@ -102,6 +107,7 @@ public class FilterAndProjectTriples implements PhysicalOperator {
     this.predicates = predicates;
     this.projectionPropertyKeys = projectionPropertyKeys;
     this.vertexMatchStrategy = vertexMatchStrategy;
+    this.setName("FilterAndProjectTriples");
   }
 
   @Override
@@ -115,10 +121,16 @@ public class FilterAndProjectTriples implements PhysicalOperator {
         projectionPropertyKeys,
         vertexMatchStrategy
       )
-    ).name(
-      "FilterAndProjectTriples(" +
-        sourceVariable + "-[" + targetVariable + "]->" + targetVariable +
-      ")"
-    );
+    ).name(getName());
+  }
+
+  @Override
+  public void setName(String newName) {
+    this.name = newName;
+  }
+
+  @Override
+  public String getName() {
+    return this.name;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectVertices.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectVertices.java
@@ -56,6 +56,11 @@ public class FilterAndProjectVertices implements PhysicalOperator {
   private final List<String> projectionPropertyKeys;
 
   /**
+   * Operator name
+   */
+  private String name;
+
+  /**
    * New vertex filter operator
    *
    * @param input Candidate vertices
@@ -67,11 +72,22 @@ public class FilterAndProjectVertices implements PhysicalOperator {
     this.input = input;
     this.predicates = predicates;
     this.projectionPropertyKeys = projectionPropertyKeys;
+    this.setName("FilterAndProjectVertices");
   }
 
   @Override
   public DataSet<Embedding> evaluate() {
     return input.flatMap(new FilterAndProjectVertex(predicates, projectionPropertyKeys))
-      .name("FilterAndProjectVertices( " + predicates + ")");
+      .name(getName());
+  }
+
+  @Override
+  public void setName(String newName) {
+    this.name = newName;
+  }
+
+  @Override
+  public String getName() {
+    return this.name;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectVertices.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectVertices.java
@@ -77,7 +77,8 @@ public class FilterAndProjectVertices implements PhysicalOperator {
 
   @Override
   public DataSet<Embedding> evaluate() {
-    return input.flatMap(new FilterAndProjectVertex(predicates, projectionPropertyKeys))
+    return input
+      .flatMap(new FilterAndProjectVertex(predicates, projectionPropertyKeys))
       .name(getName());
   }
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectVertices.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectVertices.java
@@ -56,7 +56,7 @@ public class FilterAndProjectVertices implements PhysicalOperator {
   private final List<String> projectionPropertyKeys;
 
   /**
-   * Operator name
+   * Operator name used for Flink operator description
    */
   private String name;
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectVertices.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectVertices.java
@@ -71,6 +71,7 @@ public class FilterAndProjectVertices implements PhysicalOperator {
 
   @Override
   public DataSet<Embedding> evaluate() {
-    return input.flatMap(new FilterAndProjectVertex(predicates, projectionPropertyKeys));
+    return input.flatMap(new FilterAndProjectVertex(predicates, projectionPropertyKeys))
+      .name("FilterAndProjectVertices( " + predicates + ")");
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectVerticesAlt.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectVerticesAlt.java
@@ -82,9 +82,9 @@ public class FilterAndProjectVerticesAlt implements PhysicalOperator {
   public DataSet<Embedding> evaluate() {
     return input
       .filter(new FilterVertex(predicates))
-        .name(getName())
+      .name(getName())
       .map(new ProjectVertex(projectionPropertyKeys))
-        .name(getName());
+      .name(getName());
 
   }
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectVerticesAlt.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectVerticesAlt.java
@@ -59,6 +59,11 @@ public class FilterAndProjectVerticesAlt implements PhysicalOperator {
   private final List<String> projectionPropertyKeys;
 
   /**
+   * Operator name
+   */
+  private String name;
+
+  /**
    * New vertex filter operator
    *
    * @param input Candidate vertices
@@ -70,15 +75,26 @@ public class FilterAndProjectVerticesAlt implements PhysicalOperator {
     this.input = input;
     this.predicates = predicates;
     this.projectionPropertyKeys = projectionPropertyKeys;
+    this.setName("FilterAndProjectVerticesAlt");
   }
 
   @Override
   public DataSet<Embedding> evaluate() {
     return input
       .filter(new FilterVertex(predicates))
-        .name("FilterVertices(" + predicates + ")")
+        .name(getName())
       .map(new ProjectVertex(projectionPropertyKeys))
-        .name("ProjectVertices(" + projectionPropertyKeys + ")");
+        .name(getName());
 
+  }
+
+  @Override
+  public void setName(String newName) {
+    this.name = newName;
+  }
+
+  @Override
+  public String getName() {
+    return this.name;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectVerticesAlt.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectVerticesAlt.java
@@ -59,7 +59,7 @@ public class FilterAndProjectVerticesAlt implements PhysicalOperator {
   private final List<String> projectionPropertyKeys;
 
   /**
-   * Operator name
+   * Operator name used for Flink operator description
    */
   private String name;
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectVerticesAlt.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterAndProjectVerticesAlt.java
@@ -76,6 +76,9 @@ public class FilterAndProjectVerticesAlt implements PhysicalOperator {
   public DataSet<Embedding> evaluate() {
     return input
       .filter(new FilterVertex(predicates))
-      .map(new ProjectVertex(projectionPropertyKeys));
+        .name("FilterVertices(" + predicates + ")")
+      .map(new ProjectVertex(projectionPropertyKeys))
+        .name("ProjectVertices(" + projectionPropertyKeys + ")");
+
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterEmbeddings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterEmbeddings.java
@@ -43,7 +43,7 @@ public class FilterEmbeddings implements PhysicalOperator {
   private final EmbeddingMetaData metaData;
 
   /**
-   * Operator name
+   * Operator name used for Flink operator description
    */
   private String name;
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterEmbeddings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterEmbeddings.java
@@ -67,7 +67,7 @@ public class FilterEmbeddings implements PhysicalOperator {
   public DataSet<Embedding> evaluate() {
     return input
       .filter(new FilterEmbedding(predicates, metaData))
-        .name(getName());
+      .name(getName());
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterEmbeddings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterEmbeddings.java
@@ -43,6 +43,11 @@ public class FilterEmbeddings implements PhysicalOperator {
   private final EmbeddingMetaData metaData;
 
   /**
+   * Operator name
+   */
+  private String name;
+
+  /**
    * New embedding filter operator
    * @param input Candidate embeddings
    * @param predicates Predicates to used for filtering
@@ -53,6 +58,7 @@ public class FilterEmbeddings implements PhysicalOperator {
     this.input = input;
     this.predicates = predicates;
     this.metaData = metaData;
+    this.setName("FilterEmbeddings");
   }
 
   /**
@@ -61,6 +67,16 @@ public class FilterEmbeddings implements PhysicalOperator {
   public DataSet<Embedding> evaluate() {
     return input
       .filter(new FilterEmbedding(predicates, metaData))
-        .name("FilterEmbeddings(" + predicates + ")");
+        .name(getName());
+  }
+
+  @Override
+  public void setName(String newName) {
+    this.name = newName;
+  }
+
+  @Override
+  public String getName() {
+    return this.name;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterEmbeddings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterEmbeddings.java
@@ -59,6 +59,8 @@ public class FilterEmbeddings implements PhysicalOperator {
    * {@inheritDoc}
    */
   public DataSet<Embedding> evaluate() {
-    return input.filter(new FilterEmbedding(predicates, metaData));
+    return input
+      .filter(new FilterEmbedding(predicates, metaData))
+      .name("FilterEmbeddings(" + predicates + ")");
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterEmbeddings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/filter/FilterEmbeddings.java
@@ -61,6 +61,6 @@ public class FilterEmbeddings implements PhysicalOperator {
   public DataSet<Embedding> evaluate() {
     return input
       .filter(new FilterEmbedding(predicates, metaData))
-      .name("FilterEmbeddings(" + predicates + ")");
+        .name("FilterEmbeddings(" + predicates + ")");
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/join/JoinEmbeddings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/join/JoinEmbeddings.java
@@ -83,6 +83,11 @@ public class JoinEmbeddings implements PhysicalOperator {
   private final JoinOperatorBase.JoinHint joinHint;
 
   /**
+   * Operator name
+   */
+  private String name;
+
+  /**
    * Instantiates a new join operator.
    *
    * @param left embeddings of the left side of the join
@@ -171,6 +176,7 @@ public class JoinEmbeddings implements PhysicalOperator {
     this.distinctEdgeColumnsLeft    = distinctEdgeColumnsLeft;
     this.distinctEdgeColumnsRight   = distinctEdgeColumnsRight;
     this.joinHint                   = joinHint;
+    this.name                       = "JoinEmbeddings";
   }
 
   @Override
@@ -181,6 +187,16 @@ public class JoinEmbeddings implements PhysicalOperator {
       .with(new MergeEmbeddings(rightColumns, rightJoinColumns,
         distinctVertexColumnsLeft, distinctVertexColumnsRight,
         distinctEdgeColumnsLeft, distinctEdgeColumnsRight))
-      .name("JoinEmbeddings(" + leftJoinColumns + " |x| " + rightJoinColumns + ")");
+      .name(getName());
+  }
+
+  @Override
+  public void setName(String newName) {
+    this.name = newName;
+  }
+
+  @Override
+  public String getName() {
+    return this.name;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/join/JoinEmbeddings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/join/JoinEmbeddings.java
@@ -180,6 +180,7 @@ public class JoinEmbeddings implements PhysicalOperator {
       .equalTo(new ExtractJoinColumns(rightJoinColumns))
       .with(new MergeEmbeddings(rightColumns, rightJoinColumns,
         distinctVertexColumnsLeft, distinctVertexColumnsRight,
-        distinctEdgeColumnsLeft, distinctEdgeColumnsRight));
+        distinctEdgeColumnsLeft, distinctEdgeColumnsRight))
+      .name("JoinEmbeddings(" + leftJoinColumns + " |x| " + rightJoinColumns + ")");
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/join/JoinEmbeddings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/join/JoinEmbeddings.java
@@ -176,7 +176,7 @@ public class JoinEmbeddings implements PhysicalOperator {
     this.distinctEdgeColumnsLeft    = distinctEdgeColumnsLeft;
     this.distinctEdgeColumnsRight   = distinctEdgeColumnsRight;
     this.joinHint                   = joinHint;
-    this.name                       = "JoinEmbeddings";
+    this.setName("JoinEmbeddings");
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/join/ValueJoin.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/join/ValueJoin.java
@@ -70,4 +70,14 @@ public class ValueJoin implements PhysicalOperator {
   public DataSet<Embedding> evaluate() {
     return null;
   }
+
+  @Override
+  public void setName(String newName) {
+
+  }
+
+  @Override
+  public String getName() {
+    return null;
+  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEdges.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEdges.java
@@ -66,6 +66,6 @@ public class ProjectEdges implements PhysicalOperator {
   public DataSet<Embedding> evaluate() {
     return input
       .map(new ProjectEdge(propertyKeys))
-      .name("ProjectEdges(" + propertyKeys + ")");
+       .name("ProjectEdges(" + propertyKeys + ")");
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEdges.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEdges.java
@@ -72,7 +72,7 @@ public class ProjectEdges implements PhysicalOperator {
   public DataSet<Embedding> evaluate() {
     return input
       .map(new ProjectEdge(propertyKeys))
-       .name(getName());
+      .name(getName());
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEdges.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEdges.java
@@ -42,6 +42,11 @@ public class ProjectEdges implements PhysicalOperator {
   private final List<String> propertyKeys;
 
   /**
+   * Operator name
+   */
+  private String name;
+
+  /**
    * Creates a new edge projection operator
    * @param input edges that should be projected
    * @param propertyKeys List of property names that will be kept in the projection
@@ -49,6 +54,7 @@ public class ProjectEdges implements PhysicalOperator {
   public ProjectEdges(DataSet<Edge> input, List<String> propertyKeys) {
     this.input = input;
     this.propertyKeys = propertyKeys;
+    this.name = "ProjectEdges";
   }
 
   /**
@@ -66,6 +72,16 @@ public class ProjectEdges implements PhysicalOperator {
   public DataSet<Embedding> evaluate() {
     return input
       .map(new ProjectEdge(propertyKeys))
-       .name("ProjectEdges(" + propertyKeys + ")");
+       .name(getName());
+  }
+
+  @Override
+  public void setName(String newName) {
+    this.name = newName;
+  }
+
+  @Override
+  public String getName() {
+    return this.name;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEdges.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEdges.java
@@ -64,6 +64,8 @@ public class ProjectEdges implements PhysicalOperator {
 
   @Override
   public DataSet<Embedding> evaluate() {
-    return input.map(new ProjectEdge(propertyKeys));
+    return input
+      .map(new ProjectEdge(propertyKeys))
+      .name("ProjectEdges(" + propertyKeys + ")");
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEdges.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEdges.java
@@ -42,7 +42,7 @@ public class ProjectEdges implements PhysicalOperator {
   private final List<String> propertyKeys;
 
   /**
-   * Operator name
+   * Operator name used for Flink operator description
    */
   private String name;
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEmbeddings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEmbeddings.java
@@ -53,6 +53,6 @@ public class ProjectEmbeddings implements PhysicalOperator {
   public DataSet<Embedding> evaluate() {
     return input
       .map(new ProjectEmbedding(propertyWhiteList))
-      .name("ProjectEmbeddings(" + propertyWhiteList + ")");
+        .name("ProjectEmbeddings(" + propertyWhiteList + ")");
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEmbeddings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEmbeddings.java
@@ -40,6 +40,11 @@ public class ProjectEmbeddings implements PhysicalOperator {
   private final List<Integer> propertyWhiteList;
 
   /**
+   * Operator name
+   */
+  private String name;
+
+  /**
    * Creates a new embedding projection operator
    * @param input Embeddings that should be projected
    * @param propertyWhiteList property columns in the embedding that are taken over to the output
@@ -47,12 +52,23 @@ public class ProjectEmbeddings implements PhysicalOperator {
   public ProjectEmbeddings(DataSet<Embedding> input, List<Integer> propertyWhiteList) {
     this.input = input;
     this.propertyWhiteList = propertyWhiteList.stream().sorted().collect(Collectors.toList());
+    this.name = "ProjectEmbeddings";
   }
 
   @Override
   public DataSet<Embedding> evaluate() {
     return input
       .map(new ProjectEmbedding(propertyWhiteList))
-        .name("ProjectEmbeddings(" + propertyWhiteList + ")");
+        .name(getName());
+  }
+
+  @Override
+  public void setName(String newName) {
+    this.name = newName;
+  }
+
+  @Override
+  public String getName() {
+    return this.name;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEmbeddings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEmbeddings.java
@@ -51,6 +51,8 @@ public class ProjectEmbeddings implements PhysicalOperator {
 
   @Override
   public DataSet<Embedding> evaluate() {
-    return input.map(new ProjectEmbedding(propertyWhiteList));
+    return input
+      .map(new ProjectEmbedding(propertyWhiteList))
+      .name("ProjectEmbeddings(" + propertyWhiteList + ")");
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEmbeddings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEmbeddings.java
@@ -59,7 +59,7 @@ public class ProjectEmbeddings implements PhysicalOperator {
   public DataSet<Embedding> evaluate() {
     return input
       .map(new ProjectEmbedding(propertyWhiteList))
-        .name(getName());
+      .name(getName());
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEmbeddings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectEmbeddings.java
@@ -40,7 +40,7 @@ public class ProjectEmbeddings implements PhysicalOperator {
   private final List<Integer> propertyWhiteList;
 
   /**
-   * Operator name
+   * Operator name used for Flink operator description
    */
   private String name;
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectVertices.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectVertices.java
@@ -73,7 +73,7 @@ public class ProjectVertices implements PhysicalOperator {
   public DataSet<Embedding> evaluate() {
     return input
       .map(new ProjectVertex(propertyKeys))
-        .name(getName());
+      .name(getName());
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectVertices.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectVertices.java
@@ -42,7 +42,7 @@ public class ProjectVertices implements PhysicalOperator {
   private final List<String> propertyKeys;
 
   /**
-   * Operator name
+   * Operator name used for Flink operator description
    */
   private String name;
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectVertices.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectVertices.java
@@ -67,6 +67,6 @@ public class ProjectVertices implements PhysicalOperator {
   public DataSet<Embedding> evaluate() {
     return input
       .map(new ProjectVertex(propertyKeys))
-      .name("ProjectVertices(" + propertyKeys + ")");
+        .name("ProjectVertices(" + propertyKeys + ")");
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectVertices.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectVertices.java
@@ -65,6 +65,8 @@ public class ProjectVertices implements PhysicalOperator {
 
   @Override
   public DataSet<Embedding> evaluate() {
-    return input.map(new ProjectVertex(propertyKeys));
+    return input
+      .map(new ProjectVertex(propertyKeys))
+      .name("ProjectVertices(" + propertyKeys + ")");
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectVertices.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/operators/project/ProjectVertices.java
@@ -42,6 +42,11 @@ public class ProjectVertices implements PhysicalOperator {
   private final List<String> propertyKeys;
 
   /**
+   * Operator name
+   */
+  private String name;
+
+  /**
    * Creates a new vertex projection operator
    *
    * @param input vertices that should be projected
@@ -50,6 +55,7 @@ public class ProjectVertices implements PhysicalOperator {
   public ProjectVertices(DataSet<Vertex> input, List<String> propertyKeys) {
     this.input = input;
     this.propertyKeys = propertyKeys;
+    this.name = "ProjectVertices";
   }
 
   /**
@@ -67,6 +73,16 @@ public class ProjectVertices implements PhysicalOperator {
   public DataSet<Embedding> evaluate() {
     return input
       .map(new ProjectVertex(propertyKeys))
-        .name("ProjectVertices(" + propertyKeys + ")");
+        .name(getName());
+  }
+
+  @Override
+  public void setName(String newName) {
+    this.name = newName;
+  }
+
+  @Override
+  public String getName() {
+    return this.name;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/binary/ExpandEmbeddingsNode.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/binary/ExpandEmbeddingsNode.java
@@ -24,6 +24,8 @@ import org.gradoop.flink.model.impl.operators.matching.single.cypher.common.Expa
 import org.gradoop.flink.model.impl.operators.matching.single.cypher.common.pojos.Embedding;
 import org.gradoop.flink.model.impl.operators.matching.single.cypher.common.pojos.EmbeddingMetaData;
 
+import org.gradoop.flink.model.impl.operators.matching.single.cypher.operators.expand
+  .ExpandEmbeddings;
 import org.gradoop.flink.model.impl.operators.matching.single.cypher.operators.expand.ExpandEmbeddingsBulk;
 import org.gradoop.flink.model.impl.operators.matching.single.cypher.planning.queryplan.BinaryNode;
 import org.gradoop.flink.model.impl.operators.matching.single.cypher.planning.queryplan.JoinNode;
@@ -112,11 +114,14 @@ public class ExpandEmbeddingsNode extends BinaryNode implements JoinNode {
 
   @Override
   public DataSet<Embedding> execute() {
-    return new ExpandEmbeddingsBulk(getLeftChild().execute(), getRightChild().execute(),
+    ExpandEmbeddings op = new ExpandEmbeddingsBulk(
+      getLeftChild().execute(), getRightChild().execute(),
       expandColumn, lowerBound, upperBound, expandDirection,
       getDistinctVertexColumns(getLeftChild().getEmbeddingMetaData()),
       getDistinctEdgeColumns(getLeftChild().getEmbeddingMetaData()),
-      closingColumn, JoinOperatorBase.JoinHint.OPTIMIZER_CHOOSES).evaluate();
+      closingColumn, JoinOperatorBase.JoinHint.OPTIMIZER_CHOOSES);
+    op.setName(getOperatorName());
+    return op.evaluate();
   }
 
   @Override
@@ -176,5 +181,16 @@ public class ExpandEmbeddingsNode extends BinaryNode implements JoinNode {
         "edgeMorphismType=%s}",
       startVariable, pathVariable, endVariable, lowerBound, upperBound, expandDirection,
       vertexStrategy, edgeStrategy);
+  }
+
+  /**
+   * Generates the operator description
+   * @return operator description
+   */
+  private String getOperatorName() {
+    return String.format(
+      "ExpandEmbeddings(Bulk, from: %s, via: %s, to: %s, lowerBound: %s, upperBound: %s)",
+      startVariable, pathVariable, endVariable, lowerBound, upperBound
+    );
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/binary/ExpandEmbeddingsNode.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/binary/ExpandEmbeddingsNode.java
@@ -120,7 +120,7 @@ public class ExpandEmbeddingsNode extends BinaryNode implements JoinNode {
       getDistinctVertexColumns(getLeftChild().getEmbeddingMetaData()),
       getDistinctEdgeColumns(getLeftChild().getEmbeddingMetaData()),
       closingColumn, JoinOperatorBase.JoinHint.OPTIMIZER_CHOOSES);
-    op.setName(getOperatorName());
+    op.setName(toString());
     return op.evaluate();
   }
 
@@ -171,6 +171,7 @@ public class ExpandEmbeddingsNode extends BinaryNode implements JoinNode {
   @Override
   public String toString() {
     return String.format("ExpandEmbeddingsNode={" +
+        "Bulk, " +
         "startVariable='%s', " +
         "pathVariable='%s', " +
         "endVariable='%s', " +
@@ -181,16 +182,5 @@ public class ExpandEmbeddingsNode extends BinaryNode implements JoinNode {
         "edgeMorphismType=%s}",
       startVariable, pathVariable, endVariable, lowerBound, upperBound, expandDirection,
       vertexStrategy, edgeStrategy);
-  }
-
-  /**
-   * Generates the operator description
-   * @return operator description
-   */
-  private String getOperatorName() {
-    return String.format(
-      "ExpandEmbeddings(Bulk, from: %s, via: %s, to: %s, lowerBound: %s, upperBound: %s)",
-      startVariable, pathVariable, endVariable, lowerBound, upperBound
-    );
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/binary/ExpandEmbeddingsNode.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/binary/ExpandEmbeddingsNode.java
@@ -171,7 +171,6 @@ public class ExpandEmbeddingsNode extends BinaryNode implements JoinNode {
   @Override
   public String toString() {
     return String.format("ExpandEmbeddingsNode={" +
-        "Bulk, " +
         "startVariable='%s', " +
         "pathVariable='%s', " +
         "endVariable='%s', " +

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/binary/JoinEmbeddingsNode.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/binary/JoinEmbeddingsNode.java
@@ -97,7 +97,7 @@ public class JoinEmbeddingsNode extends BinaryNode implements JoinNode {
       getDistinctVertexColumnsLeft(), getDistinctVertexColumnsRight(),
       getDistinctEdgeColumnsLeft(), getDistinctEdgeColumnsRight(),
       joinHint);
-    op.setName(getOperatorName());
+    op.setName(toString());
     return op.evaluate();
   }
 
@@ -226,13 +226,5 @@ public class JoinEmbeddingsNode extends BinaryNode implements JoinNode {
       "vertexMorphismType=%s, " +
       "edgeMorphismType=%s}",
       joinVariables, vertexStrategy, edgeStrategy);
-  }
-
-  /**
-   * Generates the operator description
-   * @return operator description
-   */
-  private String getOperatorName() {
-    return String.format("JoinEmbeddings(on: %s", joinVariables);
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/binary/JoinEmbeddingsNode.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/binary/JoinEmbeddingsNode.java
@@ -91,12 +91,14 @@ public class JoinEmbeddingsNode extends BinaryNode implements JoinNode {
 
   @Override
   public DataSet<Embedding> execute() {
-    return new JoinEmbeddings(getLeftChild().execute(), getRightChild().execute(),
+    JoinEmbeddings op = new JoinEmbeddings(getLeftChild().execute(), getRightChild().execute(),
       getRightChild().getEmbeddingMetaData().getEntryCount(),
       getJoinColumnsLeft(), getJoinColumnsRight(),
       getDistinctVertexColumnsLeft(), getDistinctVertexColumnsRight(),
       getDistinctEdgeColumnsLeft(), getDistinctEdgeColumnsRight(),
-      joinHint).evaluate();
+      joinHint);
+    op.setName(getOperatorName());
+    return op.evaluate();
   }
 
   @Override
@@ -224,5 +226,13 @@ public class JoinEmbeddingsNode extends BinaryNode implements JoinNode {
       "vertexMorphismType=%s, " +
       "edgeMorphismType=%s}",
       joinVariables, vertexStrategy, edgeStrategy);
+  }
+
+  /**
+   * Generates the operator description
+   * @return operator description
+   */
+  private String getOperatorName() {
+    return String.format("JoinEmbeddings(on: %s", joinVariables);
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectEdgesNode.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectEdgesNode.java
@@ -85,7 +85,7 @@ public class FilterAndProjectEdgesNode extends LeafNode implements FilterNode, P
   @Override
   public DataSet<Embedding> execute() {
     FilterAndProjectEdges op =  new FilterAndProjectEdges(edges, filterPredicate, projectionKeys);
-    op.setName(getOperatorName());
+    op.setName(toString());
     return op.evaluate();
   }
 
@@ -128,16 +128,5 @@ public class FilterAndProjectEdgesNode extends LeafNode implements FilterNode, P
         "filterPredicate=%s, " +
         "projectionKeys=%s}",
       sourceVariable, edgeVariable, targetVariable, filterPredicate, projectionKeys);
-  }
-
-  /**
-   * Returns the operator name
-   * @return operator name
-   */
-  private String getOperatorName() {
-    return String.format(
-      "FilterAndProjectEdges(from: %s, via: %s, to: %s, filter: %s, projection: %s)",
-      sourceVariable, edgeVariable, targetVariable, filterPredicate, projectionKeys
-    );
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectEdgesNode.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectEdgesNode.java
@@ -84,8 +84,9 @@ public class FilterAndProjectEdgesNode extends LeafNode implements FilterNode, P
 
   @Override
   public DataSet<Embedding> execute() {
-    return new FilterAndProjectEdges(edges, filterPredicate, projectionKeys)
-      .evaluate();
+    FilterAndProjectEdges op =  new FilterAndProjectEdges(edges, filterPredicate, projectionKeys);
+    op.setName(getOperatorName());
+    return op.evaluate();
   }
 
   /**
@@ -127,5 +128,16 @@ public class FilterAndProjectEdgesNode extends LeafNode implements FilterNode, P
         "filterPredicate=%s, " +
         "projectionKeys=%s}",
       sourceVariable, edgeVariable, targetVariable, filterPredicate, projectionKeys);
+  }
+
+  /**
+   * Returns the operator name
+   * @return operator name
+   */
+  private String getOperatorName() {
+    return String.format(
+      "FilterAndProjectEdges(from: %s, via: %s, to: %s, filter: %s, projection: %s)",
+      sourceVariable, edgeVariable, targetVariable, filterPredicate, projectionKeys
+    );
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectVerticesNode.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectVerticesNode.java
@@ -73,7 +73,7 @@ public class FilterAndProjectVerticesNode extends LeafNode implements FilterNode
   public DataSet<Embedding> execute() {
     FilterAndProjectVertices op =
       new FilterAndProjectVertices(vertices, filterPredicate, projectionKeys);
-    op.setName(getOperatorName());
+    op.setName(toString());
     return op.evaluate();
   }
 
@@ -111,16 +111,5 @@ public class FilterAndProjectVerticesNode extends LeafNode implements FilterNode
         "filterPredicate=%s, " +
         "projectionKeys=%s}",
       vertexVariable, filterPredicate, projectionKeys);
-  }
-
-  /**
-   * Returns the operator name
-   * @return operator name
-   */
-  private String getOperatorName() {
-    return String.format(
-      "FilterAndProjectVertices(variable: %s, filter: %s, projection: %s)",
-      vertexVariable, filterPredicate, projectionKeys
-    );
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectVerticesNode.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectVerticesNode.java
@@ -71,8 +71,10 @@ public class FilterAndProjectVerticesNode extends LeafNode implements FilterNode
 
   @Override
   public DataSet<Embedding> execute() {
-    return new FilterAndProjectVertices(vertices, filterPredicate, projectionKeys)
-      .evaluate();
+    FilterAndProjectVertices op =
+      new FilterAndProjectVertices(vertices, filterPredicate, projectionKeys);
+    op.setName(getOperatorName());
+    return op.evaluate();
   }
 
   /**
@@ -109,5 +111,16 @@ public class FilterAndProjectVerticesNode extends LeafNode implements FilterNode
         "filterPredicate=%s, " +
         "projectionKeys=%s}",
       vertexVariable, filterPredicate, projectionKeys);
+  }
+
+  /**
+   * Returns the operator name
+   * @return operator name
+   */
+  private String getOperatorName() {
+    return String.format(
+      "FilterAndProjectVertices(variable: %s, filter: %s, projection: %s)",
+      vertexVariable, filterPredicate, projectionKeys
+    );
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/unary/FilterEmbeddingsNode.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/unary/FilterEmbeddingsNode.java
@@ -49,7 +49,6 @@ public class FilterEmbeddingsNode extends UnaryNode implements FilterNode {
   public DataSet<Embedding> execute() {
     FilterEmbeddings op =
       new FilterEmbeddings(getChildNode().execute(), filterPredicate, getEmbeddingMetaData());
-
     op.setName(toString());
     return op.evaluate();
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/unary/FilterEmbeddingsNode.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/unary/FilterEmbeddingsNode.java
@@ -50,7 +50,7 @@ public class FilterEmbeddingsNode extends UnaryNode implements FilterNode {
     FilterEmbeddings op =
       new FilterEmbeddings(getChildNode().execute(), filterPredicate, getEmbeddingMetaData());
 
-    op.setName(getOperatorName());
+    op.setName(toString());
     return op.evaluate();
   }
 
@@ -71,13 +71,5 @@ public class FilterEmbeddingsNode extends UnaryNode implements FilterNode {
   @Override
   public String toString() {
     return String.format("FilterEmbeddingsNode{filterPredicate=%s}", filterPredicate);
-  }
-
-  /**
-   * Returns the operator name
-   * @return operator name
-   */
-  private String getOperatorName() {
-    return String.format("FilterEmbeddings(predicatse: %s)", filterPredicate);
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/unary/FilterEmbeddingsNode.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/unary/FilterEmbeddingsNode.java
@@ -47,8 +47,11 @@ public class FilterEmbeddingsNode extends UnaryNode implements FilterNode {
 
   @Override
   public DataSet<Embedding> execute() {
-    return new FilterEmbeddings(getChildNode().execute(), filterPredicate, getEmbeddingMetaData())
-      .evaluate();
+    FilterEmbeddings op =
+      new FilterEmbeddings(getChildNode().execute(), filterPredicate, getEmbeddingMetaData());
+
+    op.setName(getOperatorName());
+    return op.evaluate();
   }
 
   /**
@@ -68,5 +71,13 @@ public class FilterEmbeddingsNode extends UnaryNode implements FilterNode {
   @Override
   public String toString() {
     return String.format("FilterEmbeddingsNode{filterPredicate=%s}", filterPredicate);
+  }
+
+  /**
+   * Returns the operator name
+   * @return operator name
+   */
+  private String getOperatorName() {
+    return String.format("FilterEmbeddings(predicatse: %s)", filterPredicate);
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/unary/ProjectEmbeddingsNode.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/unary/ProjectEmbeddingsNode.java
@@ -63,7 +63,9 @@ public class ProjectEmbeddingsNode extends UnaryNode implements ProjectionNode {
 
   @Override
   public DataSet<Embedding> execute() {
-    return new ProjectEmbeddings(getChildNode().execute(), whiteListColumns).evaluate();
+    ProjectEmbeddings op =  new ProjectEmbeddings(getChildNode().execute(), whiteListColumns);
+    op.setName(getOperatorName());
+    return op.evaluate();
   }
 
   @Override
@@ -88,5 +90,13 @@ public class ProjectEmbeddingsNode extends UnaryNode implements ProjectionNode {
   @Override
   public String toString() {
     return String.format("ProjectEmbeddingsNode{projectionKeys=%s}", projectionKeys);
+  }
+
+  /**
+   * Generates the operator description
+   * @return operator description
+   */
+  private String getOperatorName() {
+    return String.format("ProjectEmbeddings(projectionKeys: %s", projectionKeys);
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/unary/ProjectEmbeddingsNode.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/unary/ProjectEmbeddingsNode.java
@@ -64,7 +64,7 @@ public class ProjectEmbeddingsNode extends UnaryNode implements ProjectionNode {
   @Override
   public DataSet<Embedding> execute() {
     ProjectEmbeddings op =  new ProjectEmbeddings(getChildNode().execute(), whiteListColumns);
-    op.setName(getOperatorName());
+    op.setName(toString());
     return op.evaluate();
   }
 
@@ -90,13 +90,5 @@ public class ProjectEmbeddingsNode extends UnaryNode implements ProjectionNode {
   @Override
   public String toString() {
     return String.format("ProjectEmbeddingsNode{projectionKeys=%s}", projectionKeys);
-  }
-
-  /**
-   * Generates the operator description
-   * @return operator description
-   */
-  private String getOperatorName() {
-    return String.format("ProjectEmbeddings(projectionKeys: %s", projectionKeys);
   }
 }


### PR DESCRIPTION
Fixes #572 

Adds operator names to all cypher (sub-) operators

Example: 
![image](https://cloud.githubusercontent.com/assets/1449357/24110729/83ca97f8-0d94-11e7-9c26-e3a54a133141.png)
