### PR TITLE
Ignore eclipse specific configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ target
 output
 *.iml
 dependency-reduced-pom.xml
+.classpath
+.project
+.settings/


### PR DESCRIPTION
Just like the *.iml from IntelliJ. These types of files are specific for the development environment of each contributor, they should not accidentally become part of the code base.