### PR TITLE
Windows compatibility in tests

### DIFF
--- a/gradoop-examples/src/main/java/org/gradoop/examples/patternmatching/CypherExample.java
+++ b/gradoop-examples/src/main/java/org/gradoop/examples/patternmatching/CypherExample.java
@@ -35,7 +35,7 @@ public class CypherExample {
   /**
    * Path to the data graph.
    */
-  static final String DATA_PATH = CypherExample.class.getResource("/data/json/sna").getPath();
+  static final String DATA_PATH = CypherExample.class.getResource("/data/json/sna").getFile();
   /**
    * Path to the data graph statistics (computed using {@link org.gradoop.utils.statistics.StatisticsRunner}
    */

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/tlf/functions/TLFGraphFromText.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/tlf/functions/TLFGraphFromText.java
@@ -61,7 +61,7 @@ public class TLFGraphFromText
     do {
       currChar = graph.charAt(cursor);
       if (currChar == '\n') {
-        String[] fields = stringBuilder.toString().split(" ");
+        String[] fields = stringBuilder.toString().trim().split(" ");
         if (firstLine) {
           graphHead = new TLFGraphHead(Long.valueOf(fields[2]));
           firstLine = false;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/statistics/GraphStatisticsLocalFSReader.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/statistics/GraphStatisticsLocalFSReader.java
@@ -17,6 +17,7 @@
 
 package org.gradoop.flink.model.impl.operators.matching.common.statistics;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
@@ -40,7 +41,7 @@ public class GraphStatisticsLocalFSReader extends GraphStatisticsReader {
    */
   public static GraphStatistics read(String inputPath) throws IOException {
 
-    Path statisticsDir = Paths.get(inputPath);
+    Path statisticsDir = Paths.get(new File(inputPath).getAbsolutePath());
     Charset charset = Charset.forName("UTF-8");
 
     Path p = statisticsDir.resolve(Paths.get(GraphStatisticsReader.FILE_VERTEX_COUNT));

--- a/gradoop-flink/src/test/java/org/gradoop/flink/datagen/transactions/foodbroker/FoodBrokerTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/datagen/transactions/foodbroker/FoodBrokerTest.java
@@ -30,6 +30,7 @@ import org.gradoop.flink.model.impl.functions.epgm.ByProperty;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
@@ -132,7 +133,8 @@ public class FoodBrokerTest extends GradoopFlinkTestBase {
   private GraphCollection generateCollection()
     throws IOException, JSONException, URISyntaxException {
     String configPath = Paths.get(
-      FoodBrokerTest.class.getResource("/foodbroker/config.json").toURI()).toFile().getPath();
+    		new File(FoodBrokerTest.class.getResource("/foodbroker/config.json").getFile()).getAbsolutePath())
+    		.toFile().getPath();
 
     FoodBrokerConfig config = FoodBrokerConfig.fromFile(configPath);
 

--- a/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSinkTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSinkTest.java
@@ -39,11 +39,11 @@ public class CSVDataSinkTest extends GradoopFlinkTestBase {
 
     String csvPath = VertexLabeledEdgeListDataSourceTest.class
       .getResource("/data/csv/input")
-      .getPath();
+      .getFile();
 
     String gdlPath = CSVDataSourceTest.class
       .getResource("/data/csv/expected/expected.gdl")
-      .getPath();
+      .getFile();
 
     LogicalGraph input = getLoaderFromFile(gdlPath).getLogicalGraphByVariable("expected");
 

--- a/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSourceTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSourceTest.java
@@ -12,11 +12,11 @@ public class CSVDataSourceTest extends GradoopFlinkTestBase {
   public void testRead() throws Exception {
     String csvPath = VertexLabeledEdgeListDataSourceTest.class
       .getResource("/data/csv/input")
-      .getPath();
+      .getFile();
 
     String gdlPath = CSVDataSourceTest.class
       .getResource("/data/csv/expected/expected.gdl")
-      .getPath();
+      .getFile();
 
     DataSource dataSource = new CSVDataSource(csvPath, getConfig());
     LogicalGraph input = dataSource.getLogicalGraph();

--- a/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/tlf/TLFDataSinkTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/tlf/TLFDataSinkTest.java
@@ -45,7 +45,7 @@ public class TLFDataSinkTest extends GradoopFlinkTestBase {
       .getResource("/data/tlf/io_test.tlf").getFile();
 
     String tlfFileExport = TLFDataSinkTest.class
-      .getResource("/data/tlf").toURI().getPath().concat("/io_test_output");
+      .getResource("/data/tlf").getFile() + "/io_test_output";
 
     // read from inputfile
     DataSource dataSource = new TLFDataSource(tlfFileImport, config);
@@ -75,11 +75,11 @@ public class TLFDataSinkTest extends GradoopFlinkTestBase {
       .getResource("/data/tlf/io_test_vertex_dictionary.tlf").getFile();
 
     String tlfFileExport = TLFDataSinkTest.class
-      .getResource("/data/tlf").toURI().getPath().concat("/io_test_output");
+      .getResource("/data/tlf").getFile()+"/io_test_output";
 
     String tlfVertexDictionaryFileExport = TLFDataSinkTest.class
-      .getResource("/data/tlf").toURI().getPath()
-      .concat("/dictionaries/io_test_output_vertex_dictionary");
+      .getResource("/data/tlf").getFile()
+      + "/dictionaries/io_test_output_vertex_dictionary";
 
     // read from inputfile
     DataSource dataSource = new TLFDataSource(tlfFileImport, 
@@ -128,15 +128,15 @@ public class TLFDataSinkTest extends GradoopFlinkTestBase {
       .getResource("/data/tlf/io_test_edge_dictionary.tlf").getFile();
 
     String tlfFileExport = TLFDataSinkTest.class
-      .getResource("/data/tlf").toURI().getPath().concat("/io_test_output");
+      .getResource("/data/tlf").getFile() + "/io_test_output";
 
     String tlfVertexDictionaryFileExport = TLFDataSinkTest.class
-      .getResource("/data/tlf").toURI().getPath()
-      .concat("/dictionaries/io_test_output_vertex_dictionary");
+      .getResource("/data/tlf").getFile()
+      + "/dictionaries/io_test_output_vertex_dictionary";
 
     String tlfEdgeDictionaryFileExport = TLFDataSinkTest.class
-      .getResource("/data/tlf").toURI().getPath()
-      .concat("/dictionaries/io_test_output_edge_dictionary");
+      .getResource("/data/tlf").getFile() 
+      + "/dictionaries/io_test_output_edge_dictionary";
 
     // read from inputfile
     DataSource dataSource = new TLFDataSource(tlfFileImport,

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/common/statistics/GraphStatisticsHDFSReaderTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/common/statistics/GraphStatisticsHDFSReaderTest.java
@@ -20,7 +20,7 @@ public class GraphStatisticsHDFSReaderTest extends GraphStatisticsTest {
     }
 
     // copy test resources to HDFS
-    Path localPath = new Path(GraphStatisticsHDFSReaderTest.class.getResource("/data/json/sna/statistics").getPath());
+    Path localPath = new Path(GraphStatisticsHDFSReaderTest.class.getResource("/data/json/sna/statistics").getFile());
     Path remotePath = new Path("/");
     utility.getTestFileSystem().copyFromLocalFile(localPath, remotePath);
 

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/common/statistics/GraphStatisticsLocalFSReaderTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/common/statistics/GraphStatisticsLocalFSReaderTest.java
@@ -7,6 +7,6 @@ public class GraphStatisticsLocalFSReaderTest extends GraphStatisticsTest {
   @BeforeClass
   public static void setUp() throws Exception {
     TEST_STATISTICS = GraphStatisticsLocalFSReader.read(
-      GraphStatisticsLocalFSReaderTest.class.getResource("/data/json/sna/statistics").getPath());
+      GraphStatisticsLocalFSReaderTest.class.getResource("/data/json/sna/statistics").getFile());
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/QueryEngineITTests.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/QueryEngineITTests.java
@@ -29,7 +29,7 @@ public class QueryEngineITTests extends GradoopFlinkTestBase {
   @Before
   public void setUp() throws Exception {
     socialNetwork = getSocialNetworkLoader().getDatabase().getDatabaseGraph();
-    String path = QueryEngineITTests.class.getResource("/data/json/sna/statistics").getPath();
+    String path = QueryEngineITTests.class.getResource("/data/json/sna/statistics").getFile();
     socialNetworkStatistics = GraphStatisticsLocalFSReader.read(path);
   }
 

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/estimation/EstimatorTestBase.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/estimation/EstimatorTestBase.java
@@ -11,7 +11,7 @@ public abstract class EstimatorTestBase {
   @BeforeClass
   public static void setUp() throws Exception {
     String path = JoinEstimatorTest.class
-      .getResource("/data/json/sna/statistics").getPath();
+      .getResource("/data/json/sna/statistics").getFile();
     STATS = GraphStatisticsLocalFSReader.read(path);
   }
 }


### PR DESCRIPTION
There are two main differences between Windows and Linux addressed in this PR: Line endings are \r\n instead of just \n and the conversion from URL (acquired via `class.getResource(...)` has a mandatory slash as the first character, which isn't a valid path in Windows).

With these changes I was able to run all tests successfully on Windows 7 with Hadoop 2.6.0.