### PR TITLE
Probable typo in SNA example yields empty result

### DIFF
--- a/gradoop-examples/src/main/java/org/gradoop/examples/sna/SNABenchmark1.java
+++ b/gradoop-examples/src/main/java/org/gradoop/examples/sna/SNABenchmark1.java
@@ -79,7 +79,7 @@ public class SNABenchmark1 extends AbstractRunner implements
   private static LogicalGraph execute(LogicalGraph socialNetwork) {
     return socialNetwork
       .subgraph(
-        vertex -> vertex.getLabel().equals("person"),
+        vertex -> vertex.getLabel().equals("Person"),
         edge -> edge.getLabel().equals("knows"))
       .groupBy(Arrays.asList("gender", "city"))
       .aggregate(new VertexCount())


### PR DESCRIPTION
In the example SNA files provided in gradoop/gradoop-examples/src/main/resources/data/json/sna the label "Person" starts with a capital P. Using a small "p" in the getLabel().equals() predicate makes the example compile and run correctly, but the final result is empty. I suppose this was not the intended behaviour.