### PR TITLE
#665 LabelGroup mixup

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/Grouping.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/Grouping.java
@@ -473,7 +473,8 @@ public abstract class Grouping implements UnaryGraphToGraphOperator {
      * @return this builder
      */
     public GroupingBuilder addVertexLabelGroup(
-      String label, String superVertexLabel,
+      String label,
+      String superVertexLabel,
       List<String> groupingKeys) {
       return addVertexLabelGroup(label, superVertexLabel, groupingKeys, Lists.newArrayList());
     }
@@ -489,7 +490,8 @@ public abstract class Grouping implements UnaryGraphToGraphOperator {
      * @return this builder
      */
     public GroupingBuilder addVertexLabelGroup(
-      String label, String superVertexLabel,
+      String label,
+      String superVertexLabel,
       List<String> groupingKeys,
       List<PropertyValueAggregator> aggregators) {
       vertexLabelGroups.add(new LabelGroup(label, superVertexLabel, groupingKeys, aggregators));
@@ -536,7 +538,8 @@ public abstract class Grouping implements UnaryGraphToGraphOperator {
      * @return this builder
      */
     public GroupingBuilder addEdgeLabelGroup(
-      String label, String superEdgeLabel,
+      String label,
+      String superEdgeLabel,
       List<String> groupingKeys) {
       return addEdgeLabelGroup(label, superEdgeLabel, groupingKeys, Lists.newArrayList());
     }
@@ -552,7 +555,8 @@ public abstract class Grouping implements UnaryGraphToGraphOperator {
      * @return this builder
      */
     public GroupingBuilder addEdgeLabelGroup(
-      String label, String superEdgeLabel,
+      String label,
+      String superEdgeLabel,
       List<String> groupingKeys,
       List<PropertyValueAggregator> aggregators) {
       edgeLabelGroups.add(new LabelGroup(label, superEdgeLabel, groupingKeys, aggregators));

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/Grouping.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/Grouping.java
@@ -531,7 +531,7 @@ public abstract class Grouping implements UnaryGraphToGraphOperator {
      * Note that a label may be used multiple times.
      *
      * @param label edge label
-     * @param superEdgeLabel label of the group and therefore of the new super vertex
+     * @param superEdgeLabel label of the group and therefore of the new super edge
      * @param groupingKeys keys used for grouping
      * @return this builder
      */
@@ -546,7 +546,7 @@ public abstract class Grouping implements UnaryGraphToGraphOperator {
      * specific label. Note that a label may be used multiple times.
      *
      * @param label edge label
-     * @param superEdgeLabel label of the group and therefore of the new super vertex
+     * @param superEdgeLabel label of the group and therefore of the new super edge
      * @param groupingKeys keys used for grouping
      * @param aggregators edge aggregators
      * @return this builder

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/Grouping.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/Grouping.java
@@ -349,9 +349,9 @@ public abstract class Grouping implements UnaryGraphToGraphOperator {
       this.globalVertexAggregators  = Lists.newArrayList();
       this.globalEdgeAggregators    = Lists.newArrayList();
       this.defaultVertexLabelGroup  = new LabelGroup(
-        GradoopConstants.DEFAULT_VERTEX_LABEL, Grouping.DEFAULT_VERTEX_LABEL_GROUP);
+        Grouping.DEFAULT_VERTEX_LABEL_GROUP, GradoopConstants.DEFAULT_VERTEX_LABEL);
       this.defaultEdgeLabelGroup    = new LabelGroup(
-        GradoopConstants.DEFAULT_EDGE_LABEL, Grouping.DEFAULT_EDGE_LABEL_GROUP);
+        Grouping.DEFAULT_EDGE_LABEL_GROUP, GradoopConstants.DEFAULT_EDGE_LABEL);
 
       vertexLabelGroups.add(defaultVertexLabelGroup);
       edgeLabelGroups.add(defaultEdgeLabelGroup);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/tuples/LabelGroup.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/tuples/LabelGroup.java
@@ -60,19 +60,19 @@ public class LabelGroup
     super(groupingLabel, groupLabel, propertyKeys, aggregators);
   }
 
-  public String getGroupLabel() {
+  public String getGroupingLabel() {
     return f0;
   }
 
-  public void setGroupLabel(String label) {
+  public void setGroupingLabel(String label) {
     f0 = label;
   }
 
-  public String getGroupingLabel() {
+  public String getGroupLabel() {
     return f1;
   }
 
-  public void setGroupingLabel(String label) {
+  public void setGroupLabel(String label) {
     f1 = label;
   }
 

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/grouping/GroupingTestBase.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/grouping/GroupingTestBase.java
@@ -1403,7 +1403,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
     LogicalGraph output = new Grouping.GroupingBuilder()
       .useVertexLabel(true)
       .addVertexGroupingKey("topic")
-      .addVertexLabelGroup("UserGender", "User", Lists.newArrayList("gender"))
+      .addVertexLabelGroup("User", "UserGender", Lists.newArrayList("gender"))
       .setStrategy(getStrategy())
       .build()
       .execute(input);
@@ -1588,7 +1588,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexGroupingKey("topic")
       .addVertexLabelGroup("User", Lists.newArrayList("gender"),
         Lists.newArrayList(new CountAggregator("count"), new MaxAggregator("age", "max")))
-      .addVertexLabelGroup("UserAge", "User", Lists.newArrayList("age"),
+      .addVertexLabelGroup("User", "UserAge", Lists.newArrayList("age"),
         Lists.newArrayList(new CountAggregator("count"), new SumAggregator("age", "sum")))
       .addVertexAggregator(new CountAggregator("count"))
       .setStrategy(getStrategy())
@@ -1646,7 +1646,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .useVertexLabel(true)
       .useEdgeLabel(true)
       .addEdgeGroupingKey("until")
-      .addEdgeLabelGroup("knowsSince", "knows", Lists.newArrayList("since"))
+      .addEdgeLabelGroup("knows", "knowsSince", Lists.newArrayList("since"))
       .setStrategy(getStrategy())
       .build()
       .execute(input);
@@ -1792,7 +1792,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .useVertexLabel(true)
       .addEdgeLabelGroup("knows", Lists.newArrayList("since"),
         Lists.newArrayList(new SumAggregator("since", "sum")))
-      .addEdgeLabelGroup("knowsMax", "knows", Lists.newArrayList(),
+      .addEdgeLabelGroup("knows", "knowsMax", Lists.newArrayList(),
         Lists.newArrayList(new MaxAggregator("since", "max")))
       .addEdgeLabelGroup("member", Lists.newArrayList("until"),
         Lists.newArrayList(new MinAggregator("until", "min")))


### PR DESCRIPTION
Fixed mixup, where the getter of the `LabelGroup` where defined wrong and the initialization of the `defaultLabelGroup` was mixed up. Also corrected tests.