### PR TITLE
[#681] Reenable set nature of GradoopIdList

### DIFF
--- a/gradoop-common/src/main/java/org/gradoop/common/model/api/entities/EPGMEdgeFactory.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/api/entities/EPGMEdgeFactory.java
@@ -16,7 +16,7 @@
 package org.gradoop.common.model.api.entities;
 
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.properties.Properties;
 
 /**
@@ -104,7 +104,7 @@ public interface EPGMEdgeFactory<E extends EPGMEdge>
    * @return edge data
    */
   E createEdge(String label, GradoopId sourceVertexId, GradoopId targetVertexId,
-    GradoopIdList graphIds);
+    GradoopIds graphIds);
 
   /**
    * Initializes an edge based on the given parameters.
@@ -117,7 +117,7 @@ public interface EPGMEdgeFactory<E extends EPGMEdge>
    * @return edge data
    */
   E initEdge(GradoopId id, String label, GradoopId sourceVertexId,
-    GradoopId targetVertexId, GradoopIdList graphIds);
+    GradoopId targetVertexId, GradoopIds graphIds);
 
   /**
    * Creates a new edge based on the given parameters.
@@ -130,7 +130,7 @@ public interface EPGMEdgeFactory<E extends EPGMEdge>
    * @return edge data
    */
   E createEdge(String label, GradoopId sourceVertexId, GradoopId targetVertexId,
-    Properties properties, GradoopIdList graphIds);
+    Properties properties, GradoopIds graphIds);
 
   /**
    * Initializes an edge based on the given parameters.
@@ -144,5 +144,5 @@ public interface EPGMEdgeFactory<E extends EPGMEdge>
    * @return edge data
    */
   E initEdge(GradoopId id, String label, GradoopId sourceVertexId,
-    GradoopId targetVertexId, Properties properties, GradoopIdList graphIds);
+    GradoopId targetVertexId, Properties properties, GradoopIds graphIds);
 }

--- a/gradoop-common/src/main/java/org/gradoop/common/model/api/entities/EPGMGraphElement.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/api/entities/EPGMGraphElement.java
@@ -16,7 +16,7 @@
 package org.gradoop.common.model.api.entities;
 
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * A graph element is part of a logical graph. An element can be part of more
@@ -28,7 +28,7 @@ public interface EPGMGraphElement extends EPGMElement {
    *
    * @return all graphs of that element
    */
-  GradoopIdList getGraphIds();
+  GradoopIds getGraphIds();
 
   /**
    * Adds that element to the given graphId. If the element is already an
@@ -43,7 +43,7 @@ public interface EPGMGraphElement extends EPGMElement {
    *
    * @param graphIds the graphIds to be added
    */
-  void setGraphIds(GradoopIdList graphIds);
+  void setGraphIds(GradoopIds graphIds);
 
   /**
    * Resets all graph elements.

--- a/gradoop-common/src/main/java/org/gradoop/common/model/api/entities/EPGMVertexFactory.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/api/entities/EPGMVertexFactory.java
@@ -16,7 +16,7 @@
 package org.gradoop.common.model.api.entities;
 
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.properties.Properties;
 
 /**
@@ -85,7 +85,7 @@ public interface EPGMVertexFactory<V extends EPGMVertex>
    * @param graphIds graphIds, that contain the vertex
    * @return vertex data
    */
-  V createVertex(String label, GradoopIdList graphIds);
+  V createVertex(String label, GradoopIds graphIds);
 
   /**
    * Initializes a vertex based on the given parameters.
@@ -95,7 +95,7 @@ public interface EPGMVertexFactory<V extends EPGMVertex>
    * @param graphIds graphIds, that contain the vertex
    * @return vertex data
    */
-  V initVertex(GradoopId id, String label, GradoopIdList graphIds);
+  V initVertex(GradoopId id, String label, GradoopIds graphIds);
 
   /**
    * Creates a new vertex based on the given parameters.
@@ -105,7 +105,7 @@ public interface EPGMVertexFactory<V extends EPGMVertex>
    * @param graphIds     graphIds, that contain the vertex
    * @return vertex data
    */
-  V createVertex(String label, Properties properties, GradoopIdList graphIds);
+  V createVertex(String label, Properties properties, GradoopIds graphIds);
 
   /**
    * Initializes a vertex based on the given parameters.
@@ -117,5 +117,5 @@ public interface EPGMVertexFactory<V extends EPGMVertex>
    * @return vertex data
    */
   V initVertex(GradoopId id, String label, Properties properties,
-    GradoopIdList graphIds);
+    GradoopIds graphIds);
 }

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/id/GradoopIdList.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/id/GradoopIdList.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * Represents a list of {@link GradoopId} instances, possibly containing duplicates.
+ * Represents a set of {@link GradoopId} instances, ignoring any duplicates.
  *
  * Note that by implementing {@link java.util.List} Flink uses the Kryo serializer for
  * (de-)serializing the list.
@@ -49,7 +49,7 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
   }
 
   /**
-   * Initializes the list with the given byte array.
+   * Initializes the set with the given byte array.
    *
    * @param bytes bytes representing multiple gradoop ids
    */
@@ -58,7 +58,7 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
   }
   
   /**
-   * Initializes the list with the given ids.
+   * Initializes the set with the given ids.
    *
    * @param ids a collection of {@link GradoopId}s
    */
@@ -128,7 +128,7 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
   }
 
   /**
-   * Adds the given gradoop id to the list.
+   * Adds the given gradoop id to the set.
    *
    * @param id the id to add
    */
@@ -137,7 +137,7 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
   }
 
   /**
-   * Adds the given gradoop ids to the list.
+   * Adds the given gradoop ids to the set.
    *
    * @param ids the ids to add
    */
@@ -146,7 +146,7 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
   }
 
   /**
-   * Adds the given gradoop ids to the list.
+   * Adds the given gradoop ids to the set.
    *
    * @param ids the ids to add
    */
@@ -155,20 +155,20 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
   }
 
   /**
-   * Checks if the given id is contained in the list.
+   * Checks if the given id is contained in the set.
    *
    * @param identifier the id to look for
-   * @return true, iff the given id is in the list
+   * @return true, iff the given id is in the set
    */
   public boolean contains(GradoopId identifier) {
     return this.ids.contains(identifier);
   }
 
   /**
-   * Checks if the specified ids are contained in the list.
+   * Checks if the specified ids are contained in the set.
    *
    * @param ids the ids to look for
-   * @return true, iff all specified ids are contained in the list
+   * @return true, iff all specified ids are contained in the set
    */
   public boolean containsAll(GradoopIdList ids) {
     for (GradoopId id : ids) {
@@ -183,7 +183,7 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
    * Checks if the specified ids are contained in the set.
    *
    * @param ids the ids to look for
-   * @return true, iff all specified ids are contained in the list
+   * @return true, iff all specified ids are contained in the set
    */
   public boolean containsAll(Collection<GradoopId> ids) {
     for (GradoopId id : ids) {
@@ -195,10 +195,10 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
   }
 
   /**
-   * Checks if any of the specified ids is contained in the list.
+   * Checks if any of the specified ids is contained in the set.
    *
    * @param ids the ids to look for
-   * @return true, iff any of the specified ids is contained in the list
+   * @return true, iff any of the specified ids is contained in the set
    */
   public boolean containsAny(GradoopIdList ids) {
     for (GradoopId id : ids) {
@@ -210,10 +210,10 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
   }
 
   /**
-   * Checks if any of the specified ids is contained in the list.
+   * Checks if any of the specified ids is contained in the set.
    *
    * @param ids the ids to look for
-   * @return true, iff any of the specified ids is contained in the list
+   * @return true, iff any of the specified ids is contained in the set
    */
   public boolean containsAny(Collection<GradoopId> ids) {
     for (GradoopId id : ids) {
@@ -225,9 +225,9 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
   }
 
   /**
-   * Checks if the list is empty.
+   * Checks if the set is empty.
    *
-   * @return true, iff the list contains no elements
+   * @return true, iff the set contains no elements
    */
   public boolean isEmpty() {
     return ids.isEmpty();
@@ -251,14 +251,14 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
   /**
    * Returns the number of contained gradoop ids
    *
-   * @return number of elements in the list
+   * @return number of elements in the set
    */
   public int size() {
     return ids.size();
   }
 
   /**
-   * Returns the byte representation of that list.
+   * Returns the byte representation of that set.
    *
    * @return byte array representation
    */

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/id/GradoopIds.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/id/GradoopIds.java
@@ -36,7 +36,7 @@ import java.util.Set;
  *
  * @see GradoopId
  */
-public class GradoopIdList implements Iterable<GradoopId>, Value {
+public class GradoopIds implements Iterable<GradoopId>, Value {
   /**
    * Contains the set of gradoop ids.
    */
@@ -44,7 +44,7 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
   /**
    * Required default constructor for instantiation by serialization logic.
    */
-  public GradoopIdList() { 
+  public GradoopIds() { 
     this.ids = new HashSet<>();
   }
 
@@ -53,7 +53,7 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
    *
    * @param bytes bytes representing multiple gradoop ids
    */
-  private GradoopIdList(byte[] bytes) {
+  private GradoopIds(byte[] bytes) {
     this.ids = readIds(bytes);
   }
   
@@ -62,7 +62,7 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
    *
    * @param ids a collection of {@link GradoopId}s
    */
-  private GradoopIdList(Collection<GradoopId> ids) {
+  private GradoopIds(Collection<GradoopId> ids) {
     this.ids = new HashSet<>(ids);
   }
 
@@ -103,7 +103,7 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
    * @param ids array of gradoop ids
    * @return gradoop id set
    */
-  public static GradoopIdList fromExisting(GradoopId... ids) {
+  public static GradoopIds fromExisting(GradoopId... ids) {
     return fromExisting(Arrays.asList(ids));
   }
 
@@ -113,8 +113,8 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
    * @param ids given ids
    * @return gradoop id set
    */
-  public static GradoopIdList fromExisting(Collection<GradoopId> ids) {
-    return new GradoopIdList(ids);
+  public static GradoopIds fromExisting(Collection<GradoopId> ids) {
+    return new GradoopIds(ids);
   }
 
   /**
@@ -123,8 +123,8 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
    * @param bytes byte array representing multiple gradoop ids
    * @return gradoop id set
    */
-  public static GradoopIdList fromByteArray(byte[] bytes) {
-    return new GradoopIdList(bytes);
+  public static GradoopIds fromByteArray(byte[] bytes) {
+    return new GradoopIds(bytes);
   }
 
   /**
@@ -141,7 +141,7 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
    *
    * @param ids the ids to add
    */
-  public void addAll(GradoopIdList ids) {
+  public void addAll(GradoopIds ids) {
     this.ids.addAll(ids.ids);
   }
 
@@ -170,7 +170,7 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
    * @param ids the ids to look for
    * @return true, iff all specified ids are contained in the set
    */
-  public boolean containsAll(GradoopIdList ids) {
+  public boolean containsAll(GradoopIds ids) {
     for (GradoopId id : ids) {
       if (!this.contains(id)) {
         return false;
@@ -200,7 +200,7 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
    * @param ids the ids to look for
    * @return true, iff any of the specified ids is contained in the set
    */
-  public boolean containsAny(GradoopIdList ids) {
+  public boolean containsAny(GradoopIds ids) {
     for (GradoopId id : ids) {
       if (this.contains(id)) {
         return true;
@@ -288,8 +288,8 @@ public class GradoopIdList implements Iterable<GradoopId>, Value {
   public boolean equals(Object o) {
     boolean equal = this == o;
 
-    if (!equal && o instanceof GradoopIdList) {
-      GradoopIdList that = (GradoopIdList) o;
+    if (!equal && o instanceof GradoopIds) {
+      GradoopIds that = (GradoopIds) o;
       // same number of ids
       equal = this.size() == that.size();
 

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/Edge.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/Edge.java
@@ -17,7 +17,7 @@ package org.gradoop.common.model.impl.pojo;
 
 import org.gradoop.common.model.api.entities.EPGMEdge;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.properties.Properties;
 
 /**
@@ -53,7 +53,7 @@ public class Edge extends GraphElement implements EPGMEdge {
    */
   public Edge(final GradoopId id, final String label, final GradoopId sourceId,
     final GradoopId targetId, final Properties properties,
-    GradoopIdList graphIds) {
+    GradoopIds graphIds) {
     super(id, label, properties, graphIds);
     this.sourceId = sourceId;
     this.targetId = targetId;

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/EdgeFactory.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/EdgeFactory.java
@@ -17,7 +17,7 @@ package org.gradoop.common.model.impl.pojo;
 
 import org.gradoop.common.model.api.entities.EPGMEdgeFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.common.util.GradoopConstants;
 
@@ -102,7 +102,7 @@ public class EdgeFactory implements EPGMEdgeFactory<Edge>, Serializable {
    */
   @Override
   public Edge createEdge(String label, GradoopId sourceVertexId,
-    GradoopId targetVertexId, GradoopIdList graphIds) {
+    GradoopId targetVertexId, GradoopIds graphIds) {
     return initEdge(GradoopId.get(),
       label, sourceVertexId, targetVertexId, graphIds);
   }
@@ -113,7 +113,7 @@ public class EdgeFactory implements EPGMEdgeFactory<Edge>, Serializable {
   @Override
   public Edge initEdge(final GradoopId id, final String label,
     final GradoopId sourceVertexId, final GradoopId targetVertexId,
-    GradoopIdList graphs) {
+    GradoopIds graphs) {
     return initEdge(id, label, sourceVertexId, targetVertexId, null, graphs);
   }
 
@@ -123,7 +123,7 @@ public class EdgeFactory implements EPGMEdgeFactory<Edge>, Serializable {
   @Override
   public Edge createEdge(String label, GradoopId sourceVertexId,
     GradoopId targetVertexId, Properties properties,
-    GradoopIdList graphIds) {
+    GradoopIds graphIds) {
     return initEdge(GradoopId.get(),
       label, sourceVertexId, targetVertexId, properties, graphIds);
   }
@@ -134,7 +134,7 @@ public class EdgeFactory implements EPGMEdgeFactory<Edge>, Serializable {
   @Override
   public Edge initEdge(final GradoopId id, final String label,
     final GradoopId sourceVertexId, final GradoopId targetVertexId,
-    final Properties properties, GradoopIdList graphIds) {
+    final Properties properties, GradoopIds graphIds) {
     checkNotNull(id, "Identifier was null");
     checkNotNull(label, "Label was null");
     checkNotNull(sourceVertexId, "Source vertex id was null");

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/GraphElement.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/GraphElement.java
@@ -17,7 +17,7 @@ package org.gradoop.common.model.impl.pojo;
 
 import org.gradoop.common.model.api.entities.EPGMGraphElement;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.properties.Properties;
 
 /**
@@ -31,7 +31,7 @@ public abstract class GraphElement
   /**
    * Set of graph identifiers that element is contained in
    */
-  private GradoopIdList graphIds;
+  private GradoopIds graphIds;
 
   /**
    * Default constructor.
@@ -47,7 +47,7 @@ public abstract class GraphElement
    * @param graphIds     graphIds that element is contained in
    */
   protected GraphElement(GradoopId id, String label,
-    Properties properties, GradoopIdList graphIds) {
+    Properties properties, GradoopIds graphIds) {
     super(id, label, properties);
     this.graphIds = graphIds;
   }
@@ -56,7 +56,7 @@ public abstract class GraphElement
    * {@inheritDoc}
    */
   @Override
-  public GradoopIdList getGraphIds() {
+  public GradoopIds getGraphIds() {
     return graphIds;
   }
 
@@ -66,7 +66,7 @@ public abstract class GraphElement
   @Override
   public void addGraphId(GradoopId graphId) {
     if (graphIds == null) {
-      graphIds = new GradoopIdList();
+      graphIds = new GradoopIds();
     }
     graphIds.add(graphId);
   }
@@ -75,7 +75,7 @@ public abstract class GraphElement
    * {@inheritDoc}
    */
   @Override
-  public void setGraphIds(GradoopIdList graphIds) {
+  public void setGraphIds(GradoopIds graphIds) {
     this.graphIds = graphIds;
   }
 

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/Vertex.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/Vertex.java
@@ -17,7 +17,7 @@ package org.gradoop.common.model.impl.pojo;
 
 import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.properties.Properties;
 
 /**
@@ -40,7 +40,7 @@ public class Vertex extends GraphElement implements EPGMVertex {
    * @param graphs     graphs that vertex is contained in
    */
   public Vertex(final GradoopId id, final String label,
-    final Properties properties, final GradoopIdList graphs) {
+    final Properties properties, final GradoopIds graphs) {
     super(id, label, properties, graphs);
   }
 

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/VertexFactory.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/VertexFactory.java
@@ -18,7 +18,7 @@ package org.gradoop.common.model.impl.pojo;
 import com.google.common.base.Preconditions;
 import org.gradoop.common.model.api.entities.EPGMVertexFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.common.util.GradoopConstants;
 
@@ -87,7 +87,7 @@ public class VertexFactory implements EPGMVertexFactory<Vertex>, Serializable {
    * {@inheritDoc}
    */
   @Override
-  public Vertex createVertex(String label, GradoopIdList graphIds) {
+  public Vertex createVertex(String label, GradoopIds graphIds) {
     return initVertex(GradoopId.get(), label, graphIds);
   }
 
@@ -96,7 +96,7 @@ public class VertexFactory implements EPGMVertexFactory<Vertex>, Serializable {
    */
   @Override
   public Vertex initVertex(final GradoopId vertexID, final String label,
-    final GradoopIdList graphs) {
+    final GradoopIds graphs) {
     return initVertex(vertexID, label, null, graphs);
   }
 
@@ -105,7 +105,7 @@ public class VertexFactory implements EPGMVertexFactory<Vertex>, Serializable {
    */
   @Override
   public Vertex createVertex(String label, Properties properties,
-    GradoopIdList graphIds) {
+    GradoopIds graphIds) {
     return initVertex(GradoopId.get(), label, properties, graphIds);
   }
 
@@ -114,7 +114,7 @@ public class VertexFactory implements EPGMVertexFactory<Vertex>, Serializable {
    */
   @Override
   public Vertex initVertex(final GradoopId id, final String label,
-    final Properties properties, final GradoopIdList graphs) {
+    final Properties properties, final GradoopIds graphs) {
     Preconditions.checkNotNull(id, "Identifier was null");
     Preconditions.checkNotNull(label, "Label was null");
     return new Vertex(id, label, properties, graphs);

--- a/gradoop-common/src/main/java/org/gradoop/common/util/AsciiGraphLoader.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/util/AsciiGraphLoader.java
@@ -24,7 +24,7 @@ import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.common.model.impl.id.GradoopId;
 import org.gradoop.common.config.GradoopConfig;
 import org.gradoop.common.model.api.entities.EPGMEdge;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.s1ck.gdl.GDLHandler;
 import org.s1ck.gdl.model.Edge;
@@ -295,7 +295,7 @@ public class AsciiGraphLoader
    * @param graphIds graph identifiers
    * @return vertices that are contained in the graphs
    */
-  public Collection<V> getVerticesByGraphIds(GradoopIdList graphIds) {
+  public Collection<V> getVerticesByGraphIds(GradoopIds graphIds) {
     Collection<V> result = Sets.newHashSetWithExpectedSize(graphIds.size());
     for (V vertex : vertices.values()) {
       if (vertex.getGraphIds().containsAny(graphIds)) {
@@ -312,7 +312,7 @@ public class AsciiGraphLoader
    * @return vertices that are contained in the graphs
    */
   public Collection<V> getVerticesByGraphVariables(String... graphVariables) {
-    GradoopIdList graphIds = new GradoopIdList();
+    GradoopIds graphIds = new GradoopIds();
     for (G graphHead : getGraphHeadsByVariables(graphVariables)) {
       graphIds.add(graphHead.getId());
     }
@@ -365,7 +365,7 @@ public class AsciiGraphLoader
    * @param graphIds Graph identifiers
    * @return edges
    */
-  public Collection<E>  getEdgesByGraphIds(GradoopIdList graphIds) {
+  public Collection<E>  getEdgesByGraphIds(GradoopIds graphIds) {
     Collection<E>  result = Sets.newHashSetWithExpectedSize(graphIds.size());
     for (E edge : edges.values()) {
       if (edge.getGraphIds().containsAny(graphIds)) {
@@ -382,7 +382,7 @@ public class AsciiGraphLoader
    * @return edges
    */
   public Collection<E>  getEdgesByGraphVariables(String... variables) {
-    GradoopIdList graphIds = new GradoopIdList();
+    GradoopIds graphIds = new GradoopIds();
     for (G graphHead : getGraphHeadsByVariables(variables)) {
       graphIds.add(graphHead.getId());
     }
@@ -573,8 +573,8 @@ public class AsciiGraphLoader
    * @param e graph element
    * @return GradoopIDSet for the given element
    */
-  private GradoopIdList createGradoopIdSet(GraphElement e) {
-    GradoopIdList result = new GradoopIdList();
+  private GradoopIds createGradoopIdSet(GraphElement e) {
+    GradoopIds result = new GradoopIds();
     for (Long graphId : e.getGraphs()) {
       result.add(graphHeadIds.get(graphId));
     }

--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/id/GradoopIdListTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/id/GradoopIdListTest.java
@@ -47,13 +47,13 @@ public class GradoopIdListTest {
     ids.add(id1);
     assertThat(ids.size(), is(1));
     assertTrue(ids.contains(id1));
-    // must change
+    // must not change
     ids.add(id1);
-    assertThat(ids.size(), is(2));
+    assertThat(ids.size(), is(1));
     assertTrue(ids.contains(id1));
     // must change
     ids.add(id2);
-    assertThat(ids.size(), is(3));
+    assertThat(ids.size(), is(2));
     assertTrue(ids.contains(id1));
     assertTrue(ids.contains(id2));
   }
@@ -86,7 +86,7 @@ public class GradoopIdListTest {
     assertFalse(ids.contains(id3));
 
     ids.addAll(Arrays.asList(id1, id2));
-    assertThat(ids.size(), is(4));
+    assertThat(ids.size(), is(2));
   }
 
   @Test
@@ -105,7 +105,7 @@ public class GradoopIdListTest {
     assertTrue(list2.contains(id2));
 
     list2.addAll(list1);
-    assertThat(list2.size(), is(4));  }
+    assertThat(list2.size(), is(2));  }
 
   @Test
   public void testContainsAllCollection() throws Exception {
@@ -257,9 +257,9 @@ public class GradoopIdListTest {
     ids.add(id1);
     assertThat(ids.size(), is(1));
     ids.add(id1);
-    assertThat(ids.size(), is(2));
+    assertThat(ids.size(), is(1));
     ids.add(id2);
-    assertThat(ids.size(), is(3));
+    assertThat(ids.size(), is(2));
   }
 
   @Test
@@ -286,17 +286,17 @@ public class GradoopIdListTest {
     assertTrue("hashCode failed for same ids in same order", abc.hashCode() == abc2.hashCode());
 
     GradoopIdList cba = GradoopIdList.fromExisting(c, b, a);
-    assertTrue("equals failed for same ids in different order", !abc.equals(cba));
-    assertTrue("hashCode failed for same ids in different order", abc.hashCode() == cba.hashCode());
+    assertTrue("equals succeeds for same ids in different order", abc.equals(cba));
+    assertTrue("hashCode succeeds for same ids in different order", abc.hashCode() == cba.hashCode());
 
     GradoopIdList aab = GradoopIdList.fromExisting(a, a, b);
     GradoopIdList abb = GradoopIdList.fromExisting(a, b, b);
-    assertTrue("equals failed for same ids in different cardinality", !aab.equals(abb));
-    assertTrue("hashCode failed for same ids in different cardinality", aab.hashCode() != abb.hashCode());
+    assertTrue("equals succeeds for same ids in different cardinality", aab.equals(abb));
+    assertTrue("hashCode succeeds for same ids in different cardinality", aab.hashCode() == abb.hashCode());
 
     GradoopIdList ab = GradoopIdList.fromExisting(a, b);
-    assertTrue("equals failed for same ids but different sizes", !aab.equals(ab));
-    assertTrue("hashCode failed for same ids but different sizes", aab.hashCode() != ab.hashCode());
+    assertTrue("equals succeeds for same ids but different sizes", aab.equals(ab));
+    assertTrue("hashCode succeeds for same ids but different sizes", aab.hashCode() == ab.hashCode());
 
     GradoopIdList empty = new GradoopIdList();
     assertTrue("equals failed for one empty list", !abc.equals(empty));

--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/id/GradoopIdListTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/id/GradoopIdListTest.java
@@ -40,7 +40,7 @@ public class GradoopIdListTest {
     GradoopId id1 = GradoopId.get();
     GradoopId id2 = GradoopId.get();
 
-    GradoopIdList ids = new GradoopIdList();
+    GradoopIds ids = new GradoopIds();
 
     assertThat(ids.size(), is(0));
 
@@ -63,7 +63,7 @@ public class GradoopIdListTest {
     GradoopId id1 = GradoopId.get();
     GradoopId id2 = GradoopId.get();
 
-    GradoopIdList ids = new GradoopIdList();
+    GradoopIds ids = new GradoopIds();
     ids.add(id1);
 
     assertThat(ids.size(), is(1));
@@ -77,7 +77,7 @@ public class GradoopIdListTest {
     GradoopId id2 = GradoopId.get();
     GradoopId id3 = GradoopId.get();
 
-    GradoopIdList ids = new GradoopIdList();
+    GradoopIds ids = new GradoopIds();
     ids.addAll(Arrays.asList(id1, id2));
 
     assertThat(ids.size(), is(2));
@@ -93,11 +93,11 @@ public class GradoopIdListTest {
   public void testAddAllGradoopIdList() throws Exception {
     GradoopId id1 = GradoopId.get();
     GradoopId id2 = GradoopId.get();
-    GradoopIdList list1 = new GradoopIdList();
+    GradoopIds list1 = new GradoopIds();
     list1.add(id1);
     list1.add(id2);
 
-    GradoopIdList list2 = new GradoopIdList();
+    GradoopIds list2 = new GradoopIds();
     list2.addAll(list1);
 
     assertThat(list2.size(), is(2));
@@ -113,7 +113,7 @@ public class GradoopIdListTest {
     GradoopId id2 = GradoopId.get();
     GradoopId id3 = GradoopId.get();
 
-    GradoopIdList ids = new GradoopIdList();
+    GradoopIds ids = new GradoopIds();
     ids.addAll(Arrays.asList(id1, id2));
 
     assertTrue(ids.containsAll(Arrays.asList(id1)));
@@ -130,14 +130,14 @@ public class GradoopIdListTest {
     GradoopId id3 = GradoopId.get();
 
 
-    GradoopIdList ids = new GradoopIdList();
+    GradoopIds ids = new GradoopIds();
     ids.addAll(Arrays.asList(id1, id2));
 
-    assertTrue(ids.containsAll(GradoopIdList.fromExisting(id1)));
-    assertTrue(ids.containsAll(GradoopIdList.fromExisting(id2)));
-    assertTrue(ids.containsAll(GradoopIdList.fromExisting(id1, id2)));
-    assertFalse(ids.containsAll(GradoopIdList.fromExisting(id3)));
-    assertFalse(ids.containsAll(GradoopIdList.fromExisting(id1, id3)));
+    assertTrue(ids.containsAll(GradoopIds.fromExisting(id1)));
+    assertTrue(ids.containsAll(GradoopIds.fromExisting(id2)));
+    assertTrue(ids.containsAll(GradoopIds.fromExisting(id1, id2)));
+    assertFalse(ids.containsAll(GradoopIds.fromExisting(id3)));
+    assertFalse(ids.containsAll(GradoopIds.fromExisting(id1, id3)));
   }
 
   @Test
@@ -147,7 +147,7 @@ public class GradoopIdListTest {
     GradoopId id3 = GradoopId.get();
 
 
-    GradoopIdList ids = new GradoopIdList();
+    GradoopIds ids = new GradoopIds();
     ids.addAll(Arrays.asList(id1, id2));
 
     assertTrue(ids.containsAny(Arrays.asList(id1)));
@@ -163,20 +163,20 @@ public class GradoopIdListTest {
     GradoopId id2 = GradoopId.get();
     GradoopId id3 = GradoopId.get();
 
-    GradoopIdList ids = new GradoopIdList();
+    GradoopIds ids = new GradoopIds();
     ids.addAll(Arrays.asList(id1, id2));
 
-    assertTrue(ids.containsAny(GradoopIdList.fromExisting(id1)));
-    assertTrue(ids.containsAny(GradoopIdList.fromExisting(id2)));
-    assertTrue(ids.containsAny(GradoopIdList.fromExisting(id1, id2)));
-    assertFalse(ids.containsAny(GradoopIdList.fromExisting(id3)));
-    assertTrue(ids.containsAny(GradoopIdList.fromExisting(id1, id3)));
+    assertTrue(ids.containsAny(GradoopIds.fromExisting(id1)));
+    assertTrue(ids.containsAny(GradoopIds.fromExisting(id2)));
+    assertTrue(ids.containsAny(GradoopIds.fromExisting(id1, id2)));
+    assertFalse(ids.containsAny(GradoopIds.fromExisting(id3)));
+    assertTrue(ids.containsAny(GradoopIds.fromExisting(id1, id3)));
   }
 
   @Test
   public void testIsEmpty() throws Exception {
-    GradoopIdList set1 = GradoopIdList.fromExisting(GradoopId.get());
-    GradoopIdList set2 = new GradoopIdList();
+    GradoopIds set1 = GradoopIds.fromExisting(GradoopId.get());
+    GradoopIds set2 = new GradoopIds();
 
     assertFalse(set1.isEmpty());
     assertTrue(set2.isEmpty());
@@ -187,7 +187,7 @@ public class GradoopIdListTest {
     GradoopId id1 = GradoopId.get();
     GradoopId id2 = GradoopId.get();
 
-    GradoopIdList idsWrite = GradoopIdList.fromExisting(id1, id2);
+    GradoopIds idsWrite = GradoopIds.fromExisting(id1, id2);
 
     // write to byte[]
     ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -195,7 +195,7 @@ public class GradoopIdListTest {
     idsWrite.write(dataOutputView);
 
     // read from byte[]
-    GradoopIdList idsRead = new GradoopIdList();
+    GradoopIds idsRead = new GradoopIds();
     ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
     DataInputView dataInputView = new DataInputViewStreamWrapper(in);
     idsRead.read(dataInputView);
@@ -210,7 +210,7 @@ public class GradoopIdListTest {
     GradoopId id1 = GradoopId.get();
     GradoopId id2 = GradoopId.get();
 
-    GradoopIdList ids = GradoopIdList.fromExisting(id1, id2);
+    GradoopIds ids = GradoopIds.fromExisting(id1, id2);
 
     Iterator<GradoopId> idsIterator = ids.iterator();
 
@@ -223,7 +223,7 @@ public class GradoopIdListTest {
 
   @Test(expected = NoSuchElementException.class)
   public void testIteratorException() throws Exception {
-    GradoopIdList ids = new GradoopIdList();
+    GradoopIds ids = new GradoopIds();
 
     Iterator<GradoopId> idsIterator = ids.iterator();
 
@@ -236,7 +236,7 @@ public class GradoopIdListTest {
     GradoopId id1 = GradoopId.get();
     GradoopId id2 = GradoopId.get();
 
-    GradoopIdList ids = new GradoopIdList();
+    GradoopIds ids = new GradoopIds();
     ids.add(id1);
     ids.add(id2);
 
@@ -252,7 +252,7 @@ public class GradoopIdListTest {
     GradoopId id1 = GradoopId.get();
     GradoopId id2 = GradoopId.get();
 
-    GradoopIdList ids = new GradoopIdList();
+    GradoopIds ids = new GradoopIds();
     assertThat(ids.size(), is(0));
     ids.add(id1);
     assertThat(ids.size(), is(1));
@@ -267,7 +267,7 @@ public class GradoopIdListTest {
     GradoopId id1 = GradoopId.get();
     GradoopId id2 = GradoopId.get();
     GradoopId id3 = GradoopId.get();
-    GradoopIdList ids = GradoopIdList.fromExisting(id1, id2, id3);
+    GradoopIds ids = GradoopIds.fromExisting(id1, id2, id3);
     assertThat(ids.size(), is(3));
   }
 
@@ -277,32 +277,32 @@ public class GradoopIdListTest {
     GradoopId b = GradoopId.get();
     GradoopId c = GradoopId.get();
 
-    GradoopIdList abc = GradoopIdList.fromExisting(a, b, c);
+    GradoopIds abc = GradoopIds.fromExisting(a, b, c);
     assertTrue("equals failed for same object", abc.equals(abc));
     assertTrue("hashCode failed for same object", abc.hashCode() == abc.hashCode());
 
-    GradoopIdList abc2 = GradoopIdList.fromExisting(a, b, c);
+    GradoopIds abc2 = GradoopIds.fromExisting(a, b, c);
     assertTrue("equals failed for same ids in same order", abc.equals(abc2));
     assertTrue("hashCode failed for same ids in same order", abc.hashCode() == abc2.hashCode());
 
-    GradoopIdList cba = GradoopIdList.fromExisting(c, b, a);
+    GradoopIds cba = GradoopIds.fromExisting(c, b, a);
     assertTrue("equals succeeds for same ids in different order", abc.equals(cba));
     assertTrue("hashCode succeeds for same ids in different order", abc.hashCode() == cba.hashCode());
 
-    GradoopIdList aab = GradoopIdList.fromExisting(a, a, b);
-    GradoopIdList abb = GradoopIdList.fromExisting(a, b, b);
+    GradoopIds aab = GradoopIds.fromExisting(a, a, b);
+    GradoopIds abb = GradoopIds.fromExisting(a, b, b);
     assertTrue("equals succeeds for same ids in different cardinality", aab.equals(abb));
     assertTrue("hashCode succeeds for same ids in different cardinality", aab.hashCode() == abb.hashCode());
 
-    GradoopIdList ab = GradoopIdList.fromExisting(a, b);
+    GradoopIds ab = GradoopIds.fromExisting(a, b);
     assertTrue("equals succeeds for same ids but different sizes", aab.equals(ab));
     assertTrue("hashCode succeeds for same ids but different sizes", aab.hashCode() == ab.hashCode());
 
-    GradoopIdList empty = new GradoopIdList();
+    GradoopIds empty = new GradoopIds();
     assertTrue("equals failed for one empty list", !abc.equals(empty));
     assertTrue("hashCode failed for one empty list", abc.hashCode() != empty.hashCode());
 
-    GradoopIdList empty2 = new GradoopIdList();
+    GradoopIds empty2 = new GradoopIds();
     assertTrue("equals failed for two empty lists", empty2.equals(empty));
     assertTrue("hashCode failed two one empty lists", empty2.hashCode() == empty.hashCode());
   }

--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/id/GradoopIdsTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/id/GradoopIdsTest.java
@@ -33,7 +33,7 @@ import java.util.NoSuchElementException;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
-public class GradoopIdListTest {
+public class GradoopIdsTest {
 
   @Test
   public void testAdd() throws Exception {
@@ -90,7 +90,7 @@ public class GradoopIdListTest {
   }
 
   @Test
-  public void testAddAllGradoopIdList() throws Exception {
+  public void testAddAllGradoopIds() throws Exception {
     GradoopId id1 = GradoopId.get();
     GradoopId id2 = GradoopId.get();
     GradoopIds list1 = new GradoopIds();
@@ -124,7 +124,7 @@ public class GradoopIdListTest {
   }
 
   @Test
-  public void testContainsAllGradoopIdList() throws Exception {
+  public void testContainsAllGradoopIds() throws Exception {
     GradoopId id1 = GradoopId.get();
     GradoopId id2 = GradoopId.get();
     GradoopId id3 = GradoopId.get();

--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/pojo/EdgeTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/pojo/EdgeTest.java
@@ -17,7 +17,7 @@ package org.gradoop.common.model.impl.pojo;
 
 import org.gradoop.common.model.api.entities.EPGMEdge;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.common.util.GradoopConstants;
 import org.hamcrest.core.Is;
@@ -47,7 +47,7 @@ public class EdgeTest {
     GradoopId edgeId = GradoopId.get();
     GradoopId sourceId = GradoopId.get();
     GradoopId targetId = GradoopId.get();
-    GradoopIdList graphIds = GradoopIdList
+    GradoopIds graphIds = GradoopIds
       .fromExisting(GradoopId.get(), GradoopId.get());
 
     String label = "A";

--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/pojo/VertexTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/pojo/VertexTest.java
@@ -17,7 +17,7 @@ package org.gradoop.common.model.impl.pojo;
 
 import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.common.util.GradoopConstants;
 import org.hamcrest.core.Is;
@@ -48,7 +48,7 @@ public class VertexTest {
     GradoopId graphId1 = GradoopId.get();
     GradoopId graphId2 = GradoopId.get();
 
-    GradoopIdList graphIds = new GradoopIdList();
+    GradoopIds graphIds = new GradoopIds();
     graphIds.add(graphId1);
     graphIds.add(graphId2);
 

--- a/gradoop-common/src/test/java/org/gradoop/common/util/AsciiGraphLoaderTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/util/AsciiGraphLoaderTest.java
@@ -16,7 +16,7 @@
 package org.gradoop.common.util;
 
 import org.gradoop.common.config.GradoopConfig;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -149,13 +149,13 @@ public class AsciiGraphLoaderTest {
     GraphHead h = asciiGraphLoader.getGraphHeadByVariable("h");
 
     Collection<Vertex> vertexsG = asciiGraphLoader
-      .getVerticesByGraphIds(GradoopIdList.fromExisting(g.getId()));
+      .getVerticesByGraphIds(GradoopIds.fromExisting(g.getId()));
 
     Collection<Vertex> vertexsH = asciiGraphLoader
-      .getVerticesByGraphIds(GradoopIdList.fromExisting(h.getId()));
+      .getVerticesByGraphIds(GradoopIds.fromExisting(h.getId()));
 
     Collection<Vertex> vertexsGH = asciiGraphLoader
-      .getVerticesByGraphIds(GradoopIdList.fromExisting(g.getId(), h.getId()));
+      .getVerticesByGraphIds(GradoopIds.fromExisting(g.getId(), h.getId()));
 
     Vertex a = asciiGraphLoader.getVertexByVariable("a");
     Vertex b = asciiGraphLoader.getVertexByVariable("b");
@@ -252,13 +252,13 @@ public class AsciiGraphLoaderTest {
     GraphHead h = asciiGraphLoader.getGraphHeadByVariable("h");
 
     Collection<Edge> edgesG = asciiGraphLoader
-      .getEdgesByGraphIds(GradoopIdList.fromExisting(g.getId()));
+      .getEdgesByGraphIds(GradoopIds.fromExisting(g.getId()));
 
     Collection<Edge> edgesH = asciiGraphLoader
-      .getEdgesByGraphIds(GradoopIdList.fromExisting(h.getId()));
+      .getEdgesByGraphIds(GradoopIds.fromExisting(h.getId()));
 
     Collection<Edge> edgesGH = asciiGraphLoader
-      .getEdgesByGraphIds(GradoopIdList.fromExisting(g.getId(), h.getId()));
+      .getEdgesByGraphIds(GradoopIds.fromExisting(g.getId(), h.getId()));
 
     Edge a = asciiGraphLoader.getEdgeByVariable("a");
     Edge b = asciiGraphLoader.getEdgeByVariable("b");

--- a/gradoop-examples/src/main/java/org/gradoop/benchmark/patternmatching/TransactionalBenchmark.java
+++ b/gradoop-examples/src/main/java/org/gradoop/benchmark/patternmatching/TransactionalBenchmark.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.examples.AbstractRunner;
 import org.gradoop.flink.io.impl.tlf.TLFDataSource;
 import org.gradoop.flink.model.impl.operators.matching.transactional.TransactionalPatternMatching;
@@ -103,7 +103,7 @@ public class TransactionalBenchmark extends AbstractRunner {
         .map(new GraphTransactionMatcher(queryString));
 
     if (returnEmbeddings) {
-      DataSet<Tuple4<GradoopId, GradoopId, GradoopIdList, GradoopIdList>> embeddings =
+      DataSet<Tuple4<GradoopId, GradoopId, GradoopIds, GradoopIds>> embeddings =
         graphs.flatMap(
           new FindEmbeddings(new DepthSearchMatching(), queryString));
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/BusinessTransactionGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/BusinessTransactionGraphs.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.types.NullValue;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -100,7 +100,7 @@ public class BusinessTransactionGraphs implements
       .runScatterGatherIteration(new BtgMessenger(), new BtgUpdater() , 100);
 
 
-    DataSet<Tuple2<GradoopId, GradoopIdList>> btgVerticesMap = gellyTransGraph
+    DataSet<Tuple2<GradoopId, GradoopIds>> btgVerticesMap = gellyTransGraph
       .getVerticesAsTuple2()
       .map(new SwitchPair<>())
       .groupBy(0)
@@ -135,7 +135,7 @@ public class BusinessTransactionGraphs implements
       .with(new LeftSide<>())
       .distinct();
 
-    DataSet<Tuple2<GradoopId, GradoopIdList>> vertexBtgsMap = vertexBtgMap
+    DataSet<Tuple2<GradoopId, GradoopIds>> vertexBtgsMap = vertexBtgMap
       .groupBy(0)
       //.combineGroup(new CollectGradoopIds())
       .reduceGroup(new CollectGradoopIds());

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/functions/CollectGradoopIds.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/functions/CollectGradoopIds.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * (a,b),(a,c) => (a,{b,c})
@@ -28,17 +28,17 @@ import org.gradoop.common.model.impl.id.GradoopIdList;
  */
 public class CollectGradoopIds implements
   GroupCombineFunction
-    <Tuple2<GradoopId, GradoopIdList>, Tuple2<GradoopId, GradoopIdList>>,
+    <Tuple2<GradoopId, GradoopIds>, Tuple2<GradoopId, GradoopIds>>,
   GroupReduceFunction
-    <Tuple2<GradoopId, GradoopId>, Tuple2<GradoopId, GradoopIdList>> {
+    <Tuple2<GradoopId, GradoopId>, Tuple2<GradoopId, GradoopIds>> {
 
   @Override
   public void reduce(Iterable<Tuple2<GradoopId, GradoopId>> mappings,
-    Collector<Tuple2<GradoopId, GradoopIdList>> collector) throws Exception {
+    Collector<Tuple2<GradoopId, GradoopIds>> collector) throws Exception {
 
     Boolean first = true;
     GradoopId vertexId = null;
-    GradoopIdList btgIds = new GradoopIdList();
+    GradoopIds btgIds = new GradoopIds();
 
     for (Tuple2<GradoopId, GradoopId> pair : mappings) {
       if (first) {
@@ -51,14 +51,14 @@ public class CollectGradoopIds implements
   }
 
   @Override
-  public void combine(Iterable<Tuple2<GradoopId, GradoopIdList>> mappings,
-    Collector<Tuple2<GradoopId, GradoopIdList>> collector) throws Exception {
+  public void combine(Iterable<Tuple2<GradoopId, GradoopIds>> mappings,
+    Collector<Tuple2<GradoopId, GradoopIds>> collector) throws Exception {
 
     Boolean first = true;
     GradoopId vertexId = null;
-    GradoopIdList btgIds = null;
+    GradoopIds btgIds = null;
 
-    for (Tuple2<GradoopId, GradoopIdList> pair : mappings) {
+    for (Tuple2<GradoopId, GradoopIds> pair : mappings) {
       if (first) {
         vertexId = pair.f0;
         btgIds = pair.f1;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/functions/ComponentToNewBtgId.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/functions/ComponentToNewBtgId.java
@@ -19,18 +19,18 @@ import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * replaces a component id by a new graph id
  */
 @FunctionAnnotation.ForwardedFields("f1->f1")
 public class ComponentToNewBtgId implements MapFunction
-  <Tuple2<GradoopId, GradoopIdList>, Tuple2<GradoopId, GradoopIdList>> {
+  <Tuple2<GradoopId, GradoopIds>, Tuple2<GradoopId, GradoopIds>> {
 
   @Override
-  public Tuple2<GradoopId, GradoopIdList> map(
-    Tuple2<GradoopId, GradoopIdList> pair) throws Exception {
+  public Tuple2<GradoopId, GradoopIds> map(
+    Tuple2<GradoopId, GradoopIds> pair) throws Exception {
 
     return new Tuple2<>(GradoopId.get(), pair.f1);
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/functions/SetBtgId.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/functions/SetBtgId.java
@@ -19,7 +19,7 @@ import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.api.entities.EPGMGraphElement;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Associates an edge with an business transaction graph.
@@ -30,7 +30,7 @@ public class SetBtgId<E extends EPGMGraphElement>
 
   @Override
   public E join(E element, Tuple2<GradoopId, GradoopId> mapping) {
-    element.setGraphIds(GradoopIdList.fromExisting(mapping.f1));
+    element.setGraphIds(GradoopIds.fromExisting(mapping.f1));
     return element;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/functions/SetBtgIds.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/functions/SetBtgIds.java
@@ -19,17 +19,17 @@ import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Associates a (master) vertex with business transaction graphs.
  * @param <V> vertex type
  */
 public class SetBtgIds<V extends EPGMVertex>
-  implements JoinFunction<V, Tuple2<GradoopId, GradoopIdList>, V> {
+  implements JoinFunction<V, Tuple2<GradoopId, GradoopIds>, V> {
 
   @Override
-  public V join(V element, Tuple2<GradoopId, GradoopIdList> mapping) throws
+  public V join(V element, Tuple2<GradoopId, GradoopIds> mapping) throws
     Exception {
     element.setGraphIds(mapping.f1);
     return element;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/fsm/dimspan/functions/conversion/DFSCodeToEPGMGraphTransaction.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/fsm/dimspan/functions/conversion/DFSCodeToEPGMGraphTransaction.java
@@ -19,7 +19,7 @@ import com.google.common.collect.Sets;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.configuration.Configuration;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -107,7 +107,7 @@ public class DFSCodeToEPGMGraphTransaction
     graphHead.setLabel(DIMSpanConstants.FREQUENT_PATTERN_LABEL);
     graphHead.setProperty(DIMSpanConstants.SUPPORT_KEY, (float) frequency / graphCount);
 
-    GradoopIdList graphIds = GradoopIdList.fromExisting(graphHead.getId());
+    GradoopIds graphIds = GradoopIds.fromExisting(graphHead.getId());
 
     // VERTICES
     int[] vertexLabels = graphUtils.getVertexLabels(pattern);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/fsm/transactional/tle/functions/SubgraphDecoder.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/fsm/transactional/tle/functions/SubgraphDecoder.java
@@ -22,7 +22,7 @@ import org.gradoop.common.model.api.entities.EPGMEdgeFactory;
 import org.gradoop.common.model.api.entities.EPGMGraphHeadFactory;
 import org.gradoop.common.model.api.entities.EPGMVertexFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -88,7 +88,7 @@ public abstract class SubgraphDecoder implements Serializable {
     GraphHead epgmGraphHead = graphHeadFactory
       .createGraphHead(canonicalLabel, properties);
 
-    GradoopIdList graphIds = GradoopIdList.fromExisting(epgmGraphHead.getId());
+    GradoopIds graphIds = GradoopIds.fromExisting(epgmGraphHead.getId());
 
     // VERTICES
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/TargetGraphIdList.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/TargetGraphIdList.java
@@ -19,7 +19,7 @@ import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 import java.util.Iterator;
 
@@ -27,11 +27,11 @@ import java.util.Iterator;
  * Reduces for each target id of an edge all the graph ids to one graph id list.
  */
 public class TargetGraphIdList
-  implements GroupReduceFunction<Tuple2<GradoopId, GradoopId>, Tuple2<GradoopId, GradoopIdList>> {
+  implements GroupReduceFunction<Tuple2<GradoopId, GradoopId>, Tuple2<GradoopId, GradoopIds>> {
 
   @Override
   public void reduce(Iterable<Tuple2<GradoopId, GradoopId>> values,
-    Collector<Tuple2<GradoopId, GradoopIdList>> out) throws Exception {
+    Collector<Tuple2<GradoopId, GradoopIds>> out) throws Exception {
 
     Iterator<Tuple2<GradoopId, GradoopId>> iterator = values.iterator();
 
@@ -39,7 +39,7 @@ public class TargetGraphIdList
 
     // the target id is the same for each iterator element
     GradoopId targetId = pair.f0;
-    GradoopIdList graphIds = GradoopIdList.fromExisting(pair.f1);
+    GradoopIds graphIds = GradoopIds.fromExisting(pair.f1);
 
     while (iterator.hasNext()) {
       graphIds.add(iterator.next().f1);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/UpdateGraphIds.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/UpdateGraphIds.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.datagen.transactions.foodbroker.functions;
 import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Vertex;
 
 /**
@@ -26,10 +26,10 @@ import org.gradoop.common.model.impl.pojo.Vertex;
  * element is the gradoop id of the vertex.
  */
 public class UpdateGraphIds
-  implements JoinFunction<Tuple2<GradoopId, GradoopIdList>, Vertex, Vertex> {
+  implements JoinFunction<Tuple2<GradoopId, GradoopIds>, Vertex, Vertex> {
 
   @Override
-  public Vertex join(Tuple2<GradoopId, GradoopIdList> pair, Vertex vertex) throws Exception {
+  public Vertex join(Tuple2<GradoopId, GradoopIds> pair, Vertex vertex) throws Exception {
     vertex.setGraphIds(pair.f1);
     return vertex;
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/process/AbstractProcess.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/process/AbstractProcess.java
@@ -24,7 +24,7 @@ import org.gradoop.common.model.api.entities.EPGMEdgeFactory;
 import org.gradoop.common.model.api.entities.EPGMGraphHeadFactory;
 import org.gradoop.common.model.api.entities.EPGMVertexFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -83,7 +83,7 @@ public abstract class AbstractProcess extends AbstractRichFunction {
   /**
    * Graph ids, one seperate id for each case.
    */
-  protected GradoopIdList graphIds;
+  protected GradoopIds graphIds;
   /**
    * Map to quickly receive the target id of an edge.
    * Note that a object may have multiple outgoing edges with the same label.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/process/Brokerage.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/process/Brokerage.java
@@ -23,7 +23,7 @@ import org.gradoop.common.model.api.entities.EPGMEdgeFactory;
 import org.gradoop.common.model.api.entities.EPGMGraphHeadFactory;
 import org.gradoop.common.model.api.entities.EPGMVertexFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -85,7 +85,7 @@ public class Brokerage
     vertexMap = Maps.newHashMap();
     edgeMap = Maps.newHashMap();
     graphHead = graphHeadFactory.createGraphHead();
-    graphIds = new GradoopIdList();
+    graphIds = new GradoopIds();
     graphIds.add(graphHead.getId());
     graphTransaction = new GraphTransaction();
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/process/ComplaintHandling.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/process/ComplaintHandling.java
@@ -25,7 +25,7 @@ import org.gradoop.common.model.api.entities.EPGMEdgeFactory;
 import org.gradoop.common.model.api.entities.EPGMGraphHeadFactory;
 import org.gradoop.common.model.api.entities.EPGMVertexFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -99,7 +99,7 @@ public class ComplaintHandling extends AbstractProcess
     vertexMap = Maps.newHashMap();
     masterDataMap = Maps.newHashMap();
     userMap = Maps.newHashMap();
-    graphIds = GradoopIdList.fromExisting(graph.getGraphHead().getId());
+    graphIds = GradoopIds.fromExisting(graph.getGraphHead().getId());
 
     boolean confirmed = false;
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/predictable/PredictableTransaction.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/predictable/PredictableTransaction.java
@@ -26,7 +26,7 @@ import org.gradoop.common.model.api.entities.EPGMEdgeFactory;
 import org.gradoop.common.model.api.entities.EPGMGraphHeadFactory;
 import org.gradoop.common.model.api.entities.EPGMVertexFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -97,7 +97,7 @@ public class PredictableTransaction implements
     Set<Vertex> vertices = Sets.newHashSet();
     Set<Edge> edges = Sets.newHashSet();
 
-    GradoopIdList graphIds = GradoopIdList.fromExisting(graphHead.getId());
+    GradoopIds graphIds = GradoopIds.fromExisting(graphHead.getId());
 
     Vertex centerVertex = vertexFactory.createVertex("S", graphIds);
     vertices.add(centerVertex);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/json/functions/EntityToJSON.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/json/functions/EntityToJSON.java
@@ -24,7 +24,7 @@ import org.gradoop.flink.io.impl.json.JSONConstants;
 import org.gradoop.common.model.api.entities.EPGMAttributed;
 import org.gradoop.common.model.api.entities.EPGMLabeled;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Contains methods used by all entity writers (e.g. write meta, data).
@@ -102,7 +102,7 @@ public class EntityToJSON {
    * @param values identifier set
    * @return json array containing the identifiers
    */
-  private JSONArray writeJsonArray(final GradoopIdList values) {
+  private JSONArray writeJsonArray(final GradoopIds values) {
     JSONArray jsonArray = new JSONArray();
     for (GradoopId val : values) {
       jsonArray.put(val);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/json/functions/JSONToEdge.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/json/functions/JSONToEdge.java
@@ -22,7 +22,7 @@ import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.flink.io.impl.json.JSONConstants;
 import org.gradoop.common.model.api.entities.EPGMEdgeFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.properties.Properties;
 
 /**
@@ -73,7 +73,7 @@ public class JSONToEdge extends JSONToEntity
     GradoopId targetID = getTargetId(jsonEdge);
     Properties properties = Properties.createFromMap(
       getProperties(jsonEdge));
-    GradoopIdList graphs = getGraphs(jsonEdge);
+    GradoopIds graphs = getGraphs(jsonEdge);
 
     return edgeFactory.initEdge(edgeID, edgeLabel, sourceID, targetID,
       properties, graphs);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/json/functions/JSONToEntity.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/json/functions/JSONToEntity.java
@@ -21,7 +21,7 @@ import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.gradoop.flink.io.impl.json.JSONConstants;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -83,10 +83,10 @@ public class JSONToEntity {
    * @return graph identifiers
    * @throws JSONException
    */
-  protected GradoopIdList getGraphs(JSONObject object) throws JSONException {
-    GradoopIdList result;
+  protected GradoopIds getGraphs(JSONObject object) throws JSONException {
+    GradoopIds result;
     if (!object.getJSONObject(JSONConstants.META).has(JSONConstants.GRAPHS)) {
-      result = new GradoopIdList();
+      result = new GradoopIds();
     } else {
       result = getArrayValues(object
           .getJSONObject(JSONConstants.META)
@@ -102,10 +102,10 @@ public class JSONToEntity {
    * @return long values
    * @throws JSONException
    */
-  protected GradoopIdList getArrayValues(JSONArray array) throws
+  protected GradoopIds getArrayValues(JSONArray array) throws
     JSONException {
 
-    GradoopIdList result = new GradoopIdList();
+    GradoopIds result = new GradoopIds();
 
     for (int i = 0; i < array.length(); i++) {
       result.add(GradoopId.fromString(array.getString(i)));

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/json/functions/JSONToVertex.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/json/functions/JSONToVertex.java
@@ -20,7 +20,7 @@ import org.codehaus.jettison.json.JSONObject;
 import org.gradoop.common.model.impl.pojo.Vertex;
 import org.gradoop.common.model.api.entities.EPGMVertexFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.properties.Properties;
 
 /**
@@ -70,7 +70,7 @@ public class JSONToVertex extends JSONToEntity
     String label = getLabel(jsonVertex);
     Properties properties = Properties.createFromMap(
       getProperties(jsonVertex));
-    GradoopIdList graphs = getGraphs(jsonVertex);
+    GradoopIds graphs = getGraphs(jsonVertex);
 
     return vertexFactory.initVertex(vertexID, label, properties, graphs);
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/GraphCollection.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/GraphCollection.java
@@ -19,7 +19,7 @@ import org.apache.commons.lang.NotImplementedException;
 import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.java.DataSet;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -197,7 +197,7 @@ public class GraphCollection implements GraphCollectionOperators, GraphCollectio
   @Override
   public GraphCollection getGraphs(final GradoopId... identifiers) {
 
-    GradoopIdList graphIds = new GradoopIdList();
+    GradoopIds graphIds = new GradoopIds();
 
     for (GradoopId id : identifiers) {
       graphIds.add(id);
@@ -210,7 +210,7 @@ public class GraphCollection implements GraphCollectionOperators, GraphCollectio
    * {@inheritDoc}
    */
   @Override
-  public GraphCollection getGraphs(final GradoopIdList identifiers) {
+  public GraphCollection getGraphs(final GradoopIds identifiers) {
 
     DataSet<GraphHead> newGraphHeads = this.getGraphHeads()
       .filter(new FilterFunction<GraphHead>() {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/GraphCollectionOperators.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/GraphCollectionOperators.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.api.epgm;
 import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.java.DataSet;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.util.Order;
 import org.gradoop.flink.model.api.functions.GraphHeadReduceFunction;
@@ -64,7 +64,7 @@ public interface GraphCollectionOperators extends GraphBaseOperators {
    * @param identifiers graph identifiers
    * @return collection containing requested logical graphs
    */
-  GraphCollection getGraphs(GradoopIdList identifiers);
+  GraphCollection getGraphs(GradoopIds identifiers);
 
   //----------------------------------------------------------------------------
   // Unary operators

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ExpandGradoopIds.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ExpandGradoopIds.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Takes a tuple 2, containing an object and a gradoop id set, and creates one
@@ -31,11 +31,11 @@ import org.gradoop.common.model.impl.id.GradoopIdList;
 @FunctionAnnotation.ReadFields("f1")
 @FunctionAnnotation.ForwardedFields("f0->f0")
 public class ExpandGradoopIds<T> implements FlatMapFunction
-  <Tuple2<T, GradoopIdList>, Tuple2<T, GradoopId>> {
+  <Tuple2<T, GradoopIds>, Tuple2<T, GradoopId>> {
 
   @Override
   public void flatMap(
-    Tuple2<T, GradoopIdList> pair,
+    Tuple2<T, GradoopIds> pair,
     Collector<Tuple2<T, GradoopId>> collector) throws Exception {
 
     T firstField = pair.f0;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdAsIdSet.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdAsIdSet.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.functions.epgm;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.gradoop.common.model.impl.pojo.Element;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Maps an element to a GradoopIdSet, containing the elements id.
@@ -27,10 +27,10 @@ import org.gradoop.common.model.impl.id.GradoopIdList;
  */
 @FunctionAnnotation.ReadFields("id")
 public class IdAsIdSet<EL extends Element>
-  implements MapFunction<EL, GradoopIdList> {
+  implements MapFunction<EL, GradoopIds> {
 
   @Override
-  public GradoopIdList map(EL element) {
-    return GradoopIdList.fromExisting(element.getId());
+  public GradoopIds map(EL element) {
+    return GradoopIds.fromExisting(element.getId());
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdSetCombiner.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdSetCombiner.java
@@ -16,17 +16,17 @@
 package org.gradoop.flink.model.impl.functions.epgm;
 
 import org.apache.flink.api.common.functions.ReduceFunction;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Reduces GradoopIdSets into a single, distinct one.
  *
  */
 public class IdSetCombiner
-  implements ReduceFunction<GradoopIdList> {
+  implements ReduceFunction<GradoopIds> {
 
   @Override
-  public GradoopIdList reduce(GradoopIdList in1, GradoopIdList in2) {
+  public GradoopIds reduce(GradoopIds in1, GradoopIds in2) {
     in1.addAll(in2);
     return in1;
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/MergedGraphIds.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/MergedGraphIds.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.pojo.EdgeFactory;
 import org.gradoop.common.model.impl.pojo.GraphElement;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 import java.util.Iterator;
 
@@ -47,7 +47,7 @@ public class MergedGraphIds<GE extends GraphElement>
   public void reduce(Iterable<GE> values, Collector<GE> out) throws Exception {
     Iterator<GE> iterator = values.iterator();
     GE result = iterator.next();
-    GradoopIdList graphIds = result.getGraphIds();
+    GradoopIds graphIds = result.getGraphIds();
     while (iterator.hasNext()) {
       graphIds.addAll(iterator.next().getGraphIds());
     }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ToGradoopIdSet.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ToGradoopIdSet.java
@@ -18,19 +18,19 @@ package org.gradoop.flink.model.impl.functions.epgm;
 import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * id1,..,idn => {id1,..,idn}
  */
 public class ToGradoopIdSet
-  implements GroupReduceFunction<GradoopId, GradoopIdList> {
+  implements GroupReduceFunction<GradoopId, GradoopIds> {
 
   @Override
   public void reduce(Iterable<GradoopId> iterable,
-    Collector<GradoopIdList> collector) throws Exception {
+    Collector<GradoopIds> collector) throws Exception {
 
-    GradoopIdList ids = new GradoopIdList();
+    GradoopIds ids = new GradoopIds();
 
     for (GradoopId id : iterable) {
       ids.add(id);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/ExpandGraphsToIdSet.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/ExpandGraphsToIdSet.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.functions.graphcontainment;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.gradoop.common.model.impl.pojo.GraphElement;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Maps an element to a GradoopIdSet of all graph ids the element is
@@ -30,10 +30,10 @@ import org.gradoop.common.model.impl.id.GradoopIdList;
  */
 @FunctionAnnotation.ForwardedFields("graphIds->*")
 public class ExpandGraphsToIdSet<GE extends GraphElement>
-  implements MapFunction<GE, GradoopIdList> {
+  implements MapFunction<GE, GradoopIds> {
 
   @Override
-  public GradoopIdList map(GE ge) {
+  public GradoopIds map(GE ge) {
     return ge.getGraphIds();
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/InAllGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/InAllGraphs.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.functions.graphcontainment;
 import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.gradoop.common.model.impl.pojo.GraphElement;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * True, if an element is contained in all of a set of given graphs.
@@ -32,14 +32,14 @@ public class InAllGraphs<GE extends GraphElement>
   /**
    * graph ids
    */
-  private final GradoopIdList graphIds;
+  private final GradoopIds graphIds;
 
   /**
    * constructor
    *
    * @param graphIds graph ids
    */
-  public InAllGraphs(GradoopIdList graphIds) {
+  public InAllGraphs(GradoopIds graphIds) {
     this.graphIds = graphIds;
   }
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/InAnyGraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/InAnyGraph.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.functions.graphcontainment;
 import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.gradoop.common.model.impl.pojo.GraphElement;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * True, if an element is contained in any of a set of given graphs.
@@ -32,13 +32,13 @@ public class InAnyGraph<GE extends GraphElement>
   /**
    * graph ids
    */
-  private final GradoopIdList graphIds;
+  private final GradoopIds graphIds;
 
   /**
    * constructor
    * @param graphIds graph ids
    */
-  public InAnyGraph(GradoopIdList graphIds) {
+  public InAnyGraph(GradoopIds graphIds) {
     this.graphIds = graphIds;
   }
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/cloning/functions/ElementGraphUpdater.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/cloning/functions/ElementGraphUpdater.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.configuration.Configuration;
 import org.gradoop.common.model.impl.pojo.GraphElement;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Replaces the graph set of each element by a new one, containing only the
@@ -54,7 +54,7 @@ public class ElementGraphUpdater<EL extends GraphElement>
    */
   @Override
   public EL map(EL element) {
-    element.setGraphIds(GradoopIdList.fromExisting(graphId));
+    element.setGraphIds(GradoopIds.fromExisting(graphId));
     return element;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/functions/TransposeVertexGroupItems.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/functions/TransposeVertexGroupItems.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.flink.model.impl.operators.grouping.tuples.LabelGroup;
 import org.gradoop.flink.model.impl.operators.grouping.tuples.VertexGroupItem;
 import org.gradoop.common.model.impl.properties.PropertyValueList;
@@ -106,7 +106,7 @@ public class TransposeVertexGroupItems
     }
 
     reuseInnerTuple.setId(superVertexId);
-    reuseInnerTuple.setIdSet(GradoopIdList.fromExisting(superVertexIds));
+    reuseInnerTuple.setIdSet(GradoopIds.fromExisting(superVertexIds));
 
     reuseOuterTuple.f0 = createSuperVertexTuple(superVertexId, groupLabel,
       groupPropertyValues, vertexLabelGroup.getAggregators());

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/TransactionalPatternMatching.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/TransactionalPatternMatching.java
@@ -19,7 +19,7 @@ import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -177,7 +177,7 @@ public class TransactionalPatternMatching implements UnaryCollectionToCollection
     //--------------------------------------------------------------------------
     // run the matching algorithm
     //--------------------------------------------------------------------------
-    DataSet<Tuple4<GradoopId, GradoopId, GradoopIdList, GradoopIdList>> embeddings = graphs
+    DataSet<Tuple4<GradoopId, GradoopId, GradoopIds, GradoopIds>> embeddings = graphs
       .flatMap(new FindEmbeddings(algorithm, query));
 
     //--------------------------------------------------------------------------
@@ -190,7 +190,7 @@ public class TransactionalPatternMatching implements UnaryCollectionToCollection
     //--------------------------------------------------------------------------
     // update vertex graphs
     //--------------------------------------------------------------------------
-    DataSet<Tuple2<GradoopId, GradoopIdList>> verticesWithGraphs = embeddings
+    DataSet<Tuple2<GradoopId, GradoopIds>> verticesWithGraphs = embeddings
       .map(new Project4To0And2AndSwitch<>())
       .flatMap(new ExpandFirstField<>()).groupBy(0)
       .reduceGroup(new MergeSecondField<>());
@@ -203,7 +203,7 @@ public class TransactionalPatternMatching implements UnaryCollectionToCollection
     //--------------------------------------------------------------------------
     // update edge graphs
     //--------------------------------------------------------------------------
-    DataSet<Tuple2<GradoopId, GradoopIdList>> edgesWithGraphs = embeddings
+    DataSet<Tuple2<GradoopId, GradoopIds>> edgesWithGraphs = embeddings
       .map(new Project4To0And3AndSwitch<>())
       .flatMap(new ExpandFirstField<>()).groupBy(0)
       .reduceGroup(new MergeSecondField<>());

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/BuildIdWithCandidatesAndGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/BuildIdWithCandidatesAndGraphs.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.operators.matching.transactional.function;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Vertex;
 import org.gradoop.flink.model.impl.operators.matching.common.functions.AbstractBuilder;
 import org.gradoop.flink.model.impl.operators.matching.common.matching.ElementMatcher;
@@ -37,7 +37,7 @@ import static org.gradoop.common.util.GradoopConstants.DEFAULT_VERTEX_LABEL;
  * @param <V> EPGM vertex type
  */
 public class BuildIdWithCandidatesAndGraphs<V extends Vertex>
-  extends AbstractBuilder<V, Tuple2<GradoopIdList, IdWithCandidates<GradoopId>>> {
+  extends AbstractBuilder<V, Tuple2<GradoopIds, IdWithCandidates<GradoopId>>> {
   /**
    * serial version uid
    */
@@ -53,7 +53,7 @@ public class BuildIdWithCandidatesAndGraphs<V extends Vertex>
   /**
    * Reduce instantiations
    */
-  private final Tuple2<GradoopIdList, IdWithCandidates<GradoopId>> reuseTuple;
+  private final Tuple2<GradoopIds, IdWithCandidates<GradoopId>> reuseTuple;
 
   /**
    * Constructor
@@ -74,7 +74,7 @@ public class BuildIdWithCandidatesAndGraphs<V extends Vertex>
   }
 
   @Override
-  public Tuple2<GradoopIdList, IdWithCandidates<GradoopId>> map(V v)
+  public Tuple2<GradoopIds, IdWithCandidates<GradoopId>> map(V v)
     throws Exception {
     reuseTuple.f0 = v.getGraphIds();
     reuseTuple.f1.setId(v.getId());

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/BuildTripleWithCandidatesAndGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/BuildTripleWithCandidatesAndGraphs.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.operators.matching.transactional.function;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.flink.model.impl.operators.matching.common.functions.AbstractBuilder;
 import org.gradoop.flink.model.impl.operators.matching.common.matching.ElementMatcher;
 import org.gradoop.common.model.impl.pojo.Edge;
@@ -35,7 +35,7 @@ import static org.gradoop.common.util.GradoopConstants.DEFAULT_EDGE_LABEL;
  * @param <E> EPGM edge type
  */
 public class BuildTripleWithCandidatesAndGraphs<E extends Edge>
-  extends AbstractBuilder<E, Tuple2<GradoopIdList, TripleWithCandidates<GradoopId>>> {
+  extends AbstractBuilder<E, Tuple2<GradoopIds, TripleWithCandidates<GradoopId>>> {
 
   /**
    * serial version uid
@@ -52,7 +52,7 @@ public class BuildTripleWithCandidatesAndGraphs<E extends Edge>
   /**
    * Reduce instantiations
    */
-  private final Tuple2<GradoopIdList, TripleWithCandidates<GradoopId>>
+  private final Tuple2<GradoopIds, TripleWithCandidates<GradoopId>>
     reuseTuple;
 
   /**
@@ -74,7 +74,7 @@ public class BuildTripleWithCandidatesAndGraphs<E extends Edge>
   }
 
   @Override
-  public Tuple2<GradoopIdList, TripleWithCandidates<GradoopId>> map(E e)
+  public Tuple2<GradoopIds, TripleWithCandidates<GradoopId>> map(E e)
     throws Exception {
     reuseTuple.f0 = e.getGraphIds();
     reuseTuple.f1.setEdgeId(e.getId());

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/ExpandFirstField.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/ExpandFirstField.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Returns one Tuple2<GradoopId, T> per id contained in the first field.
@@ -28,7 +28,7 @@ import org.gradoop.common.model.impl.id.GradoopIdList;
  */
 @FunctionAnnotation.ForwardedFields("f1")
 public class ExpandFirstField<T>
-  implements FlatMapFunction<Tuple2<GradoopIdList, T>, Tuple2<GradoopId, T>> {
+  implements FlatMapFunction<Tuple2<GradoopIds, T>, Tuple2<GradoopId, T>> {
 
   /**
    * Reduce instantiation
@@ -36,7 +36,7 @@ public class ExpandFirstField<T>
   private Tuple2<GradoopId, T> reuseTuple = new Tuple2<>();
 
   @Override
-  public void flatMap(Tuple2<GradoopIdList, T> tuple2, Collector<Tuple2<GradoopId, T>> collector)
+  public void flatMap(Tuple2<GradoopIds, T> tuple2, Collector<Tuple2<GradoopId, T>> collector)
     throws Exception {
 
     reuseTuple.f1 = tuple2.f1;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/FindEmbeddings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/FindEmbeddings.java
@@ -19,7 +19,7 @@ import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.flink.model.impl.operators.matching.common.tuples.Embedding;
 import org.gradoop.flink.model.impl.operators.matching.transactional.algorithm.PatternMatchingAlgorithm;
 import org.gradoop.flink.model.impl.operators.matching.transactional.tuples.GraphWithCandidates;
@@ -34,7 +34,7 @@ import java.util.List;
 public class FindEmbeddings
   implements FlatMapFunction<
   GraphWithCandidates,
-  Tuple4<GradoopId, GradoopId, GradoopIdList, GradoopIdList>> {
+  Tuple4<GradoopId, GradoopId, GradoopIds, GradoopIds>> {
 
   /**
    * The pattern matching algorithm.
@@ -59,7 +59,7 @@ public class FindEmbeddings
 
   @Override
   public void flatMap(GraphWithCandidates graphWithCandidates,
-    Collector<Tuple4<GradoopId, GradoopId, GradoopIdList, GradoopIdList>> collector) throws
+    Collector<Tuple4<GradoopId, GradoopId, GradoopIds, GradoopIds>> collector) throws
     Exception {
     List<Embedding<GradoopId>> embeddings =
       this.algo.findEmbeddings(graphWithCandidates, this.query);
@@ -68,8 +68,8 @@ public class FindEmbeddings
       GradoopId newGraphId = GradoopId.get();
       collector.collect(new Tuple4<>(newGraphId,
         graphWithCandidates.f0,
-        GradoopIdList.fromExisting(embedding.getVertexMapping()),
-        GradoopIdList.fromExisting(embedding.getEdgeMapping())));
+        GradoopIds.fromExisting(embedding.getVertexMapping()),
+        GradoopIds.fromExisting(embedding.getEdgeMapping())));
     }
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/MergeSecondField.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/MergeSecondField.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 import java.util.Iterator;
 
@@ -31,15 +31,15 @@ import java.util.Iterator;
 @FunctionAnnotation.ForwardedFields("f0")
 @FunctionAnnotation.ReadFields("f1")
 public class MergeSecondField<T>
-  implements GroupReduceFunction<Tuple2<T, GradoopId>, Tuple2<T, GradoopIdList>> {
+  implements GroupReduceFunction<Tuple2<T, GradoopId>, Tuple2<T, GradoopIds>> {
 
   @Override
   public void reduce(Iterable<Tuple2<T, GradoopId>> iterable,
-    Collector<Tuple2<T, GradoopIdList>> collector) throws Exception {
+    Collector<Tuple2<T, GradoopIds>> collector) throws Exception {
     Iterator<Tuple2<T, GradoopId>> it = iterable.iterator();
     Tuple2<T, GradoopId> firstTuple = it.next();
     T firstField = firstTuple.f0;
-    GradoopIdList secondField = GradoopIdList.fromExisting(firstTuple.f1);
+    GradoopIds secondField = GradoopIds.fromExisting(firstTuple.f1);
     while (it.hasNext()) {
       GradoopId id = it.next().f1;
       secondField.add(id);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/Split.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/Split.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -94,7 +94,7 @@ public class Split implements UnaryGraphToCollectionOperator, Serializable {
         .map(new PairTupleWithNewId<>());
 
     // build a dataset of the vertex ids and the new associated graph ids
-    DataSet<Tuple2<GradoopId, GradoopIdList>> vertexIdWithGraphIds =
+    DataSet<Tuple2<GradoopId, GradoopIds>> vertexIdWithGraphIds =
       vertexIdWithSplitValues
         .join(splitValuesWithGraphIds)
         .where(1).equalTo(0)
@@ -125,7 +125,7 @@ public class Split implements UnaryGraphToCollectionOperator, Serializable {
     //--------------------------------------------------------------------------
 
     // replace source and target id by the graph list the corresponding vertex
-    DataSet<Tuple3<Edge, GradoopIdList, GradoopIdList>> edgeGraphIdsGraphIds =
+    DataSet<Tuple3<Edge, GradoopIds, GradoopIds>> edgeGraphIdsGraphIds =
       graph.getEdges()
         .join(vertexIdWithGraphIds)
         .where(new SourceId<>()).equalTo(0)

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/AddNewGraphsToEdge.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/AddNewGraphsToEdge.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Adds new graph id's to the edge if source and target vertex are part of
@@ -32,15 +32,15 @@ import org.gradoop.common.model.impl.id.GradoopIdList;
 @FunctionAnnotation.ForwardedFields("f0.id->id;f0.sourceId->sourceId;" +
   "f0.targetId->targetId;f0.label->label;f0.properties->properties")
 public class AddNewGraphsToEdge<E extends Edge>
-  implements FlatMapFunction<Tuple3<E, GradoopIdList, GradoopIdList>, E> {
+  implements FlatMapFunction<Tuple3<E, GradoopIds, GradoopIds>, E> {
 
   @Override
   public void flatMap(
-    Tuple3<E, GradoopIdList, GradoopIdList> triple,
+    Tuple3<E, GradoopIds, GradoopIds> triple,
     Collector<E> collector) {
-    GradoopIdList sourceGraphs = triple.f1;
-    GradoopIdList targetGraphs = triple.f2;
-    GradoopIdList graphsToBeAdded = new GradoopIdList();
+    GradoopIds sourceGraphs = triple.f1;
+    GradoopIds targetGraphs = triple.f2;
+    GradoopIds graphsToBeAdded = new GradoopIds();
 
     boolean filter = false;
     for (GradoopId id : sourceGraphs) {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/AddNewGraphsToVertex.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/AddNewGraphsToVertex.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.pojo.Vertex;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Adds new graph ids to the initial vertex set
@@ -30,13 +30,13 @@ import org.gradoop.common.model.impl.id.GradoopIdList;
 @FunctionAnnotation.ReadFieldsFirst("graphIds")
 @FunctionAnnotation.ReadFieldsSecond("f1")
 public class AddNewGraphsToVertex<V extends Vertex>
-  implements JoinFunction<V, Tuple2<GradoopId, GradoopIdList>, V> {
+  implements JoinFunction<V, Tuple2<GradoopId, GradoopIds>, V> {
   /**
    * {@inheritDoc}
    */
   @Override
   public V join(V vertex,
-    Tuple2<GradoopId, GradoopIdList> vertexWithGraphIds) {
+    Tuple2<GradoopId, GradoopIds> vertexWithGraphIds) {
     vertex.getGraphIds().addAll(vertexWithGraphIds.f1);
     return vertex;
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/JoinEdgeTupleWithSourceGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/JoinEdgeTupleWithSourceGraphs.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Join edge tuples with the graph sets of their sources
@@ -30,20 +30,20 @@ import org.gradoop.common.model.impl.id.GradoopIdList;
 @FunctionAnnotation.ForwardedFieldsFirst("*->f0")
 @FunctionAnnotation.ForwardedFieldsSecond("f1->f1")
 public class JoinEdgeTupleWithSourceGraphs<E extends Edge>
-  implements JoinFunction<E, Tuple2<GradoopId, GradoopIdList>,
-  Tuple2<E, GradoopIdList>> {
+  implements JoinFunction<E, Tuple2<GradoopId, GradoopIds>,
+  Tuple2<E, GradoopIds>> {
 
   /**
    * Reduce object instantiation.
    */
-  private final Tuple2<E, GradoopIdList> reuseTuple = new Tuple2<>();
+  private final Tuple2<E, GradoopIds> reuseTuple = new Tuple2<>();
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public Tuple2<E, GradoopIdList> join(
-    E left, Tuple2<GradoopId, GradoopIdList> right) {
+  public Tuple2<E, GradoopIds> join(
+    E left, Tuple2<GradoopId, GradoopIds> right) {
     reuseTuple.f0 = left;
     reuseTuple.f1 = right.f1;
     return reuseTuple;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/JoinEdgeTupleWithTargetGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/JoinEdgeTupleWithTargetGraphs.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Join edge tuples with the graph sets of their targets
@@ -32,22 +32,22 @@ import org.gradoop.common.model.impl.id.GradoopIdList;
 @FunctionAnnotation.ForwardedFieldsSecond("f1->f2")
 public class JoinEdgeTupleWithTargetGraphs<E extends Edge>
   implements JoinFunction
-  <Tuple2<E, GradoopIdList>, Tuple2<GradoopId, GradoopIdList>,
-    Tuple3<E, GradoopIdList, GradoopIdList>> {
+  <Tuple2<E, GradoopIds>, Tuple2<GradoopId, GradoopIds>,
+    Tuple3<E, GradoopIds, GradoopIds>> {
 
   /**
    * Reduce object instantiation.
    */
-  private final Tuple3<E, GradoopIdList, GradoopIdList> reuseTuple =
+  private final Tuple3<E, GradoopIds, GradoopIds> reuseTuple =
     new Tuple3<>();
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public Tuple3<E, GradoopIdList, GradoopIdList> join(
-    Tuple2<E, GradoopIdList> left,
-    Tuple2<GradoopId, GradoopIdList> right) throws Exception {
+  public Tuple3<E, GradoopIds, GradoopIds> join(
+    Tuple2<E, GradoopIds> left,
+    Tuple2<GradoopId, GradoopIds> right) throws Exception {
     reuseTuple.f0 = left.f0;
     reuseTuple.f1 = left.f1;
     reuseTuple.f2 = right.f1;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/MultipleGraphIdsGroupReducer.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/MultipleGraphIdsGroupReducer.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Reduce each group of vertices into a single vertex, whose graphId set
@@ -29,16 +29,16 @@ import org.gradoop.common.model.impl.id.GradoopIdList;
 @FunctionAnnotation.ForwardedFields("f0")
 public class MultipleGraphIdsGroupReducer
   implements GroupReduceFunction<Tuple2<GradoopId, GradoopId>,
-  Tuple2<GradoopId, GradoopIdList>> {
+  Tuple2<GradoopId, GradoopIds>> {
 
   @Override
   public void reduce(
     Iterable<Tuple2<GradoopId, GradoopId>> iterable,
-    Collector<Tuple2<GradoopId, GradoopIdList>> collector) {
+    Collector<Tuple2<GradoopId, GradoopIds>> collector) {
 
     boolean first = true;
     GradoopId vertexId = null;
-    GradoopIdList idSet = new GradoopIdList();
+    GradoopIds idSet = new GradoopIds();
 
     for (Tuple2<GradoopId, GradoopId> vertexGraphPair : iterable) {
       if (first) {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/ApplySubgraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/ApplySubgraph.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.gradoop.common.model.api.entities.EPGMGraphHeadFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -129,7 +129,7 @@ public class ApplySubgraph implements ApplicableUnaryGraphToGraphOperator {
     // filter function is applied first to improve performance
     //--------------------------------------------------------------------------
 
-    DataSet<Tuple2<GradoopId, GradoopIdList>> vertexIdsWithNewGraphs =
+    DataSet<Tuple2<GradoopId, GradoopIds>> vertexIdsWithNewGraphs =
       collection.getVertices()
         .filter(vertexFilterFunction)
         .flatMap(new ElementIdGraphIdTuple<>())
@@ -155,7 +155,7 @@ public class ApplySubgraph implements ApplicableUnaryGraphToGraphOperator {
     // edge id, source id, target id, set of new graph ids
     //--------------------------------------------------------------------------
 
-    DataSet<Tuple4<GradoopId, GradoopId, GradoopId, GradoopIdList>> edgeTuple =
+    DataSet<Tuple4<GradoopId, GradoopId, GradoopId, GradoopIds>> edgeTuple =
       collection.getEdges()
         .flatMap(new IdSourceTargetGraphTuple<>())
         .join(graphIdDictionary)
@@ -173,7 +173,7 @@ public class ApplySubgraph implements ApplicableUnaryGraphToGraphOperator {
     // edge id, new edge graphs
     //--------------------------------------------------------------------------
 
-    DataSet<Tuple2<GradoopId, GradoopIdList>> edgeIdsWithNewGraphs =
+    DataSet<Tuple2<GradoopId, GradoopIds>> edgeIdsWithNewGraphs =
       edgeTuple
         .join(vertexIdsWithNewGraphs)
         .where(1).equalTo(0)

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/AddGraphsToElements.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/AddGraphsToElements.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.pojo.GraphElement;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Add all gradoop ids in the second field of the first tuple to the element.
@@ -30,11 +30,11 @@ import org.gradoop.common.model.impl.id.GradoopIdList;
 @FunctionAnnotation.ReadFieldsFirst("f1")
 @FunctionAnnotation.ForwardedFieldsSecond("id;label;properties")
 public class AddGraphsToElements<EL extends GraphElement>
-  implements JoinFunction<Tuple2<GradoopId, GradoopIdList>, EL, EL> {
+  implements JoinFunction<Tuple2<GradoopId, GradoopIds>, EL, EL> {
 
   @Override
   public EL join(
-    Tuple2<GradoopId, GradoopIdList> left,
+    Tuple2<GradoopId, GradoopIds> left,
     EL right) {
     right.getGraphIds().addAll(left.f1);
     return right;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/AddGraphsToElementsCoGroup.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/AddGraphsToElementsCoGroup.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.pojo.GraphElement;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * CoGroups tuples containing gradoop ids and gradoop id sets with graph
@@ -33,15 +33,15 @@ import org.gradoop.common.model.impl.id.GradoopIdList;
 @FunctionAnnotation.ReadFieldsFirst("f1")
 @FunctionAnnotation.ForwardedFieldsSecond("id;label;properties")
 public class AddGraphsToElementsCoGroup<EL extends GraphElement>
-  implements CoGroupFunction<Tuple2<GradoopId, GradoopIdList>, EL, EL> {
+  implements CoGroupFunction<Tuple2<GradoopId, GradoopIds>, EL, EL> {
 
   @Override
   public void coGroup(
-    Iterable<Tuple2<GradoopId, GradoopIdList>> graphs,
+    Iterable<Tuple2<GradoopId, GradoopIds>> graphs,
     Iterable<EL> elements,
     Collector<EL> collector) throws Exception {
     for (EL element : elements) {
-      for (Tuple2<GradoopId, GradoopIdList> graphSet : graphs) {
+      for (Tuple2<GradoopId, GradoopIds> graphSet : graphs) {
         element.getGraphIds().addAll(graphSet.f1);
       }
       collector.collect(element);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/FilterEdgeGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/FilterEdgeGraphs.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Filter the edge tuples. Check if each new graph the edge is contained in
@@ -33,19 +33,19 @@ import org.gradoop.common.model.impl.id.GradoopIdList;
 @FunctionAnnotation.ForwardedFields("f0->f0")
 public class FilterEdgeGraphs
   implements FlatMapFunction<
-  Tuple4<GradoopId, GradoopIdList, GradoopIdList, GradoopIdList>,
-  Tuple2<GradoopId, GradoopIdList>> {
+  Tuple4<GradoopId, GradoopIds, GradoopIds, GradoopIds>,
+  Tuple2<GradoopId, GradoopIds>> {
 
   /**
    * Reduce object instantiations
    */
-  private Tuple2<GradoopId, GradoopIdList> reuseTuple = new Tuple2<>();
+  private Tuple2<GradoopId, GradoopIds> reuseTuple = new Tuple2<>();
 
   @Override
   public void flatMap(
-    Tuple4<GradoopId, GradoopIdList, GradoopIdList, GradoopIdList> edgeTuple,
-    Collector<Tuple2<GradoopId, GradoopIdList>> collector) throws Exception {
-    GradoopIdList set = new GradoopIdList();
+    Tuple4<GradoopId, GradoopIds, GradoopIds, GradoopIds> edgeTuple,
+    Collector<Tuple2<GradoopId, GradoopIds>> collector) throws Exception {
+    GradoopIds set = new GradoopIds();
     for (GradoopId edgeGraph : edgeTuple.f3) {
       for (GradoopId sourceGraph : edgeTuple.f1) {
         if (edgeGraph.equals(sourceGraph)) {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/JoinWithSourceGraphIdSet.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/JoinWithSourceGraphIdSet.java
@@ -37,7 +37,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Join an edge tuple with a tuple containing the source vertex id of this edge
@@ -48,20 +48,20 @@ import org.gradoop.common.model.impl.id.GradoopIdList;
 @FunctionAnnotation.ForwardedFieldsSecond("f1->f1")
 public class JoinWithSourceGraphIdSet
   implements JoinFunction<
-  Tuple4<GradoopId, GradoopId, GradoopId, GradoopIdList>,
-  Tuple2<GradoopId, GradoopIdList>,
-  Tuple4<GradoopId, GradoopIdList, GradoopId, GradoopIdList>> {
+  Tuple4<GradoopId, GradoopId, GradoopId, GradoopIds>,
+  Tuple2<GradoopId, GradoopIds>,
+  Tuple4<GradoopId, GradoopIds, GradoopId, GradoopIds>> {
 
   /**
    * Reduce object instantiations
    */
-  private Tuple4<GradoopId, GradoopIdList, GradoopId, GradoopIdList> reuseTuple
+  private Tuple4<GradoopId, GradoopIds, GradoopId, GradoopIds> reuseTuple
     = new Tuple4<>();
 
   @Override
-  public Tuple4<GradoopId, GradoopIdList, GradoopId, GradoopIdList> join(
-    Tuple4<GradoopId, GradoopId, GradoopId, GradoopIdList> edge,
-    Tuple2<GradoopId, GradoopIdList> vertex) throws
+  public Tuple4<GradoopId, GradoopIds, GradoopId, GradoopIds> join(
+    Tuple4<GradoopId, GradoopId, GradoopId, GradoopIds> edge,
+    Tuple2<GradoopId, GradoopIds> vertex) throws
     Exception {
     reuseTuple.f0 = edge.f0;
     reuseTuple.f1 = vertex.f1;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/JoinWithTargetGraphIdSet.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/JoinWithTargetGraphIdSet.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Join an edge tuple with a tuple containing the target vertex id of this edge
@@ -31,20 +31,20 @@ import org.gradoop.common.model.impl.id.GradoopIdList;
 @FunctionAnnotation.ForwardedFieldsSecond("f1->f2")
 public class JoinWithTargetGraphIdSet
   implements JoinFunction<
-  Tuple4<GradoopId, GradoopIdList, GradoopId, GradoopIdList>,
-  Tuple2<GradoopId, GradoopIdList>,
-  Tuple4<GradoopId, GradoopIdList, GradoopIdList, GradoopIdList>> {
+  Tuple4<GradoopId, GradoopIds, GradoopId, GradoopIds>,
+  Tuple2<GradoopId, GradoopIds>,
+  Tuple4<GradoopId, GradoopIds, GradoopIds, GradoopIds>> {
 
   /**
    * Reduce object instantiations
    */
-  private Tuple4<GradoopId, GradoopIdList, GradoopIdList, GradoopIdList> reuseTuple
+  private Tuple4<GradoopId, GradoopIds, GradoopIds, GradoopIds> reuseTuple
     = new Tuple4<>();
 
   @Override
-  public Tuple4<GradoopId, GradoopIdList, GradoopIdList, GradoopIdList> join(
-    Tuple4<GradoopId, GradoopIdList, GradoopId, GradoopIdList> edge,
-    Tuple2<GradoopId, GradoopIdList> vertex) throws
+  public Tuple4<GradoopId, GradoopIds, GradoopIds, GradoopIds> join(
+    Tuple4<GradoopId, GradoopIds, GradoopId, GradoopIds> edge,
+    Tuple2<GradoopId, GradoopIds> vertex) throws
     Exception {
     reuseTuple.f0 = edge.f0;
     reuseTuple.f1 = edge.f1;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/MergeEdgeGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/MergeEdgeGraphs.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Reduces groups of tuples 4 consisting of 4 gradoop ids
@@ -34,15 +34,15 @@ import org.gradoop.common.model.impl.id.GradoopIdList;
 public class MergeEdgeGraphs implements
   GroupReduceFunction<
     Tuple4<GradoopId, GradoopId, GradoopId, GradoopId>,
-    Tuple4<GradoopId, GradoopId, GradoopId, GradoopIdList>> {
+    Tuple4<GradoopId, GradoopId, GradoopId, GradoopIds>> {
 
   @Override
   public void reduce(
     Iterable<Tuple4<GradoopId, GradoopId, GradoopId, GradoopId>> iterable,
     Collector<
-      Tuple4<GradoopId, GradoopId, GradoopId, GradoopIdList>> collector) {
+      Tuple4<GradoopId, GradoopId, GradoopId, GradoopIds>> collector) {
 
-    GradoopIdList set = new GradoopIdList();
+    GradoopIds set = new GradoopIds();
 
     boolean empty = true;
     GradoopId f0 = null;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/MergeTupleGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/MergeTupleGraphs.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Reduces groups of tuples 2 containin two gradoop ids into one tuple
@@ -32,12 +32,12 @@ import org.gradoop.common.model.impl.id.GradoopIdList;
 public class MergeTupleGraphs implements
   GroupReduceFunction<
     Tuple2<GradoopId, GradoopId>,
-    Tuple2<GradoopId, GradoopIdList>> {
+    Tuple2<GradoopId, GradoopIds>> {
 
   @Override
   public void reduce(Iterable<Tuple2<GradoopId, GradoopId>> iterable,
-    Collector<Tuple2<GradoopId, GradoopIdList>> collector) throws Exception {
-    GradoopIdList set = new GradoopIdList();
+    Collector<Tuple2<GradoopId, GradoopIds>> collector) throws Exception {
+    GradoopIds set = new GradoopIds();
     boolean empty = true;
     GradoopId first = null;
     for (Tuple2<GradoopId, GradoopId> tuple : iterable) {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/SourceTargetIdGraphsTuple.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/SourceTargetIdGraphsTuple.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * For each edge, collect two tuple 2 containing its source or target id in the
@@ -33,12 +33,12 @@ import org.gradoop.common.model.impl.id.GradoopIdList;
 @FunctionAnnotation.ReadFields("sourceId;targetId")
 @FunctionAnnotation.ForwardedFields("graphIds->f1")
 public class SourceTargetIdGraphsTuple<E extends Edge>
-  implements FlatMapFunction<E, Tuple2<GradoopId, GradoopIdList>> {
+  implements FlatMapFunction<E, Tuple2<GradoopId, GradoopIds>> {
 
   @Override
   public void flatMap(
     E e,
-    Collector<Tuple2<GradoopId, GradoopIdList>> collector) throws
+    Collector<Tuple2<GradoopId, GradoopIds>> collector) throws
     Exception {
 
     collector.collect(new Tuple2<>(e.getSourceId(), e.getGraphIds()));

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/tuples/IdWithIdSet.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/tuples/IdWithIdSet.java
@@ -17,12 +17,12 @@ package org.gradoop.flink.model.impl.tuples;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * (id, {id, id, ...})
  */
-public class IdWithIdSet extends Tuple2<GradoopId, GradoopIdList> {
+public class IdWithIdSet extends Tuple2<GradoopId, GradoopIds> {
 
   public GradoopId getId() {
     return f0;
@@ -32,11 +32,11 @@ public class IdWithIdSet extends Tuple2<GradoopId, GradoopIdList> {
     f0 = id;
   }
 
-  public GradoopIdList getIdSet() {
+  public GradoopIds getIdSet() {
     return f1;
   }
 
-  public void setIdSet(GradoopIdList idSet) {
+  public void setIdSet(GradoopIds idSet) {
     f1 = idSet;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/representation/transactional/RepresentationConverters.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/representation/transactional/RepresentationConverters.java
@@ -20,7 +20,7 @@ import com.google.common.collect.Sets;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.gradoop.common.model.api.entities.EPGMElement;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -139,7 +139,7 @@ public class RepresentationConverters {
     // GRAPH HEAD
     GraphHead graphHead = adjacencyList.getGraphHead();
 
-    GradoopIdList graphIds = GradoopIdList.fromExisting(graphHead.getId());
+    GradoopIds graphIds = GradoopIds.fromExisting(graphHead.getId());
 
     Set<Vertex> vertices = Sets.newHashSet();
     Set<Edge> edges = Sets.newHashSet();

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/EPGMDatabaseTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/EPGMDatabaseTest.java
@@ -17,7 +17,7 @@ package org.gradoop.flink.model.impl;
 
 import com.google.common.collect.Lists;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
 import org.gradoop.flink.model.api.epgm.GraphCollection;
@@ -68,7 +68,7 @@ public class EPGMDatabaseTest extends GradoopFlinkTestBase {
       graphIds.add(loader.getGraphHeadByVariable(graphVariable).getId());
     }
 
-    GradoopIdList graphIdSet = GradoopIdList.fromExisting(graphIds);
+    GradoopIds graphIdSet = GradoopIds.fromExisting(graphIds);
 
     GraphCollection collectionFromLoader =
       loader.getGraphCollectionByVariables(graphVariables);

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/id/GradoopIdSerializationTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/id/GradoopIdSerializationTest.java
@@ -16,7 +16,7 @@
 package org.gradoop.flink.model.impl.id;
 
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
 import org.gradoop.flink.model.impl.GradoopFlinkTestUtils;
 import org.junit.Test;
@@ -35,7 +35,7 @@ public class GradoopIdSerializationTest extends GradoopFlinkTestBase {
 
   @Test
   public void testGradoopIdSetSerialization() throws Exception {
-    GradoopIdList idsIn = GradoopIdList.fromExisting(
+    GradoopIds idsIn = GradoopIds.fromExisting(
       GradoopId.get(), GradoopId.get());
     assertEquals("GradoopIdSets were not equal", idsIn,
       GradoopFlinkTestUtils.writeAndRead(idsIn));

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/cloning/CloningTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/cloning/CloningTest.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.operators.cloning;
 import com.google.common.collect.Lists;
 import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
 import org.gradoop.flink.model.api.epgm.LogicalGraph;
 import org.gradoop.flink.model.impl.functions.epgm.Id;
@@ -76,7 +76,7 @@ public class CloningTest extends GradoopFlinkTestBase {
       .output(new LocalCollectionOutputFormat<>(resultEdgeIds));
 
 
-    List<GradoopIdList> resultGraphIds = Lists.newArrayList();
+    List<GradoopIds> resultGraphIds = Lists.newArrayList();
 
     result.getVertices()
       .map(new ExpandGraphsToIdSet<>())

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectEdgesNodeTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectEdgesNodeTest.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.operators.matching.single.cypher.planning.q
 import com.google.common.collect.Sets;
 import org.apache.flink.api.java.DataSet;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
@@ -81,8 +81,8 @@ public class FilterAndProjectEdgesNodeTest extends GradoopFlinkTestBase {
     Map<String, Object> edge2Props = new HashMap<>();
     edge2Props.put("foo", 42);
 
-    Edge e1 = new Edge(edge1Id, "a", sourceId, targetId, Properties.createFromMap(edge1Props), new GradoopIdList());
-    Edge e2 = new Edge(edge2Id, "b", sourceId, targetId, Properties.createFromMap(edge2Props), new GradoopIdList());
+    Edge e1 = new Edge(edge1Id, "a", sourceId, targetId, Properties.createFromMap(edge1Props), new GradoopIds());
+    Edge e2 = new Edge(edge2Id, "b", sourceId, targetId, Properties.createFromMap(edge2Props), new GradoopIds());
 
     DataSet<Edge> edges = getExecutionEnvironment().fromElements(e1, e2);
 

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectVerticesNodeTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectVerticesNodeTest.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.operators.matching.single.cypher.planning.q
 import com.google.common.collect.Sets;
 import org.apache.flink.api.java.DataSet;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Vertex;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
@@ -59,8 +59,8 @@ public class FilterAndProjectVerticesNodeTest extends GradoopFlinkTestBase {
     Map<String, Object> vertex2Props = new HashMap<>();
     vertex2Props.put("foo", 42);
 
-    Vertex vertex1 = new Vertex(vertex1Id, "A", Properties.createFromMap(vertex1Props), new GradoopIdList());
-    Vertex vertex2 = new Vertex(vertex2Id, "B", Properties.createFromMap(vertex2Props), new GradoopIdList());
+    Vertex vertex1 = new Vertex(vertex1Id, "A", Properties.createFromMap(vertex1Props), new GradoopIds());
+    Vertex vertex2 = new Vertex(vertex2Id, "B", Properties.createFromMap(vertex2Props), new GradoopIds());
 
     DataSet<Vertex> vertices = getExecutionEnvironment().fromElements(vertex1, vertex2);
 

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/pojo/PojoSerializationTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/pojo/PojoSerializationTest.java
@@ -22,7 +22,7 @@ import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
 import org.gradoop.common.model.api.entities.EPGMEdge;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.EdgeFactory;
 import org.gradoop.common.model.impl.pojo.GraphHeadFactory;
 import org.gradoop.common.model.impl.pojo.VertexFactory;
@@ -37,7 +37,7 @@ public class PojoSerializationTest extends GradoopFlinkTestBase {
     EPGMVertex vertexIn = new VertexFactory().createVertex(
       "Person",
       Properties.createFromMap(GradoopTestUtils.SUPPORTED_PROPERTIES),
-      GradoopIdList.fromExisting(GradoopId.get()));
+      GradoopIds.fromExisting(GradoopId.get()));
 
     Assert.assertEquals("EPGMVertex POJOs were not equal",
       vertexIn, GradoopFlinkTestUtils.writeAndRead(vertexIn));
@@ -50,7 +50,7 @@ public class PojoSerializationTest extends GradoopFlinkTestBase {
       GradoopId.get(),
       GradoopId.get(),
       Properties.createFromMap(GradoopTestUtils.SUPPORTED_PROPERTIES),
-      GradoopIdList.fromExisting(GradoopId.get(), GradoopId.get()));
+      GradoopIds.fromExisting(GradoopId.get(), GradoopId.get()));
 
     Assert.assertEquals("EPGMEdge POJOs were not equal",
       edgeIn, GradoopFlinkTestUtils.writeAndRead(edgeIn));

--- a/gradoop-flink/src/test/java/org/gradoop/flink/representation/RepresentationConverterTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/representation/RepresentationConverterTest.java
@@ -17,7 +17,7 @@ package org.gradoop.flink.representation;
 
 import com.google.common.collect.Sets;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -57,7 +57,7 @@ public class RepresentationConverterTest extends GradoopFlinkTestBase {
   private GraphTransaction getGraphTransaction() {
     GraphHead graphHead = new GraphHead(GradoopId.get(), "Test", null);
 
-    GradoopIdList graphIds = GradoopIdList.fromExisting(graphHead.getId());
+    GradoopIds graphIds = GradoopIds.fromExisting(graphHead.getId());
     Set<Vertex> vertices = Sets.newHashSet();
     Set<Edge> edges = Sets.newHashSet();
 

--- a/gradoop-hbase/src/main/java/org/gradoop/common/storage/api/GraphElementHandler.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/common/storage/api/GraphElementHandler.java
@@ -18,7 +18,7 @@ package org.gradoop.common.storage.api;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.gradoop.common.model.api.entities.EPGMGraphElement;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 import java.io.IOException;
 
@@ -43,5 +43,5 @@ public interface GraphElementHandler extends ElementHandler {
    * @param res HBase row
    * @return graphs identifiers
    */
-  GradoopIdList readGraphIds(final Result res) throws IOException;
+  GradoopIds readGraphIds(final Result res) throws IOException;
 }

--- a/gradoop-hbase/src/main/java/org/gradoop/common/storage/api/PersistentGraphHead.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/common/storage/api/PersistentGraphHead.java
@@ -17,7 +17,7 @@ package org.gradoop.common.storage.api;
 
 import org.gradoop.common.model.api.entities.EPGMGraphHead;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Representation of vertex data on the storage level. We additionally store
@@ -29,14 +29,14 @@ public interface PersistentGraphHead extends EPGMGraphHead {
    *
    * @return vertex ids that are contained in that graph
    */
-  GradoopIdList getVertexIds();
+  GradoopIds getVertexIds();
 
   /**
    * Sets the vertices that are contained in that graph.
    *
    * @param vertices vertex ids
    */
-  void setVertexIds(GradoopIdList vertices);
+  void setVertexIds(GradoopIds vertices);
 
   /**
    * Adds a vertex identifier to the graph data.
@@ -57,14 +57,14 @@ public interface PersistentGraphHead extends EPGMGraphHead {
    *
    * @return edge ids that are contained in that graph
    */
-  GradoopIdList getEdgeIds();
+  GradoopIds getEdgeIds();
 
   /**
    * Sets the edges that are contained in that graph.
    *
    * @param edges edge ids
    */
-  void setEdgeIds(GradoopIdList edges);
+  void setEdgeIds(GradoopIds edges);
 
   /**
    * Adds an edge identifier to the graph data.

--- a/gradoop-hbase/src/main/java/org/gradoop/common/storage/api/PersistentGraphHeadFactory.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/common/storage/api/PersistentGraphHeadFactory.java
@@ -16,7 +16,7 @@
 package org.gradoop.common.storage.api;
 
 import org.gradoop.common.model.api.entities.EPGMGraphHead;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 import java.io.Serializable;
 
@@ -37,5 +37,5 @@ public interface PersistentGraphHeadFactory<G extends EPGMGraphHead>
    * @return graph data
    */
   PersistentGraphHead createGraphHead(G inputGraphData,
-    GradoopIdList vertices, GradoopIdList edges);
+    GradoopIds vertices, GradoopIds edges);
 }

--- a/gradoop-hbase/src/main/java/org/gradoop/common/storage/impl/hbase/HBaseGraphElement.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/common/storage/impl/hbase/HBaseGraphElement.java
@@ -17,7 +17,7 @@ package org.gradoop.common.storage.impl.hbase;
 
 import org.gradoop.common.model.api.entities.EPGMGraphElement;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Wraps an EPGM graph element data entity.
@@ -40,7 +40,7 @@ public abstract class HBaseGraphElement<T extends EPGMGraphElement>
    * {@inheritDoc}
    */
   @Override
-  public GradoopIdList getGraphIds() {
+  public GradoopIds getGraphIds() {
     return getEpgmElement().getGraphIds();
   }
 
@@ -56,7 +56,7 @@ public abstract class HBaseGraphElement<T extends EPGMGraphElement>
    * {@inheritDoc}
    */
   @Override
-  public void setGraphIds(GradoopIdList graphIds) {
+  public void setGraphIds(GradoopIds graphIds) {
     getEpgmElement().setGraphIds(graphIds);
   }
 

--- a/gradoop-hbase/src/main/java/org/gradoop/common/storage/impl/hbase/HBaseGraphElementHandler.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/common/storage/impl/hbase/HBaseGraphElementHandler.java
@@ -19,7 +19,7 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.gradoop.common.model.api.entities.EPGMGraphElement;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.storage.api.GraphElementHandler;
 import org.gradoop.common.util.HBaseConstants;
 
@@ -55,15 +55,15 @@ public abstract class HBaseGraphElementHandler extends
    * {@inheritDoc}
    */
   @Override
-  public GradoopIdList readGraphIds(Result res) throws IOException {
+  public GradoopIds readGraphIds(Result res) throws IOException {
     byte[] graphBytes = res.getValue(CF_META_BYTES, COL_GRAPHS_BYTES);
 
-    GradoopIdList graphIds;
+    GradoopIds graphIds;
 
     if (graphBytes != null) {
-      graphIds = GradoopIdList.fromByteArray(graphBytes);
+      graphIds = GradoopIds.fromByteArray(graphBytes);
     } else {
-      graphIds = new GradoopIdList();
+      graphIds = new GradoopIds();
     }
 
     return graphIds;

--- a/gradoop-hbase/src/main/java/org/gradoop/common/storage/impl/hbase/HBaseGraphHead.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/common/storage/impl/hbase/HBaseGraphHead.java
@@ -17,7 +17,7 @@ package org.gradoop.common.storage.impl.hbase;
 
 import org.gradoop.common.model.api.entities.EPGMGraphHead;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.storage.api.PersistentGraphHead;
 
 /**
@@ -31,12 +31,12 @@ public class HBaseGraphHead<G extends EPGMGraphHead> extends HBaseElement<G>
   /**
    * EPGMVertex identifiers contained in that logical graph.
    */
-  private GradoopIdList vertexIds;
+  private GradoopIds vertexIds;
 
   /**
    * EPGMEdge identifiers contained in that logical graph.
    */
-  private GradoopIdList edgeIds;
+  private GradoopIds edgeIds;
 
   /**
    * Creates  persistent graph data.
@@ -45,8 +45,8 @@ public class HBaseGraphHead<G extends EPGMGraphHead> extends HBaseElement<G>
    * @param vertexIds  vertexIds contained in that graph
    * @param edgeIds     edgeIds contained in that graph
    */
-  HBaseGraphHead(G graphHead, GradoopIdList vertexIds,
-    GradoopIdList edgeIds) {
+  HBaseGraphHead(G graphHead, GradoopIds vertexIds,
+    GradoopIds edgeIds) {
     super(graphHead);
     this.vertexIds = vertexIds;
     this.edgeIds = edgeIds;
@@ -56,7 +56,7 @@ public class HBaseGraphHead<G extends EPGMGraphHead> extends HBaseElement<G>
    * {@inheritDoc}
    */
   @Override
-  public GradoopIdList getVertexIds() {
+  public GradoopIds getVertexIds() {
     return vertexIds;
   }
 
@@ -64,7 +64,7 @@ public class HBaseGraphHead<G extends EPGMGraphHead> extends HBaseElement<G>
    * {@inheritDoc}
    */
   @Override
-  public void setVertexIds(GradoopIdList vertices) {
+  public void setVertexIds(GradoopIds vertices) {
     this.vertexIds = vertices;
   }
 
@@ -76,7 +76,7 @@ public class HBaseGraphHead<G extends EPGMGraphHead> extends HBaseElement<G>
     if (vertexIds != null) {
       vertexIds.add(vertexID);
     } else {
-      vertexIds = GradoopIdList.fromExisting(vertexID);
+      vertexIds = GradoopIds.fromExisting(vertexID);
     }
   }
 
@@ -92,7 +92,7 @@ public class HBaseGraphHead<G extends EPGMGraphHead> extends HBaseElement<G>
    * {@inheritDoc}
    */
   @Override
-  public GradoopIdList getEdgeIds() {
+  public GradoopIds getEdgeIds() {
     return edgeIds;
   }
 
@@ -100,7 +100,7 @@ public class HBaseGraphHead<G extends EPGMGraphHead> extends HBaseElement<G>
    * {@inheritDoc}
    */
   @Override
-  public void setEdgeIds(GradoopIdList edgeIds) {
+  public void setEdgeIds(GradoopIds edgeIds) {
     this.edgeIds = edgeIds;
   }
 
@@ -112,7 +112,7 @@ public class HBaseGraphHead<G extends EPGMGraphHead> extends HBaseElement<G>
     if (edgeIds != null) {
       edgeIds.add(edgeID);
     } else {
-      edgeIds = GradoopIdList.fromExisting(edgeID);
+      edgeIds = GradoopIds.fromExisting(edgeID);
     }
   }
 

--- a/gradoop-hbase/src/main/java/org/gradoop/common/storage/impl/hbase/HBaseGraphHeadFactory.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/common/storage/impl/hbase/HBaseGraphHeadFactory.java
@@ -16,7 +16,7 @@
 package org.gradoop.common.storage.impl.hbase;
 
 import org.gradoop.common.model.api.entities.EPGMGraphHead;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.storage.api.PersistentGraphHeadFactory;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -39,7 +39,7 @@ public class HBaseGraphHeadFactory<G extends EPGMGraphHead>
    */
   @Override
   public HBaseGraphHead<G> createGraphHead(G inputGraphHead,
-    GradoopIdList vertices, GradoopIdList edges) {
+    GradoopIds vertices, GradoopIds edges) {
     checkNotNull(inputGraphHead, "EPGMGraphHead was null");
     checkNotNull(vertices, "EPGMVertex identifiers were null");
     checkNotNull(edges, "EPGMEdge identifiers were null");

--- a/gradoop-hbase/src/main/java/org/gradoop/flink/io/impl/hbase/HBaseDataSink.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/flink/io/impl/hbase/HBaseDataSink.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.hadoop.hbase.mapreduce.TableOutputFormat;
 import org.apache.hadoop.mapreduce.Job;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -112,7 +112,7 @@ public class HBaseDataSink extends HBaseBase<GraphHead, Vertex, Edge>
 
     // co-group (graph-id, vertex-id) and (graph-id, edge-id) tuples to
     // (graph-id, {vertex-id}, {edge-id}) triples
-    DataSet<Tuple3<GradoopId, GradoopIdList, GradoopIdList>>
+    DataSet<Tuple3<GradoopId, GradoopIds, GradoopIds>>
       graphToVertexIdsAndEdgeIds = graphIdToVertexId
         .coGroup(graphIdToEdgeId)
         .where(0)

--- a/gradoop-hbase/src/main/java/org/gradoop/flink/io/impl/hbase/functions/BuildGraphTransactions.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/flink/io/impl/hbase/functions/BuildGraphTransactions.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Co-groups graph-id, vertex-id) and (graph-id, edge-id) tuples to
@@ -44,21 +44,21 @@ import org.gradoop.common.model.impl.id.GradoopIdList;
 @FunctionAnnotation.ReadFieldsSecond("f1")
 public class BuildGraphTransactions implements CoGroupFunction<
   Tuple2<GradoopId, GradoopId>, Tuple2<GradoopId, GradoopId>,
-  Tuple3<GradoopId, GradoopIdList, GradoopIdList>> {
+  Tuple3<GradoopId, GradoopIds, GradoopIds>> {
   /**
    * Reduce object instantiations.
    */
-  private final Tuple3<GradoopId, GradoopIdList, GradoopIdList> reuseTuple =
+  private final Tuple3<GradoopId, GradoopIds, GradoopIds> reuseTuple =
     new Tuple3<>();
 
   @Override
   public void coGroup(Iterable<Tuple2<GradoopId, GradoopId>> graphToVertexIds,
     Iterable<Tuple2<GradoopId, GradoopId>> graphToEdgeIds,
-    Collector<Tuple3<GradoopId, GradoopIdList, GradoopIdList>> collector) throws
+    Collector<Tuple3<GradoopId, GradoopIds, GradoopIds>> collector) throws
     Exception {
 
-    GradoopIdList vertexIds  = new GradoopIdList();
-    GradoopIdList edgeIds    = new GradoopIdList();
+    GradoopIds vertexIds  = new GradoopIds();
+    GradoopIds edgeIds    = new GradoopIds();
     boolean initialized     = false;
 
     for (Tuple2<GradoopId, GradoopId> graphToVertexTuple : graphToVertexIds) {

--- a/gradoop-hbase/src/main/java/org/gradoop/flink/io/impl/hbase/functions/BuildPersistentGraphHead.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/flink/io/impl/hbase/functions/BuildPersistentGraphHead.java
@@ -19,7 +19,7 @@ import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.gradoop.common.model.api.entities.EPGMGraphHead;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.storage.api.PersistentGraphHead;
 import org.gradoop.common.storage.api.PersistentGraphHeadFactory;
 
@@ -30,7 +30,7 @@ import org.gradoop.common.storage.api.PersistentGraphHeadFactory;
  */
 public class BuildPersistentGraphHead<G extends EPGMGraphHead>
   implements JoinFunction
-  <Tuple3<GradoopId, GradoopIdList, GradoopIdList>, G, PersistentGraphHead> {
+  <Tuple3<GradoopId, GradoopIds, GradoopIds>, G, PersistentGraphHead> {
 
   /**
    * Persistent graph data factory.
@@ -52,7 +52,7 @@ public class BuildPersistentGraphHead<G extends EPGMGraphHead>
    */
   @Override
   public PersistentGraphHead join(
-    Tuple3<GradoopId, GradoopIdList, GradoopIdList> longSetSetTuple3, G graphHead)
+    Tuple3<GradoopId, GradoopIds, GradoopIds> longSetSetTuple3, G graphHead)
       throws Exception {
     return graphHeadFactory.createGraphHead(graphHead, longSetSetTuple3.f1,
       longSetSetTuple3.f2);

--- a/gradoop-hbase/src/test/java/org/gradoop/common/storage/impl/hbase/GradoopHBaseTestUtils.java
+++ b/gradoop-hbase/src/test/java/org/gradoop/common/storage/impl/hbase/GradoopHBaseTestUtils.java
@@ -20,7 +20,7 @@ import org.gradoop.common.model.api.entities.EPGMEdge;
 import org.gradoop.common.model.api.entities.EPGMGraphHead;
 import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -99,8 +99,8 @@ public class GradoopHBaseTestUtils {
     for(G graphHead : loader.getGraphHeads()) {
 
       GradoopId graphId = graphHead.getId();
-      GradoopIdList vertexIds = new GradoopIdList();
-      GradoopIdList edgeIds = new GradoopIdList();
+      GradoopIds vertexIds = new GradoopIds();
+      GradoopIds edgeIds = new GradoopIds();
 
       for (EPGMVertex vertex : loader.getVertices()) {
         if (vertex.getGraphIds().contains(graphId)) {

--- a/gradoop-hbase/src/test/java/org/gradoop/common/storage/impl/hbase/HBaseGraphStoreTest.java
+++ b/gradoop-hbase/src/test/java/org/gradoop/common/storage/impl/hbase/HBaseGraphStoreTest.java
@@ -24,7 +24,7 @@ import org.gradoop.common.model.api.entities.EPGMGraphHead;
 import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.common.model.api.entities.EPGMVertexFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIdList;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -192,7 +192,7 @@ public class HBaseGraphStoreTest extends GradoopHBaseTestBase {
 
     final Set<Edge> outEdges = Sets.newHashSetWithExpectedSize(0);
     final Set<Edge> inEdges = Sets.newHashSetWithExpectedSize(0);
-    final GradoopIdList graphs = new GradoopIdList();
+    final GradoopIds graphs = new GradoopIds();
     PersistentVertex<Edge> v = persistentVertexFactory.createVertex(
         vertexFactory.initVertex(vertexID, label, props, graphs),
         outEdges, inEdges);
@@ -218,7 +218,7 @@ public class HBaseGraphStoreTest extends GradoopHBaseTestBase {
 
     final Set<Edge> outEdges = Sets.newHashSetWithExpectedSize(0);
     final Set<Edge> inEdges = Sets.newHashSetWithExpectedSize(0);
-    final GradoopIdList graphs = new GradoopIdList();
+    final GradoopIds graphs = new GradoopIds();
 
     // write to store
     graphStore.writeVertex(persistentVertexFactory.createVertex(
@@ -282,8 +282,8 @@ public class HBaseGraphStoreTest extends GradoopHBaseTestBase {
     HBaseEPGMStore<GraphHead, Vertex, Edge> graphStore, GraphHead graphHead,
     Vertex vertex, Edge edge) {
     graphStore.writeGraphHead(new HBaseGraphHeadFactory<>().createGraphHead(
-      graphHead, GradoopIdList.fromExisting(vertex.getId()),
-      GradoopIdList.fromExisting(edge.getId())
+      graphHead, GradoopIds.fromExisting(vertex.getId()),
+      GradoopIds.fromExisting(edge.getId())
       )
     );
   }


### PR DESCRIPTION
We don't need a list with duplicates. The only test I had to adjust was for GradoopIdList itself. There are no known operators that rely on duplicate ids or the order of ids in the list.
