### PR TITLE
[#725] use set nature of ids to prevent iterating over potentially large collections

### DIFF
--- a/gradoop-common/src/main/java/org/gradoop/common/model/api/entities/EPGMEdgeFactory.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/api/entities/EPGMEdgeFactory.java
@@ -16,7 +16,7 @@
 package org.gradoop.common.model.api.entities;
 
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.properties.Properties;
 
 /**
@@ -104,7 +104,7 @@ public interface EPGMEdgeFactory<E extends EPGMEdge>
    * @return edge data
    */
   E createEdge(String label, GradoopId sourceVertexId, GradoopId targetVertexId,
-    GradoopIds graphIds);
+    GradoopIdSet graphIds);
 
   /**
    * Initializes an edge based on the given parameters.
@@ -117,7 +117,7 @@ public interface EPGMEdgeFactory<E extends EPGMEdge>
    * @return edge data
    */
   E initEdge(GradoopId id, String label, GradoopId sourceVertexId,
-    GradoopId targetVertexId, GradoopIds graphIds);
+    GradoopId targetVertexId, GradoopIdSet graphIds);
 
   /**
    * Creates a new edge based on the given parameters.
@@ -130,7 +130,7 @@ public interface EPGMEdgeFactory<E extends EPGMEdge>
    * @return edge data
    */
   E createEdge(String label, GradoopId sourceVertexId, GradoopId targetVertexId,
-    Properties properties, GradoopIds graphIds);
+    Properties properties, GradoopIdSet graphIds);
 
   /**
    * Initializes an edge based on the given parameters.
@@ -144,5 +144,5 @@ public interface EPGMEdgeFactory<E extends EPGMEdge>
    * @return edge data
    */
   E initEdge(GradoopId id, String label, GradoopId sourceVertexId,
-    GradoopId targetVertexId, Properties properties, GradoopIds graphIds);
+    GradoopId targetVertexId, Properties properties, GradoopIdSet graphIds);
 }

--- a/gradoop-common/src/main/java/org/gradoop/common/model/api/entities/EPGMGraphElement.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/api/entities/EPGMGraphElement.java
@@ -16,7 +16,7 @@
 package org.gradoop.common.model.api.entities;
 
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * A graph element is part of a logical graph. An element can be part of more
@@ -28,7 +28,7 @@ public interface EPGMGraphElement extends EPGMElement {
    *
    * @return all graphs of that element
    */
-  GradoopIds getGraphIds();
+  GradoopIdSet getGraphIds();
 
   /**
    * Adds that element to the given graphId. If the element is already an
@@ -43,7 +43,7 @@ public interface EPGMGraphElement extends EPGMElement {
    *
    * @param graphIds the graphIds to be added
    */
-  void setGraphIds(GradoopIds graphIds);
+  void setGraphIds(GradoopIdSet graphIds);
 
   /**
    * Resets all graph elements.

--- a/gradoop-common/src/main/java/org/gradoop/common/model/api/entities/EPGMVertexFactory.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/api/entities/EPGMVertexFactory.java
@@ -16,7 +16,7 @@
 package org.gradoop.common.model.api.entities;
 
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.properties.Properties;
 
 /**
@@ -85,7 +85,7 @@ public interface EPGMVertexFactory<V extends EPGMVertex>
    * @param graphIds graphIds, that contain the vertex
    * @return vertex data
    */
-  V createVertex(String label, GradoopIds graphIds);
+  V createVertex(String label, GradoopIdSet graphIds);
 
   /**
    * Initializes a vertex based on the given parameters.
@@ -95,7 +95,7 @@ public interface EPGMVertexFactory<V extends EPGMVertex>
    * @param graphIds graphIds, that contain the vertex
    * @return vertex data
    */
-  V initVertex(GradoopId id, String label, GradoopIds graphIds);
+  V initVertex(GradoopId id, String label, GradoopIdSet graphIds);
 
   /**
    * Creates a new vertex based on the given parameters.
@@ -105,7 +105,7 @@ public interface EPGMVertexFactory<V extends EPGMVertex>
    * @param graphIds     graphIds, that contain the vertex
    * @return vertex data
    */
-  V createVertex(String label, Properties properties, GradoopIds graphIds);
+  V createVertex(String label, Properties properties, GradoopIdSet graphIds);
 
   /**
    * Initializes a vertex based on the given parameters.
@@ -117,5 +117,5 @@ public interface EPGMVertexFactory<V extends EPGMVertex>
    * @return vertex data
    */
   V initVertex(GradoopId id, String label, Properties properties,
-    GradoopIds graphIds);
+    GradoopIdSet graphIds);
 }

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/id/GradoopIdSet.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/id/GradoopIdSet.java
@@ -34,7 +34,7 @@ import java.util.Set;
  *
  * @see GradoopId
  */
-public class GradoopIds implements Iterable<GradoopId>, Value {
+public class GradoopIdSet implements Iterable<GradoopId>, Value {
   /**
    * Contains the set of gradoop ids.
    */
@@ -43,7 +43,7 @@ public class GradoopIds implements Iterable<GradoopId>, Value {
   /**
    * Required default constructor for instantiation by serialization logic.
    */
-  public GradoopIds() {
+  public GradoopIdSet() {
     this.ids = new HashSet<>();
   }
 
@@ -52,7 +52,7 @@ public class GradoopIds implements Iterable<GradoopId>, Value {
    *
    * @param bytes bytes representing multiple gradoop ids
    */
-  private GradoopIds(byte[] bytes) {
+  private GradoopIdSet(byte[] bytes) {
     this.ids = readIds(bytes);
   }
 
@@ -61,7 +61,7 @@ public class GradoopIds implements Iterable<GradoopId>, Value {
    *
    * @param ids a collection of {@link GradoopId}s
    */
-  private GradoopIds(Collection<GradoopId> ids) {
+  private GradoopIdSet(Collection<GradoopId> ids) {
     this.ids = new HashSet<>(ids);
   }
 
@@ -86,7 +86,7 @@ public class GradoopIds implements Iterable<GradoopId>, Value {
    * @param ids sequence of {@link GradoopId}s
    * @return a binary representation
    */
-  private byte[] writeIds(Collection<GradoopId> ids) {
+  private byte[] writeIds(Set<GradoopId> ids) {
     byte[] bytes = new byte[ids.size() * GradoopId.ID_SIZE];
 
     int i = 0;
@@ -103,7 +103,7 @@ public class GradoopIds implements Iterable<GradoopId>, Value {
    * @param ids array of gradoop ids
    * @return gradoop id set
    */
-  public static GradoopIds fromExisting(GradoopId... ids) {
+  public static GradoopIdSet fromExisting(GradoopId... ids) {
     return fromExisting(Arrays.asList(ids));
   }
 
@@ -113,8 +113,8 @@ public class GradoopIds implements Iterable<GradoopId>, Value {
    * @param ids given ids
    * @return gradoop id set
    */
-  public static GradoopIds fromExisting(Collection<GradoopId> ids) {
-    return new GradoopIds(ids);
+  public static GradoopIdSet fromExisting(Collection<GradoopId> ids) {
+    return new GradoopIdSet(ids);
   }
 
   /**
@@ -123,8 +123,8 @@ public class GradoopIds implements Iterable<GradoopId>, Value {
    * @param bytes byte array representing multiple gradoop ids
    * @return gradoop id set
    */
-  public static GradoopIds fromByteArray(byte[] bytes) {
-    return new GradoopIds(bytes);
+  public static GradoopIdSet fromByteArray(byte[] bytes) {
+    return new GradoopIdSet(bytes);
   }
 
   /**
@@ -141,7 +141,7 @@ public class GradoopIds implements Iterable<GradoopId>, Value {
    *
    * @param ids the ids to add
    */
-  public void addAll(GradoopIds ids) {
+  public void addAll(GradoopIdSet ids) {
     this.ids.addAll(ids.ids);
   }
 
@@ -170,7 +170,7 @@ public class GradoopIds implements Iterable<GradoopId>, Value {
    * @param other the ids to look for
    * @return true, iff all specified ids are contained in the set
    */
-  public boolean containsAll(GradoopIds other) {
+  public boolean containsAll(GradoopIdSet other) {
     if (other.size() > this.size()) {
       return false;
     }
@@ -188,7 +188,7 @@ public class GradoopIds implements Iterable<GradoopId>, Value {
    * @param other the ids to look for
    * @return true, iff all specified ids are contained in the set
    */
-  public boolean containsAll(Collection<GradoopId> other) {
+  public boolean containsAll(Set<GradoopId> other) {
     if (other.size() > this.size()) {
       return false;
     }
@@ -206,7 +206,7 @@ public class GradoopIds implements Iterable<GradoopId>, Value {
    * @param other the ids to look for
    * @return true, iff any of the specified ids is contained in the set
    */
-  public boolean containsAny(GradoopIds other) {
+  public boolean containsAny(GradoopIdSet other) {
     // Algorithm: the sizes of both lists might be vastly different
     // to prevent the case of iterating multiple times over large collections
     // we make sure to always iterate over the smaller one
@@ -233,7 +233,7 @@ public class GradoopIds implements Iterable<GradoopId>, Value {
    * @param ids the ids to look for
    * @return true, iff any of the specified ids is contained in the set
    */
-  public boolean containsAny(Collection<GradoopId> ids) {
+  public boolean containsAny(Set<GradoopId> ids) {
     // we can't use the same logic as in #containsAny(GradoopIdList)
     // because the #contains method of `ids` might be inefficient
     for (GradoopId id : ids) {
@@ -308,8 +308,8 @@ public class GradoopIds implements Iterable<GradoopId>, Value {
   public boolean equals(Object o) {
     boolean equal = this == o;
 
-    if (!equal && o instanceof GradoopIds) {
-      GradoopIds that = (GradoopIds) o;
+    if (!equal && o instanceof GradoopIdSet) {
+      GradoopIdSet that = (GradoopIdSet) o;
       // same number of ids
       equal = this.size() == that.size();
 

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/id/GradoopIdSet.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/id/GradoopIdSet.java
@@ -194,7 +194,7 @@ public class GradoopIdSet extends AbstractSet<GradoopId> implements Value {
    */
   @Override
   public boolean containsAll(Collection<?> other) {
-    if (other.size() > this.size()) {
+    if (other instanceof Set && other.size() > this.size()) {
       return false;
     }
     for (Object id : other) {
@@ -235,14 +235,21 @@ public class GradoopIdSet extends AbstractSet<GradoopId> implements Value {
   /**
    * Checks if any of the specified ids is contained in the set.
    *
-   * @param ids the ids to look for
+   * @param other the ids to look for
    * @return true, iff any of the specified ids is contained in the set
    */
-  public boolean containsAny(Set<GradoopId> ids) {
-    // we can't use the same logic as in #containsAny(GradoopIdList)
-    // because the #contains method of `ids` might be inefficient
-    for (GradoopId id : ids) {
-      if (this.contains(id)) {
+  public boolean containsAny(Set<GradoopId> other) {
+    Set<GradoopId> iterate = this.ids;
+    Set<GradoopId> contains = other;
+    int thisSize = this.size();
+    int otherSize = other.size();
+    if (thisSize > otherSize) {
+      iterate = other;
+      contains = this.ids;
+    }
+
+    for (GradoopId id : iterate) {
+      if (contains.contains(id)) {
         return true;
       }
     }

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/id/GradoopIdSet.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/id/GradoopIdSet.java
@@ -20,6 +20,7 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.types.Value;
 
 import java.io.IOException;
+import java.util.AbstractSet;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -34,7 +35,7 @@ import java.util.Set;
  *
  * @see GradoopId
  */
-public class GradoopIdSet implements Iterable<GradoopId>, Value {
+public class GradoopIdSet extends AbstractSet<GradoopId> implements Value {
   /**
    * Contains the set of gradoop ids.
    */
@@ -132,8 +133,9 @@ public class GradoopIdSet implements Iterable<GradoopId>, Value {
    *
    * @param id the id to add
    */
-  public void add(GradoopId id) {
-    this.ids.add(id);
+  @Override
+  public boolean add(GradoopId id) {
+    return this.ids.add(id);
   }
 
   /**
@@ -150,8 +152,9 @@ public class GradoopIdSet implements Iterable<GradoopId>, Value {
    *
    * @param ids the ids to add
    */
-  public void addAll(Collection<GradoopId> ids) {
-    this.ids.addAll(ids);
+  @Override
+  public boolean addAll(Collection<? extends GradoopId> ids) {
+    return this.ids.addAll(ids);
   }
 
   /**
@@ -160,7 +163,8 @@ public class GradoopIdSet implements Iterable<GradoopId>, Value {
    * @param identifier the id to look for
    * @return true, iff the given id is in the set
    */
-  public boolean contains(GradoopId identifier) {
+  @Override
+  public boolean contains(Object identifier) {
     return this.ids.contains(identifier);
   }
 
@@ -188,11 +192,12 @@ public class GradoopIdSet implements Iterable<GradoopId>, Value {
    * @param other the ids to look for
    * @return true, iff all specified ids are contained in the set
    */
-  public boolean containsAll(Set<GradoopId> other) {
+  @Override
+  public boolean containsAll(Collection<?> other) {
     if (other.size() > this.size()) {
       return false;
     }
-    for (GradoopId id : other) {
+    for (Object id : other) {
       if (!this.contains(id)) {
         return false;
       }

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/id/GradoopIds.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/id/GradoopIds.java
@@ -167,11 +167,14 @@ public class GradoopIds implements Iterable<GradoopId>, Value {
   /**
    * Checks if the specified ids are contained in the set.
    *
-   * @param ids the ids to look for
+   * @param other the ids to look for
    * @return true, iff all specified ids are contained in the set
    */
-  public boolean containsAll(GradoopIds ids) {
-    for (GradoopId id : ids) {
+  public boolean containsAll(GradoopIds other) {
+    if (other.size() > this.size()) {
+      return false;
+    }
+    for (GradoopId id : other) {
       if (!this.contains(id)) {
         return false;
       }
@@ -182,11 +185,14 @@ public class GradoopIds implements Iterable<GradoopId>, Value {
   /**
    * Checks if the specified ids are contained in the set.
    *
-   * @param ids the ids to look for
+   * @param other the ids to look for
    * @return true, iff all specified ids are contained in the set
    */
-  public boolean containsAll(Collection<GradoopId> ids) {
-    for (GradoopId id : ids) {
+  public boolean containsAll(Collection<GradoopId> other) {
+    if (other.size() > this.size()) {
+      return false;
+    }
+    for (GradoopId id : other) {
       if (!this.contains(id)) {
         return false;
       }
@@ -197,12 +203,24 @@ public class GradoopIds implements Iterable<GradoopId>, Value {
   /**
    * Checks if any of the specified ids is contained in the set.
    *
-   * @param ids the ids to look for
+   * @param other the ids to look for
    * @return true, iff any of the specified ids is contained in the set
    */
-  public boolean containsAny(GradoopIds ids) {
-    for (GradoopId id : ids) {
-      if (this.contains(id)) {
+  public boolean containsAny(GradoopIds other) {
+    // Algorithm: the sizes of both lists might be vastly different
+    // to prevent the case of iterating multiple times over large collections
+    // we make sure to always iterate over the smaller one
+    Set<GradoopId> iterate = this.ids;
+    Set<GradoopId> contains = other.ids;
+    int thisSize = this.size();
+    int otherSize = other.size();
+    if (thisSize > otherSize) {
+      iterate = other.ids;
+      contains = this.ids;
+    }
+
+    for (GradoopId id : iterate) {
+      if (contains.contains(id)) {
         return true;
       }
     }
@@ -216,6 +234,8 @@ public class GradoopIds implements Iterable<GradoopId>, Value {
    * @return true, iff any of the specified ids is contained in the set
    */
   public boolean containsAny(Collection<GradoopId> ids) {
+    // we can't use the same logic as in #containsAny(GradoopIdList)
+    // because the #contains method of `ids` might be inefficient
     for (GradoopId id : ids) {
       if (this.contains(id)) {
         return true;

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/Edge.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/Edge.java
@@ -17,7 +17,7 @@ package org.gradoop.common.model.impl.pojo;
 
 import org.gradoop.common.model.api.entities.EPGMEdge;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.properties.Properties;
 
 /**
@@ -53,7 +53,7 @@ public class Edge extends GraphElement implements EPGMEdge {
    */
   public Edge(final GradoopId id, final String label, final GradoopId sourceId,
     final GradoopId targetId, final Properties properties,
-    GradoopIds graphIds) {
+    GradoopIdSet graphIds) {
     super(id, label, properties, graphIds);
     this.sourceId = sourceId;
     this.targetId = targetId;

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/EdgeFactory.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/EdgeFactory.java
@@ -17,7 +17,7 @@ package org.gradoop.common.model.impl.pojo;
 
 import org.gradoop.common.model.api.entities.EPGMEdgeFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.common.util.GradoopConstants;
 
@@ -102,7 +102,7 @@ public class EdgeFactory implements EPGMEdgeFactory<Edge>, Serializable {
    */
   @Override
   public Edge createEdge(String label, GradoopId sourceVertexId,
-    GradoopId targetVertexId, GradoopIds graphIds) {
+    GradoopId targetVertexId, GradoopIdSet graphIds) {
     return initEdge(GradoopId.get(),
       label, sourceVertexId, targetVertexId, graphIds);
   }
@@ -113,7 +113,7 @@ public class EdgeFactory implements EPGMEdgeFactory<Edge>, Serializable {
   @Override
   public Edge initEdge(final GradoopId id, final String label,
     final GradoopId sourceVertexId, final GradoopId targetVertexId,
-    GradoopIds graphs) {
+    GradoopIdSet graphs) {
     return initEdge(id, label, sourceVertexId, targetVertexId, null, graphs);
   }
 
@@ -123,7 +123,7 @@ public class EdgeFactory implements EPGMEdgeFactory<Edge>, Serializable {
   @Override
   public Edge createEdge(String label, GradoopId sourceVertexId,
     GradoopId targetVertexId, Properties properties,
-    GradoopIds graphIds) {
+    GradoopIdSet graphIds) {
     return initEdge(GradoopId.get(),
       label, sourceVertexId, targetVertexId, properties, graphIds);
   }
@@ -134,7 +134,7 @@ public class EdgeFactory implements EPGMEdgeFactory<Edge>, Serializable {
   @Override
   public Edge initEdge(final GradoopId id, final String label,
     final GradoopId sourceVertexId, final GradoopId targetVertexId,
-    final Properties properties, GradoopIds graphIds) {
+    final Properties properties, GradoopIdSet graphIds) {
     checkNotNull(id, "Identifier was null");
     checkNotNull(label, "Label was null");
     checkNotNull(sourceVertexId, "Source vertex id was null");

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/GraphElement.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/GraphElement.java
@@ -17,7 +17,7 @@ package org.gradoop.common.model.impl.pojo;
 
 import org.gradoop.common.model.api.entities.EPGMGraphElement;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.properties.Properties;
 
 /**
@@ -31,7 +31,7 @@ public abstract class GraphElement
   /**
    * Set of graph identifiers that element is contained in
    */
-  private GradoopIds graphIds;
+  private GradoopIdSet graphIds;
 
   /**
    * Default constructor.
@@ -47,7 +47,7 @@ public abstract class GraphElement
    * @param graphIds     graphIds that element is contained in
    */
   protected GraphElement(GradoopId id, String label,
-    Properties properties, GradoopIds graphIds) {
+    Properties properties, GradoopIdSet graphIds) {
     super(id, label, properties);
     this.graphIds = graphIds;
   }
@@ -56,7 +56,7 @@ public abstract class GraphElement
    * {@inheritDoc}
    */
   @Override
-  public GradoopIds getGraphIds() {
+  public GradoopIdSet getGraphIds() {
     return graphIds;
   }
 
@@ -66,7 +66,7 @@ public abstract class GraphElement
   @Override
   public void addGraphId(GradoopId graphId) {
     if (graphIds == null) {
-      graphIds = new GradoopIds();
+      graphIds = new GradoopIdSet();
     }
     graphIds.add(graphId);
   }
@@ -75,7 +75,7 @@ public abstract class GraphElement
    * {@inheritDoc}
    */
   @Override
-  public void setGraphIds(GradoopIds graphIds) {
+  public void setGraphIds(GradoopIdSet graphIds) {
     this.graphIds = graphIds;
   }
 

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/Vertex.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/Vertex.java
@@ -17,7 +17,7 @@ package org.gradoop.common.model.impl.pojo;
 
 import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.properties.Properties;
 
 /**
@@ -40,7 +40,7 @@ public class Vertex extends GraphElement implements EPGMVertex {
    * @param graphs     graphs that vertex is contained in
    */
   public Vertex(final GradoopId id, final String label,
-    final Properties properties, final GradoopIds graphs) {
+    final Properties properties, final GradoopIdSet graphs) {
     super(id, label, properties, graphs);
   }
 

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/VertexFactory.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/pojo/VertexFactory.java
@@ -18,7 +18,7 @@ package org.gradoop.common.model.impl.pojo;
 import com.google.common.base.Preconditions;
 import org.gradoop.common.model.api.entities.EPGMVertexFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.common.util.GradoopConstants;
 
@@ -87,7 +87,7 @@ public class VertexFactory implements EPGMVertexFactory<Vertex>, Serializable {
    * {@inheritDoc}
    */
   @Override
-  public Vertex createVertex(String label, GradoopIds graphIds) {
+  public Vertex createVertex(String label, GradoopIdSet graphIds) {
     return initVertex(GradoopId.get(), label, graphIds);
   }
 
@@ -96,7 +96,7 @@ public class VertexFactory implements EPGMVertexFactory<Vertex>, Serializable {
    */
   @Override
   public Vertex initVertex(final GradoopId vertexID, final String label,
-    final GradoopIds graphs) {
+    final GradoopIdSet graphs) {
     return initVertex(vertexID, label, null, graphs);
   }
 
@@ -105,7 +105,7 @@ public class VertexFactory implements EPGMVertexFactory<Vertex>, Serializable {
    */
   @Override
   public Vertex createVertex(String label, Properties properties,
-    GradoopIds graphIds) {
+    GradoopIdSet graphIds) {
     return initVertex(GradoopId.get(), label, properties, graphIds);
   }
 
@@ -114,7 +114,7 @@ public class VertexFactory implements EPGMVertexFactory<Vertex>, Serializable {
    */
   @Override
   public Vertex initVertex(final GradoopId id, final String label,
-    final Properties properties, final GradoopIds graphs) {
+    final Properties properties, final GradoopIdSet graphs) {
     Preconditions.checkNotNull(id, "Identifier was null");
     Preconditions.checkNotNull(label, "Label was null");
     return new Vertex(id, label, properties, graphs);

--- a/gradoop-common/src/main/java/org/gradoop/common/util/AsciiGraphLoader.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/util/AsciiGraphLoader.java
@@ -24,7 +24,7 @@ import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.common.model.impl.id.GradoopId;
 import org.gradoop.common.config.GradoopConfig;
 import org.gradoop.common.model.api.entities.EPGMEdge;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.s1ck.gdl.GDLHandler;
 import org.s1ck.gdl.model.Edge;
@@ -295,7 +295,7 @@ public class AsciiGraphLoader
    * @param graphIds graph identifiers
    * @return vertices that are contained in the graphs
    */
-  public Collection<V> getVerticesByGraphIds(GradoopIds graphIds) {
+  public Collection<V> getVerticesByGraphIds(GradoopIdSet graphIds) {
     Collection<V> result = Sets.newHashSetWithExpectedSize(graphIds.size());
     for (V vertex : vertices.values()) {
       if (vertex.getGraphIds().containsAny(graphIds)) {
@@ -312,7 +312,7 @@ public class AsciiGraphLoader
    * @return vertices that are contained in the graphs
    */
   public Collection<V> getVerticesByGraphVariables(String... graphVariables) {
-    GradoopIds graphIds = new GradoopIds();
+    GradoopIdSet graphIds = new GradoopIdSet();
     for (G graphHead : getGraphHeadsByVariables(graphVariables)) {
       graphIds.add(graphHead.getId());
     }
@@ -365,7 +365,7 @@ public class AsciiGraphLoader
    * @param graphIds Graph identifiers
    * @return edges
    */
-  public Collection<E>  getEdgesByGraphIds(GradoopIds graphIds) {
+  public Collection<E>  getEdgesByGraphIds(GradoopIdSet graphIds) {
     Collection<E>  result = Sets.newHashSetWithExpectedSize(graphIds.size());
     for (E edge : edges.values()) {
       if (edge.getGraphIds().containsAny(graphIds)) {
@@ -382,7 +382,7 @@ public class AsciiGraphLoader
    * @return edges
    */
   public Collection<E>  getEdgesByGraphVariables(String... variables) {
-    GradoopIds graphIds = new GradoopIds();
+    GradoopIdSet graphIds = new GradoopIdSet();
     for (G graphHead : getGraphHeadsByVariables(variables)) {
       graphIds.add(graphHead.getId());
     }
@@ -573,8 +573,8 @@ public class AsciiGraphLoader
    * @param e graph element
    * @return GradoopIDSet for the given element
    */
-  private GradoopIds createGradoopIdSet(GraphElement e) {
-    GradoopIds result = new GradoopIds();
+  private GradoopIdSet createGradoopIdSet(GraphElement e) {
+    GradoopIdSet result = new GradoopIdSet();
     for (Long graphId : e.getGraphs()) {
       result.add(graphHeadIds.get(graphId));
     }

--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/id/GradoopIdsTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/id/GradoopIdsTest.java
@@ -21,6 +21,8 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.junit.Test;
 
+import com.google.common.collect.Sets;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
@@ -40,7 +42,7 @@ public class GradoopIdsTest {
     GradoopId id1 = GradoopId.get();
     GradoopId id2 = GradoopId.get();
 
-    GradoopIds ids = new GradoopIds();
+    GradoopIdSet ids = new GradoopIdSet();
 
     assertThat(ids.size(), is(0));
 
@@ -63,7 +65,7 @@ public class GradoopIdsTest {
     GradoopId id1 = GradoopId.get();
     GradoopId id2 = GradoopId.get();
 
-    GradoopIds ids = new GradoopIds();
+    GradoopIdSet ids = new GradoopIdSet();
     ids.add(id1);
 
     assertThat(ids.size(), is(1));
@@ -77,7 +79,7 @@ public class GradoopIdsTest {
     GradoopId id2 = GradoopId.get();
     GradoopId id3 = GradoopId.get();
 
-    GradoopIds ids = new GradoopIds();
+    GradoopIdSet ids = new GradoopIdSet();
     ids.addAll(Arrays.asList(id1, id2));
 
     assertThat(ids.size(), is(2));
@@ -93,11 +95,11 @@ public class GradoopIdsTest {
   public void testAddAllGradoopIds() throws Exception {
     GradoopId id1 = GradoopId.get();
     GradoopId id2 = GradoopId.get();
-    GradoopIds list1 = new GradoopIds();
+    GradoopIdSet list1 = new GradoopIdSet();
     list1.add(id1);
     list1.add(id2);
 
-    GradoopIds list2 = new GradoopIds();
+    GradoopIdSet list2 = new GradoopIdSet();
     list2.addAll(list1);
 
     assertThat(list2.size(), is(2));
@@ -113,14 +115,14 @@ public class GradoopIdsTest {
     GradoopId id2 = GradoopId.get();
     GradoopId id3 = GradoopId.get();
 
-    GradoopIds ids = new GradoopIds();
+    GradoopIdSet ids = new GradoopIdSet();
     ids.addAll(Arrays.asList(id1, id2));
 
-    assertTrue(ids.containsAll(Arrays.asList(id1)));
-    assertTrue(ids.containsAll(Arrays.asList(id2)));
-    assertTrue(ids.containsAll(Arrays.asList(id1, id2)));
-    assertFalse(ids.containsAll(Arrays.asList(id3)));
-    assertFalse(ids.containsAll(Arrays.asList(id1, id3)));
+    assertTrue(ids.containsAll(Sets.newHashSet(id1)));
+    assertTrue(ids.containsAll(Sets.newHashSet(id2)));
+    assertTrue(ids.containsAll(Sets.newHashSet(id1, id2)));
+    assertFalse(ids.containsAll(Sets.newHashSet(id3)));
+    assertFalse(ids.containsAll(Sets.newHashSet(id1, id3)));
   }
 
   @Test
@@ -130,14 +132,14 @@ public class GradoopIdsTest {
     GradoopId id3 = GradoopId.get();
 
 
-    GradoopIds ids = new GradoopIds();
+    GradoopIdSet ids = new GradoopIdSet();
     ids.addAll(Arrays.asList(id1, id2));
 
-    assertTrue(ids.containsAll(GradoopIds.fromExisting(id1)));
-    assertTrue(ids.containsAll(GradoopIds.fromExisting(id2)));
-    assertTrue(ids.containsAll(GradoopIds.fromExisting(id1, id2)));
-    assertFalse(ids.containsAll(GradoopIds.fromExisting(id3)));
-    assertFalse(ids.containsAll(GradoopIds.fromExisting(id1, id3)));
+    assertTrue(ids.containsAll(GradoopIdSet.fromExisting(id1)));
+    assertTrue(ids.containsAll(GradoopIdSet.fromExisting(id2)));
+    assertTrue(ids.containsAll(GradoopIdSet.fromExisting(id1, id2)));
+    assertFalse(ids.containsAll(GradoopIdSet.fromExisting(id3)));
+    assertFalse(ids.containsAll(GradoopIdSet.fromExisting(id1, id3)));
   }
 
   @Test
@@ -147,14 +149,14 @@ public class GradoopIdsTest {
     GradoopId id3 = GradoopId.get();
 
 
-    GradoopIds ids = new GradoopIds();
+    GradoopIdSet ids = new GradoopIdSet();
     ids.addAll(Arrays.asList(id1, id2));
 
-    assertTrue(ids.containsAny(Arrays.asList(id1)));
-    assertTrue(ids.containsAny(Arrays.asList(id2)));
-    assertTrue(ids.containsAny(Arrays.asList(id1, id2)));
-    assertFalse(ids.containsAny(Arrays.asList(id3)));
-    assertTrue(ids.containsAny(Arrays.asList(id1, id3)));
+    assertTrue(ids.containsAny(Sets.newHashSet(id1)));
+    assertTrue(ids.containsAny(Sets.newHashSet(id2)));
+    assertTrue(ids.containsAny(Sets.newHashSet(id1, id2)));
+    assertFalse(ids.containsAny(Sets.newHashSet(id3)));
+    assertTrue(ids.containsAny(Sets.newHashSet(id1, id3)));
   }
 
   @Test
@@ -163,20 +165,20 @@ public class GradoopIdsTest {
     GradoopId id2 = GradoopId.get();
     GradoopId id3 = GradoopId.get();
 
-    GradoopIds ids = new GradoopIds();
+    GradoopIdSet ids = new GradoopIdSet();
     ids.addAll(Arrays.asList(id1, id2));
 
-    assertTrue(ids.containsAny(GradoopIds.fromExisting(id1)));
-    assertTrue(ids.containsAny(GradoopIds.fromExisting(id2)));
-    assertTrue(ids.containsAny(GradoopIds.fromExisting(id1, id2)));
-    assertFalse(ids.containsAny(GradoopIds.fromExisting(id3)));
-    assertTrue(ids.containsAny(GradoopIds.fromExisting(id1, id3)));
+    assertTrue(ids.containsAny(GradoopIdSet.fromExisting(id1)));
+    assertTrue(ids.containsAny(GradoopIdSet.fromExisting(id2)));
+    assertTrue(ids.containsAny(GradoopIdSet.fromExisting(id1, id2)));
+    assertFalse(ids.containsAny(GradoopIdSet.fromExisting(id3)));
+    assertTrue(ids.containsAny(GradoopIdSet.fromExisting(id1, id3)));
   }
 
   @Test
   public void testIsEmpty() throws Exception {
-    GradoopIds set1 = GradoopIds.fromExisting(GradoopId.get());
-    GradoopIds set2 = new GradoopIds();
+    GradoopIdSet set1 = GradoopIdSet.fromExisting(GradoopId.get());
+    GradoopIdSet set2 = new GradoopIdSet();
 
     assertFalse(set1.isEmpty());
     assertTrue(set2.isEmpty());
@@ -187,7 +189,7 @@ public class GradoopIdsTest {
     GradoopId id1 = GradoopId.get();
     GradoopId id2 = GradoopId.get();
 
-    GradoopIds idsWrite = GradoopIds.fromExisting(id1, id2);
+    GradoopIdSet idsWrite = GradoopIdSet.fromExisting(id1, id2);
 
     // write to byte[]
     ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -195,7 +197,7 @@ public class GradoopIdsTest {
     idsWrite.write(dataOutputView);
 
     // read from byte[]
-    GradoopIds idsRead = new GradoopIds();
+    GradoopIdSet idsRead = new GradoopIdSet();
     ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
     DataInputView dataInputView = new DataInputViewStreamWrapper(in);
     idsRead.read(dataInputView);
@@ -210,7 +212,7 @@ public class GradoopIdsTest {
     GradoopId id1 = GradoopId.get();
     GradoopId id2 = GradoopId.get();
 
-    GradoopIds ids = GradoopIds.fromExisting(id1, id2);
+    GradoopIdSet ids = GradoopIdSet.fromExisting(id1, id2);
 
     Iterator<GradoopId> idsIterator = ids.iterator();
 
@@ -223,7 +225,7 @@ public class GradoopIdsTest {
 
   @Test(expected = NoSuchElementException.class)
   public void testIteratorException() throws Exception {
-    GradoopIds ids = new GradoopIds();
+    GradoopIdSet ids = new GradoopIdSet();
 
     Iterator<GradoopId> idsIterator = ids.iterator();
 
@@ -236,7 +238,7 @@ public class GradoopIdsTest {
     GradoopId id1 = GradoopId.get();
     GradoopId id2 = GradoopId.get();
 
-    GradoopIds ids = new GradoopIds();
+    GradoopIdSet ids = new GradoopIdSet();
     ids.add(id1);
     ids.add(id2);
 
@@ -252,7 +254,7 @@ public class GradoopIdsTest {
     GradoopId id1 = GradoopId.get();
     GradoopId id2 = GradoopId.get();
 
-    GradoopIds ids = new GradoopIds();
+    GradoopIdSet ids = new GradoopIdSet();
     assertThat(ids.size(), is(0));
     ids.add(id1);
     assertThat(ids.size(), is(1));
@@ -267,7 +269,7 @@ public class GradoopIdsTest {
     GradoopId id1 = GradoopId.get();
     GradoopId id2 = GradoopId.get();
     GradoopId id3 = GradoopId.get();
-    GradoopIds ids = GradoopIds.fromExisting(id1, id2, id3);
+    GradoopIdSet ids = GradoopIdSet.fromExisting(id1, id2, id3);
     assertThat(ids.size(), is(3));
   }
 
@@ -277,32 +279,32 @@ public class GradoopIdsTest {
     GradoopId b = GradoopId.get();
     GradoopId c = GradoopId.get();
 
-    GradoopIds abc = GradoopIds.fromExisting(a, b, c);
+    GradoopIdSet abc = GradoopIdSet.fromExisting(a, b, c);
     assertTrue("equals failed for same object", abc.equals(abc));
     assertTrue("hashCode failed for same object", abc.hashCode() == abc.hashCode());
 
-    GradoopIds abc2 = GradoopIds.fromExisting(a, b, c);
+    GradoopIdSet abc2 = GradoopIdSet.fromExisting(a, b, c);
     assertTrue("equals failed for same ids in same order", abc.equals(abc2));
     assertTrue("hashCode failed for same ids in same order", abc.hashCode() == abc2.hashCode());
 
-    GradoopIds cba = GradoopIds.fromExisting(c, b, a);
+    GradoopIdSet cba = GradoopIdSet.fromExisting(c, b, a);
     assertTrue("equals succeeds for same ids in different order", abc.equals(cba));
     assertTrue("hashCode succeeds for same ids in different order", abc.hashCode() == cba.hashCode());
 
-    GradoopIds aab = GradoopIds.fromExisting(a, a, b);
-    GradoopIds abb = GradoopIds.fromExisting(a, b, b);
+    GradoopIdSet aab = GradoopIdSet.fromExisting(a, a, b);
+    GradoopIdSet abb = GradoopIdSet.fromExisting(a, b, b);
     assertTrue("equals succeeds for same ids in different cardinality", aab.equals(abb));
     assertTrue("hashCode succeeds for same ids in different cardinality", aab.hashCode() == abb.hashCode());
 
-    GradoopIds ab = GradoopIds.fromExisting(a, b);
+    GradoopIdSet ab = GradoopIdSet.fromExisting(a, b);
     assertTrue("equals succeeds for same ids but different sizes", aab.equals(ab));
     assertTrue("hashCode succeeds for same ids but different sizes", aab.hashCode() == ab.hashCode());
 
-    GradoopIds empty = new GradoopIds();
+    GradoopIdSet empty = new GradoopIdSet();
     assertTrue("equals failed for one empty list", !abc.equals(empty));
     assertTrue("hashCode failed for one empty list", abc.hashCode() != empty.hashCode());
 
-    GradoopIds empty2 = new GradoopIds();
+    GradoopIdSet empty2 = new GradoopIdSet();
     assertTrue("equals failed for two empty lists", empty2.equals(empty));
     assertTrue("hashCode failed two one empty lists", empty2.hashCode() == empty.hashCode());
   }

--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/pojo/EdgeTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/pojo/EdgeTest.java
@@ -17,7 +17,7 @@ package org.gradoop.common.model.impl.pojo;
 
 import org.gradoop.common.model.api.entities.EPGMEdge;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.common.util.GradoopConstants;
 import org.hamcrest.core.Is;
@@ -47,7 +47,7 @@ public class EdgeTest {
     GradoopId edgeId = GradoopId.get();
     GradoopId sourceId = GradoopId.get();
     GradoopId targetId = GradoopId.get();
-    GradoopIds graphIds = GradoopIds
+    GradoopIdSet graphIds = GradoopIdSet
       .fromExisting(GradoopId.get(), GradoopId.get());
 
     String label = "A";

--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/pojo/VertexTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/pojo/VertexTest.java
@@ -17,7 +17,7 @@ package org.gradoop.common.model.impl.pojo;
 
 import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.common.util.GradoopConstants;
 import org.hamcrest.core.Is;
@@ -48,7 +48,7 @@ public class VertexTest {
     GradoopId graphId1 = GradoopId.get();
     GradoopId graphId2 = GradoopId.get();
 
-    GradoopIds graphIds = new GradoopIds();
+    GradoopIdSet graphIds = new GradoopIdSet();
     graphIds.add(graphId1);
     graphIds.add(graphId2);
 

--- a/gradoop-common/src/test/java/org/gradoop/common/util/AsciiGraphLoaderTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/util/AsciiGraphLoaderTest.java
@@ -16,7 +16,7 @@
 package org.gradoop.common.util;
 
 import org.gradoop.common.config.GradoopConfig;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -149,13 +149,13 @@ public class AsciiGraphLoaderTest {
     GraphHead h = asciiGraphLoader.getGraphHeadByVariable("h");
 
     Collection<Vertex> vertexsG = asciiGraphLoader
-      .getVerticesByGraphIds(GradoopIds.fromExisting(g.getId()));
+      .getVerticesByGraphIds(GradoopIdSet.fromExisting(g.getId()));
 
     Collection<Vertex> vertexsH = asciiGraphLoader
-      .getVerticesByGraphIds(GradoopIds.fromExisting(h.getId()));
+      .getVerticesByGraphIds(GradoopIdSet.fromExisting(h.getId()));
 
     Collection<Vertex> vertexsGH = asciiGraphLoader
-      .getVerticesByGraphIds(GradoopIds.fromExisting(g.getId(), h.getId()));
+      .getVerticesByGraphIds(GradoopIdSet.fromExisting(g.getId(), h.getId()));
 
     Vertex a = asciiGraphLoader.getVertexByVariable("a");
     Vertex b = asciiGraphLoader.getVertexByVariable("b");
@@ -252,13 +252,13 @@ public class AsciiGraphLoaderTest {
     GraphHead h = asciiGraphLoader.getGraphHeadByVariable("h");
 
     Collection<Edge> edgesG = asciiGraphLoader
-      .getEdgesByGraphIds(GradoopIds.fromExisting(g.getId()));
+      .getEdgesByGraphIds(GradoopIdSet.fromExisting(g.getId()));
 
     Collection<Edge> edgesH = asciiGraphLoader
-      .getEdgesByGraphIds(GradoopIds.fromExisting(h.getId()));
+      .getEdgesByGraphIds(GradoopIdSet.fromExisting(h.getId()));
 
     Collection<Edge> edgesGH = asciiGraphLoader
-      .getEdgesByGraphIds(GradoopIds.fromExisting(g.getId(), h.getId()));
+      .getEdgesByGraphIds(GradoopIdSet.fromExisting(g.getId(), h.getId()));
 
     Edge a = asciiGraphLoader.getEdgeByVariable("a");
     Edge b = asciiGraphLoader.getEdgeByVariable("b");

--- a/gradoop-examples/src/main/java/org/gradoop/benchmark/patternmatching/TransactionalBenchmark.java
+++ b/gradoop-examples/src/main/java/org/gradoop/benchmark/patternmatching/TransactionalBenchmark.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.examples.AbstractRunner;
 import org.gradoop.flink.io.impl.tlf.TLFDataSource;
 import org.gradoop.flink.model.impl.operators.matching.transactional.TransactionalPatternMatching;
@@ -103,7 +103,7 @@ public class TransactionalBenchmark extends AbstractRunner {
         .map(new GraphTransactionMatcher(queryString));
 
     if (returnEmbeddings) {
-      DataSet<Tuple4<GradoopId, GradoopId, GradoopIds, GradoopIds>> embeddings =
+      DataSet<Tuple4<GradoopId, GradoopId, GradoopIdSet, GradoopIdSet>> embeddings =
         graphs.flatMap(
           new FindEmbeddings(new DepthSearchMatching(), queryString));
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/BusinessTransactionGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/BusinessTransactionGraphs.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.types.NullValue;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -100,7 +100,7 @@ public class BusinessTransactionGraphs implements
       .runScatterGatherIteration(new BtgMessenger(), new BtgUpdater() , 100);
 
 
-    DataSet<Tuple2<GradoopId, GradoopIds>> btgVerticesMap = gellyTransGraph
+    DataSet<Tuple2<GradoopId, GradoopIdSet>> btgVerticesMap = gellyTransGraph
       .getVerticesAsTuple2()
       .map(new SwitchPair<>())
       .groupBy(0)
@@ -135,7 +135,7 @@ public class BusinessTransactionGraphs implements
       .with(new LeftSide<>())
       .distinct();
 
-    DataSet<Tuple2<GradoopId, GradoopIds>> vertexBtgsMap = vertexBtgMap
+    DataSet<Tuple2<GradoopId, GradoopIdSet>> vertexBtgsMap = vertexBtgMap
       .groupBy(0)
       //.combineGroup(new CollectGradoopIds())
       .reduceGroup(new CollectGradoopIds());

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/functions/CollectGradoopIds.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/functions/CollectGradoopIds.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * (a,b),(a,c) => (a,{b,c})
@@ -28,17 +28,17 @@ import org.gradoop.common.model.impl.id.GradoopIds;
  */
 public class CollectGradoopIds implements
   GroupCombineFunction
-    <Tuple2<GradoopId, GradoopIds>, Tuple2<GradoopId, GradoopIds>>,
+    <Tuple2<GradoopId, GradoopIdSet>, Tuple2<GradoopId, GradoopIdSet>>,
   GroupReduceFunction
-    <Tuple2<GradoopId, GradoopId>, Tuple2<GradoopId, GradoopIds>> {
+    <Tuple2<GradoopId, GradoopId>, Tuple2<GradoopId, GradoopIdSet>> {
 
   @Override
   public void reduce(Iterable<Tuple2<GradoopId, GradoopId>> mappings,
-    Collector<Tuple2<GradoopId, GradoopIds>> collector) throws Exception {
+    Collector<Tuple2<GradoopId, GradoopIdSet>> collector) throws Exception {
 
     Boolean first = true;
     GradoopId vertexId = null;
-    GradoopIds btgIds = new GradoopIds();
+    GradoopIdSet btgIds = new GradoopIdSet();
 
     for (Tuple2<GradoopId, GradoopId> pair : mappings) {
       if (first) {
@@ -51,14 +51,14 @@ public class CollectGradoopIds implements
   }
 
   @Override
-  public void combine(Iterable<Tuple2<GradoopId, GradoopIds>> mappings,
-    Collector<Tuple2<GradoopId, GradoopIds>> collector) throws Exception {
+  public void combine(Iterable<Tuple2<GradoopId, GradoopIdSet>> mappings,
+    Collector<Tuple2<GradoopId, GradoopIdSet>> collector) throws Exception {
 
     Boolean first = true;
     GradoopId vertexId = null;
-    GradoopIds btgIds = null;
+    GradoopIdSet btgIds = null;
 
-    for (Tuple2<GradoopId, GradoopIds> pair : mappings) {
+    for (Tuple2<GradoopId, GradoopIdSet> pair : mappings) {
       if (first) {
         vertexId = pair.f0;
         btgIds = pair.f1;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/functions/ComponentToNewBtgId.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/functions/ComponentToNewBtgId.java
@@ -19,18 +19,18 @@ import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * replaces a component id by a new graph id
  */
 @FunctionAnnotation.ForwardedFields("f1->f1")
 public class ComponentToNewBtgId implements MapFunction
-  <Tuple2<GradoopId, GradoopIds>, Tuple2<GradoopId, GradoopIds>> {
+  <Tuple2<GradoopId, GradoopIdSet>, Tuple2<GradoopId, GradoopIdSet>> {
 
   @Override
-  public Tuple2<GradoopId, GradoopIds> map(
-    Tuple2<GradoopId, GradoopIds> pair) throws Exception {
+  public Tuple2<GradoopId, GradoopIdSet> map(
+    Tuple2<GradoopId, GradoopIdSet> pair) throws Exception {
 
     return new Tuple2<>(GradoopId.get(), pair.f1);
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/functions/SetBtgId.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/functions/SetBtgId.java
@@ -19,7 +19,7 @@ import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.api.entities.EPGMGraphElement;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Associates an edge with an business transaction graph.
@@ -30,7 +30,7 @@ public class SetBtgId<E extends EPGMGraphElement>
 
   @Override
   public E join(E element, Tuple2<GradoopId, GradoopId> mapping) {
-    element.setGraphIds(GradoopIds.fromExisting(mapping.f1));
+    element.setGraphIds(GradoopIdSet.fromExisting(mapping.f1));
     return element;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/functions/SetBtgIds.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/functions/SetBtgIds.java
@@ -19,17 +19,17 @@ import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Associates a (master) vertex with business transaction graphs.
  * @param <V> vertex type
  */
 public class SetBtgIds<V extends EPGMVertex>
-  implements JoinFunction<V, Tuple2<GradoopId, GradoopIds>, V> {
+  implements JoinFunction<V, Tuple2<GradoopId, GradoopIdSet>, V> {
 
   @Override
-  public V join(V element, Tuple2<GradoopId, GradoopIds> mapping) throws
+  public V join(V element, Tuple2<GradoopId, GradoopIdSet> mapping) throws
     Exception {
     element.setGraphIds(mapping.f1);
     return element;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/fsm/dimspan/functions/conversion/DFSCodeToEPGMGraphTransaction.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/fsm/dimspan/functions/conversion/DFSCodeToEPGMGraphTransaction.java
@@ -19,7 +19,7 @@ import com.google.common.collect.Sets;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.configuration.Configuration;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -107,7 +107,7 @@ public class DFSCodeToEPGMGraphTransaction
     graphHead.setLabel(DIMSpanConstants.FREQUENT_PATTERN_LABEL);
     graphHead.setProperty(DIMSpanConstants.SUPPORT_KEY, (float) frequency / graphCount);
 
-    GradoopIds graphIds = GradoopIds.fromExisting(graphHead.getId());
+    GradoopIdSet graphIds = GradoopIdSet.fromExisting(graphHead.getId());
 
     // VERTICES
     int[] vertexLabels = graphUtils.getVertexLabels(pattern);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/fsm/transactional/tle/functions/SubgraphDecoder.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/fsm/transactional/tle/functions/SubgraphDecoder.java
@@ -22,7 +22,7 @@ import org.gradoop.common.model.api.entities.EPGMEdgeFactory;
 import org.gradoop.common.model.api.entities.EPGMGraphHeadFactory;
 import org.gradoop.common.model.api.entities.EPGMVertexFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -88,7 +88,7 @@ public abstract class SubgraphDecoder implements Serializable {
     GraphHead epgmGraphHead = graphHeadFactory
       .createGraphHead(canonicalLabel, properties);
 
-    GradoopIds graphIds = GradoopIds.fromExisting(epgmGraphHead.getId());
+    GradoopIdSet graphIds = GradoopIdSet.fromExisting(epgmGraphHead.getId());
 
     // VERTICES
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/TargetGraphIdList.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/TargetGraphIdList.java
@@ -19,7 +19,7 @@ import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 import java.util.Iterator;
 
@@ -27,11 +27,11 @@ import java.util.Iterator;
  * Reduces for each target id of an edge all the graph ids to one graph id list.
  */
 public class TargetGraphIdList
-  implements GroupReduceFunction<Tuple2<GradoopId, GradoopId>, Tuple2<GradoopId, GradoopIds>> {
+  implements GroupReduceFunction<Tuple2<GradoopId, GradoopId>, Tuple2<GradoopId, GradoopIdSet>> {
 
   @Override
   public void reduce(Iterable<Tuple2<GradoopId, GradoopId>> values,
-    Collector<Tuple2<GradoopId, GradoopIds>> out) throws Exception {
+    Collector<Tuple2<GradoopId, GradoopIdSet>> out) throws Exception {
 
     Iterator<Tuple2<GradoopId, GradoopId>> iterator = values.iterator();
 
@@ -39,7 +39,7 @@ public class TargetGraphIdList
 
     // the target id is the same for each iterator element
     GradoopId targetId = pair.f0;
-    GradoopIds graphIds = GradoopIds.fromExisting(pair.f1);
+    GradoopIdSet graphIds = GradoopIdSet.fromExisting(pair.f1);
 
     while (iterator.hasNext()) {
       graphIds.add(iterator.next().f1);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/UpdateGraphIds.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/UpdateGraphIds.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.datagen.transactions.foodbroker.functions;
 import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Vertex;
 
 /**
@@ -26,10 +26,10 @@ import org.gradoop.common.model.impl.pojo.Vertex;
  * element is the gradoop id of the vertex.
  */
 public class UpdateGraphIds
-  implements JoinFunction<Tuple2<GradoopId, GradoopIds>, Vertex, Vertex> {
+  implements JoinFunction<Tuple2<GradoopId, GradoopIdSet>, Vertex, Vertex> {
 
   @Override
-  public Vertex join(Tuple2<GradoopId, GradoopIds> pair, Vertex vertex) throws Exception {
+  public Vertex join(Tuple2<GradoopId, GradoopIdSet> pair, Vertex vertex) throws Exception {
     vertex.setGraphIds(pair.f1);
     return vertex;
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/process/AbstractProcess.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/process/AbstractProcess.java
@@ -24,7 +24,7 @@ import org.gradoop.common.model.api.entities.EPGMEdgeFactory;
 import org.gradoop.common.model.api.entities.EPGMGraphHeadFactory;
 import org.gradoop.common.model.api.entities.EPGMVertexFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -83,7 +83,7 @@ public abstract class AbstractProcess extends AbstractRichFunction {
   /**
    * Graph ids, one seperate id for each case.
    */
-  protected GradoopIds graphIds;
+  protected GradoopIdSet graphIds;
   /**
    * Map to quickly receive the target id of an edge.
    * Note that a object may have multiple outgoing edges with the same label.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/process/Brokerage.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/process/Brokerage.java
@@ -23,7 +23,7 @@ import org.gradoop.common.model.api.entities.EPGMEdgeFactory;
 import org.gradoop.common.model.api.entities.EPGMGraphHeadFactory;
 import org.gradoop.common.model.api.entities.EPGMVertexFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -85,7 +85,7 @@ public class Brokerage
     vertexMap = Maps.newHashMap();
     edgeMap = Maps.newHashMap();
     graphHead = graphHeadFactory.createGraphHead();
-    graphIds = new GradoopIds();
+    graphIds = new GradoopIdSet();
     graphIds.add(graphHead.getId());
     graphTransaction = new GraphTransaction();
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/process/ComplaintHandling.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/process/ComplaintHandling.java
@@ -25,7 +25,7 @@ import org.gradoop.common.model.api.entities.EPGMEdgeFactory;
 import org.gradoop.common.model.api.entities.EPGMGraphHeadFactory;
 import org.gradoop.common.model.api.entities.EPGMVertexFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -99,7 +99,7 @@ public class ComplaintHandling extends AbstractProcess
     vertexMap = Maps.newHashMap();
     masterDataMap = Maps.newHashMap();
     userMap = Maps.newHashMap();
-    graphIds = GradoopIds.fromExisting(graph.getGraphHead().getId());
+    graphIds = GradoopIdSet.fromExisting(graph.getGraphHead().getId());
 
     boolean confirmed = false;
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/predictable/PredictableTransaction.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/datagen/transactions/predictable/PredictableTransaction.java
@@ -26,7 +26,7 @@ import org.gradoop.common.model.api.entities.EPGMEdgeFactory;
 import org.gradoop.common.model.api.entities.EPGMGraphHeadFactory;
 import org.gradoop.common.model.api.entities.EPGMVertexFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -97,7 +97,7 @@ public class PredictableTransaction implements
     Set<Vertex> vertices = Sets.newHashSet();
     Set<Edge> edges = Sets.newHashSet();
 
-    GradoopIds graphIds = GradoopIds.fromExisting(graphHead.getId());
+    GradoopIdSet graphIds = GradoopIdSet.fromExisting(graphHead.getId());
 
     Vertex centerVertex = vertexFactory.createVertex("S", graphIds);
     vertices.add(centerVertex);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/json/functions/EntityToJSON.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/json/functions/EntityToJSON.java
@@ -24,7 +24,7 @@ import org.gradoop.flink.io.impl.json.JSONConstants;
 import org.gradoop.common.model.api.entities.EPGMAttributed;
 import org.gradoop.common.model.api.entities.EPGMLabeled;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Contains methods used by all entity writers (e.g. write meta, data).
@@ -102,7 +102,7 @@ public class EntityToJSON {
    * @param values identifier set
    * @return json array containing the identifiers
    */
-  private JSONArray writeJsonArray(final GradoopIds values) {
+  private JSONArray writeJsonArray(final GradoopIdSet values) {
     JSONArray jsonArray = new JSONArray();
     for (GradoopId val : values) {
       jsonArray.put(val);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/json/functions/JSONToEdge.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/json/functions/JSONToEdge.java
@@ -22,7 +22,7 @@ import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.flink.io.impl.json.JSONConstants;
 import org.gradoop.common.model.api.entities.EPGMEdgeFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.properties.Properties;
 
 /**
@@ -73,7 +73,7 @@ public class JSONToEdge extends JSONToEntity
     GradoopId targetID = getTargetId(jsonEdge);
     Properties properties = Properties.createFromMap(
       getProperties(jsonEdge));
-    GradoopIds graphs = getGraphs(jsonEdge);
+    GradoopIdSet graphs = getGraphs(jsonEdge);
 
     return edgeFactory.initEdge(edgeID, edgeLabel, sourceID, targetID,
       properties, graphs);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/json/functions/JSONToEntity.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/json/functions/JSONToEntity.java
@@ -21,7 +21,7 @@ import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.gradoop.flink.io.impl.json.JSONConstants;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -83,10 +83,10 @@ public class JSONToEntity {
    * @return graph identifiers
    * @throws JSONException
    */
-  protected GradoopIds getGraphs(JSONObject object) throws JSONException {
-    GradoopIds result;
+  protected GradoopIdSet getGraphs(JSONObject object) throws JSONException {
+    GradoopIdSet result;
     if (!object.getJSONObject(JSONConstants.META).has(JSONConstants.GRAPHS)) {
-      result = new GradoopIds();
+      result = new GradoopIdSet();
     } else {
       result = getArrayValues(object
           .getJSONObject(JSONConstants.META)
@@ -102,10 +102,10 @@ public class JSONToEntity {
    * @return long values
    * @throws JSONException
    */
-  protected GradoopIds getArrayValues(JSONArray array) throws
+  protected GradoopIdSet getArrayValues(JSONArray array) throws
     JSONException {
 
-    GradoopIds result = new GradoopIds();
+    GradoopIdSet result = new GradoopIdSet();
 
     for (int i = 0; i < array.length(); i++) {
       result.add(GradoopId.fromString(array.getString(i)));

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/json/functions/JSONToVertex.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/json/functions/JSONToVertex.java
@@ -20,7 +20,7 @@ import org.codehaus.jettison.json.JSONObject;
 import org.gradoop.common.model.impl.pojo.Vertex;
 import org.gradoop.common.model.api.entities.EPGMVertexFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.properties.Properties;
 
 /**
@@ -70,7 +70,7 @@ public class JSONToVertex extends JSONToEntity
     String label = getLabel(jsonVertex);
     Properties properties = Properties.createFromMap(
       getProperties(jsonVertex));
-    GradoopIds graphs = getGraphs(jsonVertex);
+    GradoopIdSet graphs = getGraphs(jsonVertex);
 
     return vertexFactory.initVertex(vertexID, label, properties, graphs);
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/GraphCollection.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/GraphCollection.java
@@ -19,7 +19,7 @@ import org.apache.commons.lang.NotImplementedException;
 import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.java.DataSet;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -197,7 +197,7 @@ public class GraphCollection implements GraphCollectionOperators, GraphCollectio
   @Override
   public GraphCollection getGraphs(final GradoopId... identifiers) {
 
-    GradoopIds graphIds = new GradoopIds();
+    GradoopIdSet graphIds = new GradoopIdSet();
 
     for (GradoopId id : identifiers) {
       graphIds.add(id);
@@ -210,7 +210,7 @@ public class GraphCollection implements GraphCollectionOperators, GraphCollectio
    * {@inheritDoc}
    */
   @Override
-  public GraphCollection getGraphs(final GradoopIds identifiers) {
+  public GraphCollection getGraphs(final GradoopIdSet identifiers) {
 
     DataSet<GraphHead> newGraphHeads = this.getGraphHeads()
       .filter(new FilterFunction<GraphHead>() {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/GraphCollectionOperators.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/GraphCollectionOperators.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.api.epgm;
 import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.java.DataSet;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.util.Order;
 import org.gradoop.flink.model.api.functions.GraphHeadReduceFunction;
@@ -64,7 +64,7 @@ public interface GraphCollectionOperators extends GraphBaseOperators {
    * @param identifiers graph identifiers
    * @return collection containing requested logical graphs
    */
-  GraphCollection getGraphs(GradoopIds identifiers);
+  GraphCollection getGraphs(GradoopIdSet identifiers);
 
   //----------------------------------------------------------------------------
   // Unary operators

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ElementsOfSelectedGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ElementsOfSelectedGraphs.java
@@ -20,9 +20,8 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.GraphElement;
-
-import java.util.Collection;
 
 /**
  * graphIds (BC)
@@ -43,7 +42,7 @@ public class ElementsOfSelectedGraphs<EL extends GraphElement> extends
   /**
    * graph ids
    */
-  protected Collection<GradoopId> graphIds;
+  protected GradoopIds graphIds;
 
   /**
    * reuse tuple
@@ -61,7 +60,7 @@ public class ElementsOfSelectedGraphs<EL extends GraphElement> extends
   public void open(Configuration parameters) throws Exception {
     super.open(parameters);
 
-    graphIds = getRuntimeContext().getBroadcastVariable(GRAPH_IDS);
+    graphIds = GradoopIds.fromExisting(getRuntimeContext().getBroadcastVariable(GRAPH_IDS));
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ElementsOfSelectedGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ElementsOfSelectedGraphs.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.GraphElement;
 
 /**
@@ -42,7 +42,7 @@ public class ElementsOfSelectedGraphs<EL extends GraphElement> extends
   /**
    * graph ids
    */
-  protected GradoopIds graphIds;
+  protected GradoopIdSet graphIds;
 
   /**
    * reuse tuple
@@ -60,7 +60,7 @@ public class ElementsOfSelectedGraphs<EL extends GraphElement> extends
   public void open(Configuration parameters) throws Exception {
     super.open(parameters);
 
-    graphIds = GradoopIds.fromExisting(getRuntimeContext().getBroadcastVariable(GRAPH_IDS));
+    graphIds = GradoopIdSet.fromExisting(getRuntimeContext().getBroadcastVariable(GRAPH_IDS));
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ExpandGradoopIds.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ExpandGradoopIds.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Takes a tuple 2, containing an object and a gradoop id set, and creates one
@@ -31,11 +31,11 @@ import org.gradoop.common.model.impl.id.GradoopIds;
 @FunctionAnnotation.ReadFields("f1")
 @FunctionAnnotation.ForwardedFields("f0->f0")
 public class ExpandGradoopIds<T> implements FlatMapFunction
-  <Tuple2<T, GradoopIds>, Tuple2<T, GradoopId>> {
+  <Tuple2<T, GradoopIdSet>, Tuple2<T, GradoopId>> {
 
   @Override
   public void flatMap(
-    Tuple2<T, GradoopIds> pair,
+    Tuple2<T, GradoopIdSet> pair,
     Collector<Tuple2<T, GradoopId>> collector) throws Exception {
 
     T firstField = pair.f0;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdAsIdSet.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdAsIdSet.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.functions.epgm;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.gradoop.common.model.impl.pojo.Element;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Maps an element to a GradoopIdSet, containing the elements id.
@@ -27,10 +27,10 @@ import org.gradoop.common.model.impl.id.GradoopIds;
  */
 @FunctionAnnotation.ReadFields("id")
 public class IdAsIdSet<EL extends Element>
-  implements MapFunction<EL, GradoopIds> {
+  implements MapFunction<EL, GradoopIdSet> {
 
   @Override
-  public GradoopIds map(EL element) {
-    return GradoopIds.fromExisting(element.getId());
+  public GradoopIdSet map(EL element) {
+    return GradoopIdSet.fromExisting(element.getId());
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdInBroadcast.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdInBroadcast.java
@@ -15,13 +15,10 @@
  */
 package org.gradoop.flink.model.impl.functions.epgm;
 
-import com.google.common.collect.Sets;
 import org.apache.flink.api.common.functions.RichFilterFunction;
 import org.apache.flink.configuration.Configuration;
 import org.gradoop.common.model.api.entities.EPGMElement;
-import org.gradoop.common.model.impl.id.GradoopId;
-
-import java.util.Collection;
+import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
  * Filters a dataset of EPGM elements to those whose id is contained in an id dataset.
@@ -38,13 +35,12 @@ public class IdInBroadcast<EL extends EPGMElement> extends RichFilterFunction<EL
   /**
    * graph ids
    */
-  protected Collection<GradoopId> ids;
+  protected GradoopIds ids;
 
   @Override
   public void open(Configuration parameters) throws Exception {
     super.open(parameters);
-    ids = getRuntimeContext().getBroadcastVariable(IDS);
-    ids = Sets.newHashSet(ids);
+    ids = GradoopIds.fromExisting(getRuntimeContext().getBroadcastVariable(IDS));
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdInBroadcast.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdInBroadcast.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.functions.epgm;
 import org.apache.flink.api.common.functions.RichFilterFunction;
 import org.apache.flink.configuration.Configuration;
 import org.gradoop.common.model.api.entities.EPGMElement;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Filters a dataset of EPGM elements to those whose id is contained in an id dataset.
@@ -35,12 +35,12 @@ public class IdInBroadcast<EL extends EPGMElement> extends RichFilterFunction<EL
   /**
    * graph ids
    */
-  protected GradoopIds ids;
+  protected GradoopIdSet ids;
 
   @Override
   public void open(Configuration parameters) throws Exception {
     super.open(parameters);
-    ids = GradoopIds.fromExisting(getRuntimeContext().getBroadcastVariable(IDS));
+    ids = GradoopIdSet.fromExisting(getRuntimeContext().getBroadcastVariable(IDS));
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdNotInBroadcast.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdNotInBroadcast.java
@@ -13,34 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradoop.flink.model.impl.operators.matching.transactional.function;
+package org.gradoop.flink.model.impl.functions.epgm;
 
 import org.apache.flink.api.common.functions.RichFilterFunction;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
-import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.common.model.api.entities.EPGMElement;
 import org.gradoop.common.model.impl.id.GradoopIds;
 
 /**
- * Filters a set of Tuple2 with GradoopIds in the first field by the
- * containment of this id in a broadcast set.
+ * Filters a dataset of EPGM elements to those whose id is not contained in an id dataset.
  *
- * @param <T> any type
+ * @param <EL> element type
  */
-public class GraphIdFilter<T> extends RichFilterFunction<Tuple2<GradoopId, T>> {
+public class IdNotInBroadcast<EL extends EPGMElement> extends RichFilterFunction<EL> {
 
   /**
-   * Broadcast set of gradoop ids
+   * broadcast id set name
    */
-  private GradoopIds graphIds;
+  public static final String IDS = "IdsNotIn";
+
+  /**
+   * graph ids
+   */
+  protected GradoopIds ids;
 
   @Override
   public void open(Configuration parameters) throws Exception {
-    this.graphIds = GradoopIds.fromExisting(getRuntimeContext().getBroadcastVariable("graph-ids"));
+    super.open(parameters);
+    ids = GradoopIds.fromExisting(getRuntimeContext().getBroadcastVariable(IDS));
   }
 
   @Override
-  public boolean filter(Tuple2<GradoopId, T> tuple2) throws Exception {
-    return graphIds.contains(tuple2.f0);
+  public boolean filter(EL identifiable) throws Exception {
+    return !ids.contains(identifiable.getId());
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdNotInBroadcast.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdNotInBroadcast.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.functions.epgm;
 import org.apache.flink.api.common.functions.RichFilterFunction;
 import org.apache.flink.configuration.Configuration;
 import org.gradoop.common.model.api.entities.EPGMElement;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Filters a dataset of EPGM elements to those whose id is not contained in an id dataset.
@@ -35,12 +35,12 @@ public class IdNotInBroadcast<EL extends EPGMElement> extends RichFilterFunction
   /**
    * graph ids
    */
-  protected GradoopIds ids;
+  protected GradoopIdSet ids;
 
   @Override
   public void open(Configuration parameters) throws Exception {
     super.open(parameters);
-    ids = GradoopIds.fromExisting(getRuntimeContext().getBroadcastVariable(IDS));
+    ids = GradoopIdSet.fromExisting(getRuntimeContext().getBroadcastVariable(IDS));
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdSetCombiner.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdSetCombiner.java
@@ -16,17 +16,17 @@
 package org.gradoop.flink.model.impl.functions.epgm;
 
 import org.apache.flink.api.common.functions.ReduceFunction;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Reduces GradoopIdSets into a single, distinct one.
  *
  */
 public class IdSetCombiner
-  implements ReduceFunction<GradoopIds> {
+  implements ReduceFunction<GradoopIdSet> {
 
   @Override
-  public GradoopIds reduce(GradoopIds in1, GradoopIds in2) {
+  public GradoopIdSet reduce(GradoopIdSet in1, GradoopIdSet in2) {
     in1.addAll(in2);
     return in1;
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/MergedGraphIds.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/MergedGraphIds.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.pojo.GraphElement;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 import java.util.Iterator;
 
@@ -46,7 +46,7 @@ public class MergedGraphIds<GE extends GraphElement>
   public void reduce(Iterable<GE> values, Collector<GE> out) throws Exception {
     Iterator<GE> iterator = values.iterator();
     GE result = iterator.next();
-    GradoopIds graphIds = result.getGraphIds();
+    GradoopIdSet graphIds = result.getGraphIds();
     while (iterator.hasNext()) {
       graphIds.addAll(iterator.next().getGraphIds());
     }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ToGradoopIdSet.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ToGradoopIdSet.java
@@ -18,19 +18,19 @@ package org.gradoop.flink.model.impl.functions.epgm;
 import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * id1,..,idn => {id1,..,idn}
  */
 public class ToGradoopIdSet
-  implements GroupReduceFunction<GradoopId, GradoopIds> {
+  implements GroupReduceFunction<GradoopId, GradoopIdSet> {
 
   @Override
   public void reduce(Iterable<GradoopId> iterable,
-    Collector<GradoopIds> collector) throws Exception {
+    Collector<GradoopIdSet> collector) throws Exception {
 
-    GradoopIds ids = new GradoopIds();
+    GradoopIdSet ids = new GradoopIdSet();
 
     for (GradoopId id : iterable) {
       ids.add(id);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/ExpandGraphsToIdSet.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/ExpandGraphsToIdSet.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.functions.graphcontainment;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.gradoop.common.model.impl.pojo.GraphElement;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Maps an element to a GradoopIdSet of all graph ids the element is
@@ -30,10 +30,10 @@ import org.gradoop.common.model.impl.id.GradoopIds;
  */
 @FunctionAnnotation.ForwardedFields("graphIds->*")
 public class ExpandGraphsToIdSet<GE extends GraphElement>
-  implements MapFunction<GE, GradoopIds> {
+  implements MapFunction<GE, GradoopIdSet> {
 
   @Override
-  public GradoopIds map(GE ge) {
+  public GradoopIdSet map(GE ge) {
     return ge.getGraphIds();
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/GraphsContainmentFilterBroadcast.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/GraphsContainmentFilterBroadcast.java
@@ -17,7 +17,7 @@ package org.gradoop.flink.model.impl.functions.graphcontainment;
 
 import org.apache.flink.api.common.functions.RichFilterFunction;
 import org.apache.flink.configuration.Configuration;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.GraphElement;
 
 /**
@@ -36,11 +36,11 @@ public abstract class GraphsContainmentFilterBroadcast
   /**
    * graph ids
    */
-  protected GradoopIds graphIds;
+  protected GradoopIdSet graphIds;
 
   @Override
   public void open(Configuration parameters) throws Exception {
     super.open(parameters);
-    graphIds = GradoopIds.fromExisting(getRuntimeContext().getBroadcastVariable(GRAPH_IDS));
+    graphIds = GradoopIdSet.fromExisting(getRuntimeContext().getBroadcastVariable(GRAPH_IDS));
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/GraphsContainmentFilterBroadcast.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/GraphsContainmentFilterBroadcast.java
@@ -17,10 +17,8 @@ package org.gradoop.flink.model.impl.functions.graphcontainment;
 
 import org.apache.flink.api.common.functions.RichFilterFunction;
 import org.apache.flink.configuration.Configuration;
+import org.gradoop.common.model.impl.id.GradoopIds;
 import org.gradoop.common.model.impl.pojo.GraphElement;
-import org.gradoop.common.model.impl.id.GradoopId;
-
-import java.util.Collection;
 
 /**
  * Superclass of multi graph containment filters using broadcast variables.
@@ -38,11 +36,11 @@ public abstract class GraphsContainmentFilterBroadcast
   /**
    * graph ids
    */
-  protected Collection<GradoopId> graphIds;
+  protected GradoopIds graphIds;
 
   @Override
   public void open(Configuration parameters) throws Exception {
     super.open(parameters);
-    graphIds = getRuntimeContext().getBroadcastVariable(GRAPH_IDS);
+    graphIds = GradoopIds.fromExisting(getRuntimeContext().getBroadcastVariable(GRAPH_IDS));
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/InAllGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/InAllGraphs.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.functions.graphcontainment;
 import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.gradoop.common.model.impl.pojo.GraphElement;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * True, if an element is contained in all of a set of given graphs.
@@ -32,14 +32,14 @@ public class InAllGraphs<GE extends GraphElement>
   /**
    * graph ids
    */
-  private final GradoopIds graphIds;
+  private final GradoopIdSet graphIds;
 
   /**
    * constructor
    *
    * @param graphIds graph ids
    */
-  public InAllGraphs(GradoopIds graphIds) {
+  public InAllGraphs(GradoopIdSet graphIds) {
     this.graphIds = graphIds;
   }
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/InAnyGraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/InAnyGraph.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.functions.graphcontainment;
 import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.gradoop.common.model.impl.pojo.GraphElement;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * True, if an element is contained in any of a set of given graphs.
@@ -32,13 +32,13 @@ public class InAnyGraph<GE extends GraphElement>
   /**
    * graph ids
    */
-  private final GradoopIds graphIds;
+  private final GradoopIdSet graphIds;
 
   /**
    * constructor
    * @param graphIds graph ids
    */
-  public InAnyGraph(GradoopIds graphIds) {
+  public InAnyGraph(GradoopIdSet graphIds) {
     this.graphIds = graphIds;
   }
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/cloning/functions/ElementGraphUpdater.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/cloning/functions/ElementGraphUpdater.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.configuration.Configuration;
 import org.gradoop.common.model.impl.pojo.GraphElement;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Replaces the graph set of each element by a new one, containing only the
@@ -54,7 +54,7 @@ public class ElementGraphUpdater<EL extends GraphElement>
    */
   @Override
   public EL map(EL element) {
-    element.setGraphIds(GradoopIds.fromExisting(graphId));
+    element.setGraphIds(GradoopIdSet.fromExisting(graphId));
     return element;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/functions/TransposeVertexGroupItems.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/functions/TransposeVertexGroupItems.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.flink.model.impl.operators.grouping.tuples.LabelGroup;
 import org.gradoop.flink.model.impl.operators.grouping.tuples.VertexGroupItem;
 import org.gradoop.common.model.impl.properties.PropertyValueList;
@@ -106,7 +106,7 @@ public class TransposeVertexGroupItems
     }
 
     reuseInnerTuple.setId(superVertexId);
-    reuseInnerTuple.setIdSet(GradoopIds.fromExisting(superVertexIds));
+    reuseInnerTuple.setIdSet(GradoopIdSet.fromExisting(superVertexIds));
 
     reuseOuterTuple.f0 = createSuperVertexTuple(superVertexId, groupLabel,
       groupPropertyValues, vertexLabelGroup.getAggregators());

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/TransactionalPatternMatching.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/TransactionalPatternMatching.java
@@ -19,7 +19,7 @@ import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -177,7 +177,7 @@ public class TransactionalPatternMatching implements UnaryCollectionToCollection
     //--------------------------------------------------------------------------
     // run the matching algorithm
     //--------------------------------------------------------------------------
-    DataSet<Tuple4<GradoopId, GradoopId, GradoopIds, GradoopIds>> embeddings = graphs
+    DataSet<Tuple4<GradoopId, GradoopId, GradoopIdSet, GradoopIdSet>> embeddings = graphs
       .flatMap(new FindEmbeddings(algorithm, query));
 
     //--------------------------------------------------------------------------
@@ -190,7 +190,7 @@ public class TransactionalPatternMatching implements UnaryCollectionToCollection
     //--------------------------------------------------------------------------
     // update vertex graphs
     //--------------------------------------------------------------------------
-    DataSet<Tuple2<GradoopId, GradoopIds>> verticesWithGraphs = embeddings
+    DataSet<Tuple2<GradoopId, GradoopIdSet>> verticesWithGraphs = embeddings
       .map(new Project4To0And2AndSwitch<>())
       .flatMap(new ExpandFirstField<>()).groupBy(0)
       .reduceGroup(new MergeSecondField<>());
@@ -203,7 +203,7 @@ public class TransactionalPatternMatching implements UnaryCollectionToCollection
     //--------------------------------------------------------------------------
     // update edge graphs
     //--------------------------------------------------------------------------
-    DataSet<Tuple2<GradoopId, GradoopIds>> edgesWithGraphs = embeddings
+    DataSet<Tuple2<GradoopId, GradoopIdSet>> edgesWithGraphs = embeddings
       .map(new Project4To0And3AndSwitch<>())
       .flatMap(new ExpandFirstField<>()).groupBy(0)
       .reduceGroup(new MergeSecondField<>());

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/BuildIdWithCandidatesAndGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/BuildIdWithCandidatesAndGraphs.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.operators.matching.transactional.function;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Vertex;
 import org.gradoop.flink.model.impl.operators.matching.common.functions.AbstractBuilder;
 import org.gradoop.flink.model.impl.operators.matching.common.matching.ElementMatcher;
@@ -37,7 +37,7 @@ import static org.gradoop.common.util.GradoopConstants.DEFAULT_VERTEX_LABEL;
  * @param <V> EPGM vertex type
  */
 public class BuildIdWithCandidatesAndGraphs<V extends Vertex>
-  extends AbstractBuilder<V, Tuple2<GradoopIds, IdWithCandidates<GradoopId>>> {
+  extends AbstractBuilder<V, Tuple2<GradoopIdSet, IdWithCandidates<GradoopId>>> {
   /**
    * serial version uid
    */
@@ -53,7 +53,7 @@ public class BuildIdWithCandidatesAndGraphs<V extends Vertex>
   /**
    * Reduce instantiations
    */
-  private final Tuple2<GradoopIds, IdWithCandidates<GradoopId>> reuseTuple;
+  private final Tuple2<GradoopIdSet, IdWithCandidates<GradoopId>> reuseTuple;
 
   /**
    * Constructor
@@ -74,7 +74,7 @@ public class BuildIdWithCandidatesAndGraphs<V extends Vertex>
   }
 
   @Override
-  public Tuple2<GradoopIds, IdWithCandidates<GradoopId>> map(V v)
+  public Tuple2<GradoopIdSet, IdWithCandidates<GradoopId>> map(V v)
     throws Exception {
     reuseTuple.f0 = v.getGraphIds();
     reuseTuple.f1.setId(v.getId());

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/BuildTripleWithCandidatesAndGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/BuildTripleWithCandidatesAndGraphs.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.operators.matching.transactional.function;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.flink.model.impl.operators.matching.common.functions.AbstractBuilder;
 import org.gradoop.flink.model.impl.operators.matching.common.matching.ElementMatcher;
 import org.gradoop.common.model.impl.pojo.Edge;
@@ -35,7 +35,7 @@ import static org.gradoop.common.util.GradoopConstants.DEFAULT_EDGE_LABEL;
  * @param <E> EPGM edge type
  */
 public class BuildTripleWithCandidatesAndGraphs<E extends Edge>
-  extends AbstractBuilder<E, Tuple2<GradoopIds, TripleWithCandidates<GradoopId>>> {
+  extends AbstractBuilder<E, Tuple2<GradoopIdSet, TripleWithCandidates<GradoopId>>> {
 
   /**
    * serial version uid
@@ -52,7 +52,7 @@ public class BuildTripleWithCandidatesAndGraphs<E extends Edge>
   /**
    * Reduce instantiations
    */
-  private final Tuple2<GradoopIds, TripleWithCandidates<GradoopId>>
+  private final Tuple2<GradoopIdSet, TripleWithCandidates<GradoopId>>
     reuseTuple;
 
   /**
@@ -74,7 +74,7 @@ public class BuildTripleWithCandidatesAndGraphs<E extends Edge>
   }
 
   @Override
-  public Tuple2<GradoopIds, TripleWithCandidates<GradoopId>> map(E e)
+  public Tuple2<GradoopIdSet, TripleWithCandidates<GradoopId>> map(E e)
     throws Exception {
     reuseTuple.f0 = e.getGraphIds();
     reuseTuple.f1.setEdgeId(e.getId());

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/ExpandFirstField.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/ExpandFirstField.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Returns one Tuple2<GradoopId, T> per id contained in the first field.
@@ -28,7 +28,7 @@ import org.gradoop.common.model.impl.id.GradoopIds;
  */
 @FunctionAnnotation.ForwardedFields("f1")
 public class ExpandFirstField<T>
-  implements FlatMapFunction<Tuple2<GradoopIds, T>, Tuple2<GradoopId, T>> {
+  implements FlatMapFunction<Tuple2<GradoopIdSet, T>, Tuple2<GradoopId, T>> {
 
   /**
    * Reduce instantiation
@@ -36,7 +36,7 @@ public class ExpandFirstField<T>
   private Tuple2<GradoopId, T> reuseTuple = new Tuple2<>();
 
   @Override
-  public void flatMap(Tuple2<GradoopIds, T> tuple2, Collector<Tuple2<GradoopId, T>> collector)
+  public void flatMap(Tuple2<GradoopIdSet, T> tuple2, Collector<Tuple2<GradoopId, T>> collector)
     throws Exception {
 
     reuseTuple.f1 = tuple2.f1;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/FindEmbeddings.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/FindEmbeddings.java
@@ -19,7 +19,7 @@ import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.flink.model.impl.operators.matching.common.tuples.Embedding;
 import org.gradoop.flink.model.impl.operators.matching.transactional.algorithm.PatternMatchingAlgorithm;
 import org.gradoop.flink.model.impl.operators.matching.transactional.tuples.GraphWithCandidates;
@@ -34,7 +34,7 @@ import java.util.List;
 public class FindEmbeddings
   implements FlatMapFunction<
   GraphWithCandidates,
-  Tuple4<GradoopId, GradoopId, GradoopIds, GradoopIds>> {
+  Tuple4<GradoopId, GradoopId, GradoopIdSet, GradoopIdSet>> {
 
   /**
    * The pattern matching algorithm.
@@ -59,7 +59,7 @@ public class FindEmbeddings
 
   @Override
   public void flatMap(GraphWithCandidates graphWithCandidates,
-    Collector<Tuple4<GradoopId, GradoopId, GradoopIds, GradoopIds>> collector) throws
+    Collector<Tuple4<GradoopId, GradoopId, GradoopIdSet, GradoopIdSet>> collector) throws
     Exception {
     List<Embedding<GradoopId>> embeddings =
       this.algo.findEmbeddings(graphWithCandidates, this.query);
@@ -68,8 +68,8 @@ public class FindEmbeddings
       GradoopId newGraphId = GradoopId.get();
       collector.collect(new Tuple4<>(newGraphId,
         graphWithCandidates.f0,
-        GradoopIds.fromExisting(embedding.getVertexMapping()),
-        GradoopIds.fromExisting(embedding.getEdgeMapping())));
+        GradoopIdSet.fromExisting(embedding.getVertexMapping()),
+        GradoopIdSet.fromExisting(embedding.getEdgeMapping())));
     }
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/GraphIdFilter.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/GraphIdFilter.java
@@ -19,7 +19,7 @@ import org.apache.flink.api.common.functions.RichFilterFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Filters a set of Tuple2 with GradoopIds in the first field by the
@@ -32,11 +32,12 @@ public class GraphIdFilter<T> extends RichFilterFunction<Tuple2<GradoopId, T>> {
   /**
    * Broadcast set of gradoop ids
    */
-  private GradoopIds graphIds;
+  private GradoopIdSet graphIds;
 
   @Override
   public void open(Configuration parameters) throws Exception {
-    this.graphIds = GradoopIds.fromExisting(getRuntimeContext().getBroadcastVariable("graph-ids"));
+    this.graphIds = GradoopIdSet.fromExisting(
+        getRuntimeContext().getBroadcastVariable("graph-ids"));
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/MergeSecondField.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/function/MergeSecondField.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 import java.util.Iterator;
 
@@ -31,15 +31,15 @@ import java.util.Iterator;
 @FunctionAnnotation.ForwardedFields("f0")
 @FunctionAnnotation.ReadFields("f1")
 public class MergeSecondField<T>
-  implements GroupReduceFunction<Tuple2<T, GradoopId>, Tuple2<T, GradoopIds>> {
+  implements GroupReduceFunction<Tuple2<T, GradoopId>, Tuple2<T, GradoopIdSet>> {
 
   @Override
   public void reduce(Iterable<Tuple2<T, GradoopId>> iterable,
-    Collector<Tuple2<T, GradoopIds>> collector) throws Exception {
+    Collector<Tuple2<T, GradoopIdSet>> collector) throws Exception {
     Iterator<Tuple2<T, GradoopId>> it = iterable.iterator();
     Tuple2<T, GradoopId> firstTuple = it.next();
     T firstField = firstTuple.f0;
-    GradoopIds secondField = GradoopIds.fromExisting(firstTuple.f1);
+    GradoopIdSet secondField = GradoopIdSet.fromExisting(firstTuple.f1);
     while (it.hasNext()) {
       GradoopId id = it.next().f1;
       secondField.add(id);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/Split.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/Split.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -94,7 +94,7 @@ public class Split implements UnaryGraphToCollectionOperator, Serializable {
         .map(new PairTupleWithNewId<>());
 
     // build a dataset of the vertex ids and the new associated graph ids
-    DataSet<Tuple2<GradoopId, GradoopIds>> vertexIdWithGraphIds =
+    DataSet<Tuple2<GradoopId, GradoopIdSet>> vertexIdWithGraphIds =
       vertexIdWithSplitValues
         .join(splitValuesWithGraphIds)
         .where(1).equalTo(0)
@@ -125,7 +125,7 @@ public class Split implements UnaryGraphToCollectionOperator, Serializable {
     //--------------------------------------------------------------------------
 
     // replace source and target id by the graph list the corresponding vertex
-    DataSet<Tuple3<Edge, GradoopIds, GradoopIds>> edgeGraphIdsGraphIds =
+    DataSet<Tuple3<Edge, GradoopIdSet, GradoopIdSet>> edgeGraphIdsGraphIds =
       graph.getEdges()
         .join(vertexIdWithGraphIds)
         .where(new SourceId<>()).equalTo(0)

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/AddNewGraphsToEdge.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/AddNewGraphsToEdge.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Adds new graph id's to the edge if source and target vertex are part of
@@ -32,15 +32,15 @@ import org.gradoop.common.model.impl.id.GradoopIds;
 @FunctionAnnotation.ForwardedFields("f0.id->id;f0.sourceId->sourceId;" +
   "f0.targetId->targetId;f0.label->label;f0.properties->properties")
 public class AddNewGraphsToEdge<E extends Edge>
-  implements FlatMapFunction<Tuple3<E, GradoopIds, GradoopIds>, E> {
+  implements FlatMapFunction<Tuple3<E, GradoopIdSet, GradoopIdSet>, E> {
 
   @Override
   public void flatMap(
-    Tuple3<E, GradoopIds, GradoopIds> triple,
+    Tuple3<E, GradoopIdSet, GradoopIdSet> triple,
     Collector<E> collector) {
-    GradoopIds sourceGraphs = triple.f1;
-    GradoopIds targetGraphs = triple.f2;
-    GradoopIds graphsToBeAdded = new GradoopIds();
+    GradoopIdSet sourceGraphs = triple.f1;
+    GradoopIdSet targetGraphs = triple.f2;
+    GradoopIdSet graphsToBeAdded = new GradoopIdSet();
 
     boolean filter = false;
     for (GradoopId id : sourceGraphs) {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/AddNewGraphsToVertex.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/AddNewGraphsToVertex.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.pojo.Vertex;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Adds new graph ids to the initial vertex set
@@ -30,13 +30,13 @@ import org.gradoop.common.model.impl.id.GradoopIds;
 @FunctionAnnotation.ReadFieldsFirst("graphIds")
 @FunctionAnnotation.ReadFieldsSecond("f1")
 public class AddNewGraphsToVertex<V extends Vertex>
-  implements JoinFunction<V, Tuple2<GradoopId, GradoopIds>, V> {
+  implements JoinFunction<V, Tuple2<GradoopId, GradoopIdSet>, V> {
   /**
    * {@inheritDoc}
    */
   @Override
   public V join(V vertex,
-    Tuple2<GradoopId, GradoopIds> vertexWithGraphIds) {
+    Tuple2<GradoopId, GradoopIdSet> vertexWithGraphIds) {
     vertex.getGraphIds().addAll(vertexWithGraphIds.f1);
     return vertex;
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/JoinEdgeTupleWithSourceGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/JoinEdgeTupleWithSourceGraphs.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Join edge tuples with the graph sets of their sources
@@ -30,20 +30,20 @@ import org.gradoop.common.model.impl.id.GradoopIds;
 @FunctionAnnotation.ForwardedFieldsFirst("*->f0")
 @FunctionAnnotation.ForwardedFieldsSecond("f1->f1")
 public class JoinEdgeTupleWithSourceGraphs<E extends Edge>
-  implements JoinFunction<E, Tuple2<GradoopId, GradoopIds>,
-  Tuple2<E, GradoopIds>> {
+  implements JoinFunction<E, Tuple2<GradoopId, GradoopIdSet>,
+  Tuple2<E, GradoopIdSet>> {
 
   /**
    * Reduce object instantiation.
    */
-  private final Tuple2<E, GradoopIds> reuseTuple = new Tuple2<>();
+  private final Tuple2<E, GradoopIdSet> reuseTuple = new Tuple2<>();
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public Tuple2<E, GradoopIds> join(
-    E left, Tuple2<GradoopId, GradoopIds> right) {
+  public Tuple2<E, GradoopIdSet> join(
+    E left, Tuple2<GradoopId, GradoopIdSet> right) {
     reuseTuple.f0 = left;
     reuseTuple.f1 = right.f1;
     return reuseTuple;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/JoinEdgeTupleWithTargetGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/JoinEdgeTupleWithTargetGraphs.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Join edge tuples with the graph sets of their targets
@@ -32,22 +32,22 @@ import org.gradoop.common.model.impl.id.GradoopIds;
 @FunctionAnnotation.ForwardedFieldsSecond("f1->f2")
 public class JoinEdgeTupleWithTargetGraphs<E extends Edge>
   implements JoinFunction
-  <Tuple2<E, GradoopIds>, Tuple2<GradoopId, GradoopIds>,
-    Tuple3<E, GradoopIds, GradoopIds>> {
+  <Tuple2<E, GradoopIdSet>, Tuple2<GradoopId, GradoopIdSet>,
+    Tuple3<E, GradoopIdSet, GradoopIdSet>> {
 
   /**
    * Reduce object instantiation.
    */
-  private final Tuple3<E, GradoopIds, GradoopIds> reuseTuple =
+  private final Tuple3<E, GradoopIdSet, GradoopIdSet> reuseTuple =
     new Tuple3<>();
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public Tuple3<E, GradoopIds, GradoopIds> join(
-    Tuple2<E, GradoopIds> left,
-    Tuple2<GradoopId, GradoopIds> right) throws Exception {
+  public Tuple3<E, GradoopIdSet, GradoopIdSet> join(
+    Tuple2<E, GradoopIdSet> left,
+    Tuple2<GradoopId, GradoopIdSet> right) throws Exception {
     reuseTuple.f0 = left.f0;
     reuseTuple.f1 = left.f1;
     reuseTuple.f2 = right.f1;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/MultipleGraphIdsGroupReducer.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/functions/MultipleGraphIdsGroupReducer.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Reduce each group of vertices into a single vertex, whose graphId set
@@ -29,16 +29,16 @@ import org.gradoop.common.model.impl.id.GradoopIds;
 @FunctionAnnotation.ForwardedFields("f0")
 public class MultipleGraphIdsGroupReducer
   implements GroupReduceFunction<Tuple2<GradoopId, GradoopId>,
-  Tuple2<GradoopId, GradoopIds>> {
+  Tuple2<GradoopId, GradoopIdSet>> {
 
   @Override
   public void reduce(
     Iterable<Tuple2<GradoopId, GradoopId>> iterable,
-    Collector<Tuple2<GradoopId, GradoopIds>> collector) {
+    Collector<Tuple2<GradoopId, GradoopIdSet>> collector) {
 
     boolean first = true;
     GradoopId vertexId = null;
-    GradoopIds idSet = new GradoopIds();
+    GradoopIdSet idSet = new GradoopIdSet();
 
     for (Tuple2<GradoopId, GradoopId> vertexGraphPair : iterable) {
       if (first) {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/ApplySubgraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/ApplySubgraph.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.gradoop.common.model.api.entities.EPGMGraphHeadFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -129,7 +129,7 @@ public class ApplySubgraph implements ApplicableUnaryGraphToGraphOperator {
     // filter function is applied first to improve performance
     //--------------------------------------------------------------------------
 
-    DataSet<Tuple2<GradoopId, GradoopIds>> vertexIdsWithNewGraphs =
+    DataSet<Tuple2<GradoopId, GradoopIdSet>> vertexIdsWithNewGraphs =
       collection.getVertices()
         .filter(vertexFilterFunction)
         .flatMap(new ElementIdGraphIdTuple<>())
@@ -155,7 +155,7 @@ public class ApplySubgraph implements ApplicableUnaryGraphToGraphOperator {
     // edge id, source id, target id, set of new graph ids
     //--------------------------------------------------------------------------
 
-    DataSet<Tuple4<GradoopId, GradoopId, GradoopId, GradoopIds>> edgeTuple =
+    DataSet<Tuple4<GradoopId, GradoopId, GradoopId, GradoopIdSet>> edgeTuple =
       collection.getEdges()
         .flatMap(new IdSourceTargetGraphTuple<>())
         .join(graphIdDictionary)
@@ -173,7 +173,7 @@ public class ApplySubgraph implements ApplicableUnaryGraphToGraphOperator {
     // edge id, new edge graphs
     //--------------------------------------------------------------------------
 
-    DataSet<Tuple2<GradoopId, GradoopIds>> edgeIdsWithNewGraphs =
+    DataSet<Tuple2<GradoopId, GradoopIdSet>> edgeIdsWithNewGraphs =
       edgeTuple
         .join(vertexIdsWithNewGraphs)
         .where(1).equalTo(0)

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/AddGraphsToElements.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/AddGraphsToElements.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.pojo.GraphElement;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Add all gradoop ids in the second field of the first tuple to the element.
@@ -30,11 +30,11 @@ import org.gradoop.common.model.impl.id.GradoopIds;
 @FunctionAnnotation.ReadFieldsFirst("f1")
 @FunctionAnnotation.ForwardedFieldsSecond("id;label;properties")
 public class AddGraphsToElements<EL extends GraphElement>
-  implements JoinFunction<Tuple2<GradoopId, GradoopIds>, EL, EL> {
+  implements JoinFunction<Tuple2<GradoopId, GradoopIdSet>, EL, EL> {
 
   @Override
   public EL join(
-    Tuple2<GradoopId, GradoopIds> left,
+    Tuple2<GradoopId, GradoopIdSet> left,
     EL right) {
     right.getGraphIds().addAll(left.f1);
     return right;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/AddGraphsToElementsCoGroup.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/AddGraphsToElementsCoGroup.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.pojo.GraphElement;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * CoGroups tuples containing gradoop ids and gradoop id sets with graph
@@ -33,16 +33,16 @@ import org.gradoop.common.model.impl.id.GradoopIds;
 @FunctionAnnotation.ReadFieldsFirst("f1")
 @FunctionAnnotation.ForwardedFieldsSecond("id;label;properties")
 public class AddGraphsToElementsCoGroup<EL extends GraphElement>
-  implements CoGroupFunction<Tuple2<GradoopId, GradoopIds>, EL, EL> {
+  implements CoGroupFunction<Tuple2<GradoopId, GradoopIdSet>, EL, EL> {
 
   @Override
   public void coGroup(
-    Iterable<Tuple2<GradoopId, GradoopIds>> graphs,
+    Iterable<Tuple2<GradoopId, GradoopIdSet>> graphs,
     Iterable<EL> elements,
     Collector<EL> collector) throws Exception {
     boolean wasGraphSetEmpty = true;
     for (EL element : elements) {
-      for (Tuple2<GradoopId, GradoopIds> graphSet : graphs) {
+      for (Tuple2<GradoopId, GradoopIdSet> graphSet : graphs) {
         element.getGraphIds().addAll(graphSet.f1);
         wasGraphSetEmpty = false;
       }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/FilterEdgeGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/FilterEdgeGraphs.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Filter the edge tuples. Check if each new graph the edge is contained in
@@ -33,19 +33,19 @@ import org.gradoop.common.model.impl.id.GradoopIds;
 @FunctionAnnotation.ForwardedFields("f0->f0")
 public class FilterEdgeGraphs
   implements FlatMapFunction<
-  Tuple4<GradoopId, GradoopIds, GradoopIds, GradoopIds>,
-  Tuple2<GradoopId, GradoopIds>> {
+  Tuple4<GradoopId, GradoopIdSet, GradoopIdSet, GradoopIdSet>,
+  Tuple2<GradoopId, GradoopIdSet>> {
 
   /**
    * Reduce object instantiations
    */
-  private Tuple2<GradoopId, GradoopIds> reuseTuple = new Tuple2<>();
+  private Tuple2<GradoopId, GradoopIdSet> reuseTuple = new Tuple2<>();
 
   @Override
   public void flatMap(
-    Tuple4<GradoopId, GradoopIds, GradoopIds, GradoopIds> edgeTuple,
-    Collector<Tuple2<GradoopId, GradoopIds>> collector) throws Exception {
-    GradoopIds set = new GradoopIds();
+    Tuple4<GradoopId, GradoopIdSet, GradoopIdSet, GradoopIdSet> edgeTuple,
+    Collector<Tuple2<GradoopId, GradoopIdSet>> collector) throws Exception {
+    GradoopIdSet set = new GradoopIdSet();
     for (GradoopId edgeGraph : edgeTuple.f3) {
       for (GradoopId sourceGraph : edgeTuple.f1) {
         if (edgeGraph.equals(sourceGraph)) {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/JoinWithSourceGraphIdSet.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/JoinWithSourceGraphIdSet.java
@@ -37,7 +37,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Join an edge tuple with a tuple containing the source vertex id of this edge
@@ -48,20 +48,20 @@ import org.gradoop.common.model.impl.id.GradoopIds;
 @FunctionAnnotation.ForwardedFieldsSecond("f1->f1")
 public class JoinWithSourceGraphIdSet
   implements JoinFunction<
-  Tuple4<GradoopId, GradoopId, GradoopId, GradoopIds>,
-  Tuple2<GradoopId, GradoopIds>,
-  Tuple4<GradoopId, GradoopIds, GradoopId, GradoopIds>> {
+  Tuple4<GradoopId, GradoopId, GradoopId, GradoopIdSet>,
+  Tuple2<GradoopId, GradoopIdSet>,
+  Tuple4<GradoopId, GradoopIdSet, GradoopId, GradoopIdSet>> {
 
   /**
    * Reduce object instantiations
    */
-  private Tuple4<GradoopId, GradoopIds, GradoopId, GradoopIds> reuseTuple
+  private Tuple4<GradoopId, GradoopIdSet, GradoopId, GradoopIdSet> reuseTuple
     = new Tuple4<>();
 
   @Override
-  public Tuple4<GradoopId, GradoopIds, GradoopId, GradoopIds> join(
-    Tuple4<GradoopId, GradoopId, GradoopId, GradoopIds> edge,
-    Tuple2<GradoopId, GradoopIds> vertex) throws
+  public Tuple4<GradoopId, GradoopIdSet, GradoopId, GradoopIdSet> join(
+    Tuple4<GradoopId, GradoopId, GradoopId, GradoopIdSet> edge,
+    Tuple2<GradoopId, GradoopIdSet> vertex) throws
     Exception {
     reuseTuple.f0 = edge.f0;
     reuseTuple.f1 = vertex.f1;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/JoinWithTargetGraphIdSet.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/JoinWithTargetGraphIdSet.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Join an edge tuple with a tuple containing the target vertex id of this edge
@@ -31,20 +31,20 @@ import org.gradoop.common.model.impl.id.GradoopIds;
 @FunctionAnnotation.ForwardedFieldsSecond("f1->f2")
 public class JoinWithTargetGraphIdSet
   implements JoinFunction<
-  Tuple4<GradoopId, GradoopIds, GradoopId, GradoopIds>,
-  Tuple2<GradoopId, GradoopIds>,
-  Tuple4<GradoopId, GradoopIds, GradoopIds, GradoopIds>> {
+  Tuple4<GradoopId, GradoopIdSet, GradoopId, GradoopIdSet>,
+  Tuple2<GradoopId, GradoopIdSet>,
+  Tuple4<GradoopId, GradoopIdSet, GradoopIdSet, GradoopIdSet>> {
 
   /**
    * Reduce object instantiations
    */
-  private Tuple4<GradoopId, GradoopIds, GradoopIds, GradoopIds> reuseTuple
+  private Tuple4<GradoopId, GradoopIdSet, GradoopIdSet, GradoopIdSet> reuseTuple
     = new Tuple4<>();
 
   @Override
-  public Tuple4<GradoopId, GradoopIds, GradoopIds, GradoopIds> join(
-    Tuple4<GradoopId, GradoopIds, GradoopId, GradoopIds> edge,
-    Tuple2<GradoopId, GradoopIds> vertex) throws
+  public Tuple4<GradoopId, GradoopIdSet, GradoopIdSet, GradoopIdSet> join(
+    Tuple4<GradoopId, GradoopIdSet, GradoopId, GradoopIdSet> edge,
+    Tuple2<GradoopId, GradoopIdSet> vertex) throws
     Exception {
     reuseTuple.f0 = edge.f0;
     reuseTuple.f1 = edge.f1;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/MergeEdgeGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/MergeEdgeGraphs.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Reduces groups of tuples 4 consisting of 4 gradoop ids
@@ -34,15 +34,15 @@ import org.gradoop.common.model.impl.id.GradoopIds;
 public class MergeEdgeGraphs implements
   GroupReduceFunction<
     Tuple4<GradoopId, GradoopId, GradoopId, GradoopId>,
-    Tuple4<GradoopId, GradoopId, GradoopId, GradoopIds>> {
+    Tuple4<GradoopId, GradoopId, GradoopId, GradoopIdSet>> {
 
   @Override
   public void reduce(
     Iterable<Tuple4<GradoopId, GradoopId, GradoopId, GradoopId>> iterable,
     Collector<
-      Tuple4<GradoopId, GradoopId, GradoopId, GradoopIds>> collector) {
+      Tuple4<GradoopId, GradoopId, GradoopId, GradoopIdSet>> collector) {
 
-    GradoopIds set = new GradoopIds();
+    GradoopIdSet set = new GradoopIdSet();
 
     boolean empty = true;
     GradoopId f0 = null;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/MergeTupleGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/MergeTupleGraphs.java
@@ -20,7 +20,7 @@ import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Reduces groups of tuples 2 containin two gradoop ids into one tuple
@@ -32,12 +32,12 @@ import org.gradoop.common.model.impl.id.GradoopIds;
 public class MergeTupleGraphs implements
   GroupReduceFunction<
     Tuple2<GradoopId, GradoopId>,
-    Tuple2<GradoopId, GradoopIds>> {
+    Tuple2<GradoopId, GradoopIdSet>> {
 
   @Override
   public void reduce(Iterable<Tuple2<GradoopId, GradoopId>> iterable,
-    Collector<Tuple2<GradoopId, GradoopIds>> collector) throws Exception {
-    GradoopIds set = new GradoopIds();
+    Collector<Tuple2<GradoopId, GradoopIdSet>> collector) throws Exception {
+    GradoopIdSet set = new GradoopIdSet();
     boolean empty = true;
     GradoopId first = null;
     for (Tuple2<GradoopId, GradoopId> tuple : iterable) {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/SourceTargetIdGraphsTuple.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/SourceTargetIdGraphsTuple.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * For each edge, collect two tuple 2 containing its source or target id in the
@@ -33,12 +33,12 @@ import org.gradoop.common.model.impl.id.GradoopIds;
 @FunctionAnnotation.ReadFields("sourceId;targetId")
 @FunctionAnnotation.ForwardedFields("graphIds->f1")
 public class SourceTargetIdGraphsTuple<E extends Edge>
-  implements FlatMapFunction<E, Tuple2<GradoopId, GradoopIds>> {
+  implements FlatMapFunction<E, Tuple2<GradoopId, GradoopIdSet>> {
 
   @Override
   public void flatMap(
     E e,
-    Collector<Tuple2<GradoopId, GradoopIds>> collector) throws
+    Collector<Tuple2<GradoopId, GradoopIdSet>> collector) throws
     Exception {
 
     collector.collect(new Tuple2<>(e.getSourceId(), e.getGraphIds()));

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/tuples/IdWithIdSet.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/tuples/IdWithIdSet.java
@@ -17,12 +17,12 @@ package org.gradoop.flink.model.impl.tuples;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * (id, {id, id, ...})
  */
-public class IdWithIdSet extends Tuple2<GradoopId, GradoopIds> {
+public class IdWithIdSet extends Tuple2<GradoopId, GradoopIdSet> {
 
   public GradoopId getId() {
     return f0;
@@ -32,11 +32,11 @@ public class IdWithIdSet extends Tuple2<GradoopId, GradoopIds> {
     f0 = id;
   }
 
-  public GradoopIds getIdSet() {
+  public GradoopIdSet getIdSet() {
     return f1;
   }
 
-  public void setIdSet(GradoopIds idSet) {
+  public void setIdSet(GradoopIdSet idSet) {
     f1 = idSet;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/representation/transactional/RepresentationConverters.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/representation/transactional/RepresentationConverters.java
@@ -20,7 +20,7 @@ import com.google.common.collect.Sets;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.gradoop.common.model.api.entities.EPGMElement;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -139,7 +139,7 @@ public class RepresentationConverters {
     // GRAPH HEAD
     GraphHead graphHead = adjacencyList.getGraphHead();
 
-    GradoopIds graphIds = GradoopIds.fromExisting(graphHead.getId());
+    GradoopIdSet graphIds = GradoopIdSet.fromExisting(graphHead.getId());
 
     Set<Vertex> vertices = Sets.newHashSet();
     Set<Edge> edges = Sets.newHashSet();

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/EPGMDatabaseTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/EPGMDatabaseTest.java
@@ -17,7 +17,7 @@ package org.gradoop.flink.model.impl;
 
 import com.google.common.collect.Lists;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
 import org.gradoop.flink.model.api.epgm.GraphCollection;
@@ -68,7 +68,7 @@ public class EPGMDatabaseTest extends GradoopFlinkTestBase {
       graphIds.add(loader.getGraphHeadByVariable(graphVariable).getId());
     }
 
-    GradoopIds graphIdSet = GradoopIds.fromExisting(graphIds);
+    GradoopIdSet graphIdSet = GradoopIdSet.fromExisting(graphIds);
 
     GraphCollection collectionFromLoader =
       loader.getGraphCollectionByVariables(graphVariables);

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/id/GradoopIdSerializationTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/id/GradoopIdSerializationTest.java
@@ -16,7 +16,7 @@
 package org.gradoop.flink.model.impl.id;
 
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
 import org.gradoop.flink.model.impl.GradoopFlinkTestUtils;
 import org.junit.Test;
@@ -35,7 +35,7 @@ public class GradoopIdSerializationTest extends GradoopFlinkTestBase {
 
   @Test
   public void testGradoopIdSetSerialization() throws Exception {
-    GradoopIds idsIn = GradoopIds.fromExisting(
+    GradoopIdSet idsIn = GradoopIdSet.fromExisting(
       GradoopId.get(), GradoopId.get());
     assertEquals("GradoopIdSets were not equal", idsIn,
       GradoopFlinkTestUtils.writeAndRead(idsIn));

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/cloning/CloningTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/cloning/CloningTest.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.operators.cloning;
 import com.google.common.collect.Lists;
 import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
 import org.gradoop.flink.model.api.epgm.LogicalGraph;
 import org.gradoop.flink.model.impl.functions.epgm.Id;
@@ -76,7 +76,7 @@ public class CloningTest extends GradoopFlinkTestBase {
       .output(new LocalCollectionOutputFormat<>(resultEdgeIds));
 
 
-    List<GradoopIds> resultGraphIds = Lists.newArrayList();
+    List<GradoopIdSet> resultGraphIds = Lists.newArrayList();
 
     result.getVertices()
       .map(new ExpandGraphsToIdSet<>())

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectEdgesNodeTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectEdgesNodeTest.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.operators.matching.single.cypher.planning.q
 import com.google.common.collect.Sets;
 import org.apache.flink.api.java.DataSet;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
@@ -81,8 +81,8 @@ public class FilterAndProjectEdgesNodeTest extends GradoopFlinkTestBase {
     Map<String, Object> edge2Props = new HashMap<>();
     edge2Props.put("foo", 42);
 
-    Edge e1 = new Edge(edge1Id, "a", sourceId, targetId, Properties.createFromMap(edge1Props), new GradoopIds());
-    Edge e2 = new Edge(edge2Id, "b", sourceId, targetId, Properties.createFromMap(edge2Props), new GradoopIds());
+    Edge e1 = new Edge(edge1Id, "a", sourceId, targetId, Properties.createFromMap(edge1Props), new GradoopIdSet());
+    Edge e2 = new Edge(edge2Id, "b", sourceId, targetId, Properties.createFromMap(edge2Props), new GradoopIdSet());
 
     DataSet<Edge> edges = getExecutionEnvironment().fromElements(e1, e2);
 

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectVerticesNodeTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectVerticesNodeTest.java
@@ -18,7 +18,7 @@ package org.gradoop.flink.model.impl.operators.matching.single.cypher.planning.q
 import com.google.common.collect.Sets;
 import org.apache.flink.api.java.DataSet;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Vertex;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
@@ -59,8 +59,8 @@ public class FilterAndProjectVerticesNodeTest extends GradoopFlinkTestBase {
     Map<String, Object> vertex2Props = new HashMap<>();
     vertex2Props.put("foo", 42);
 
-    Vertex vertex1 = new Vertex(vertex1Id, "A", Properties.createFromMap(vertex1Props), new GradoopIds());
-    Vertex vertex2 = new Vertex(vertex2Id, "B", Properties.createFromMap(vertex2Props), new GradoopIds());
+    Vertex vertex1 = new Vertex(vertex1Id, "A", Properties.createFromMap(vertex1Props), new GradoopIdSet());
+    Vertex vertex2 = new Vertex(vertex2Id, "B", Properties.createFromMap(vertex2Props), new GradoopIdSet());
 
     DataSet<Vertex> vertices = getExecutionEnvironment().fromElements(vertex1, vertex2);
 

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/pojo/PojoSerializationTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/pojo/PojoSerializationTest.java
@@ -22,7 +22,7 @@ import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
 import org.gradoop.common.model.api.entities.EPGMEdge;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.EdgeFactory;
 import org.gradoop.common.model.impl.pojo.GraphHeadFactory;
 import org.gradoop.common.model.impl.pojo.VertexFactory;
@@ -37,7 +37,7 @@ public class PojoSerializationTest extends GradoopFlinkTestBase {
     EPGMVertex vertexIn = new VertexFactory().createVertex(
       "Person",
       Properties.createFromMap(GradoopTestUtils.SUPPORTED_PROPERTIES),
-      GradoopIds.fromExisting(GradoopId.get()));
+      GradoopIdSet.fromExisting(GradoopId.get()));
 
     Assert.assertEquals("EPGMVertex POJOs were not equal",
       vertexIn, GradoopFlinkTestUtils.writeAndRead(vertexIn));
@@ -50,7 +50,7 @@ public class PojoSerializationTest extends GradoopFlinkTestBase {
       GradoopId.get(),
       GradoopId.get(),
       Properties.createFromMap(GradoopTestUtils.SUPPORTED_PROPERTIES),
-      GradoopIds.fromExisting(GradoopId.get(), GradoopId.get()));
+      GradoopIdSet.fromExisting(GradoopId.get(), GradoopId.get()));
 
     Assert.assertEquals("EPGMEdge POJOs were not equal",
       edgeIn, GradoopFlinkTestUtils.writeAndRead(edgeIn));

--- a/gradoop-flink/src/test/java/org/gradoop/flink/representation/RepresentationConverterTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/representation/RepresentationConverterTest.java
@@ -17,7 +17,7 @@ package org.gradoop.flink.representation;
 
 import com.google.common.collect.Sets;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -57,7 +57,7 @@ public class RepresentationConverterTest extends GradoopFlinkTestBase {
   private GraphTransaction getGraphTransaction() {
     GraphHead graphHead = new GraphHead(GradoopId.get(), "Test", null);
 
-    GradoopIds graphIds = GradoopIds.fromExisting(graphHead.getId());
+    GradoopIdSet graphIds = GradoopIdSet.fromExisting(graphHead.getId());
     Set<Vertex> vertices = Sets.newHashSet();
     Set<Edge> edges = Sets.newHashSet();
 

--- a/gradoop-hbase/src/main/java/org/gradoop/common/storage/api/GraphElementHandler.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/common/storage/api/GraphElementHandler.java
@@ -18,7 +18,7 @@ package org.gradoop.common.storage.api;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.gradoop.common.model.api.entities.EPGMGraphElement;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 import java.io.IOException;
 
@@ -43,5 +43,5 @@ public interface GraphElementHandler extends ElementHandler {
    * @param res HBase row
    * @return graphs identifiers
    */
-  GradoopIds readGraphIds(final Result res) throws IOException;
+  GradoopIdSet readGraphIds(final Result res) throws IOException;
 }

--- a/gradoop-hbase/src/main/java/org/gradoop/common/storage/api/PersistentGraphHead.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/common/storage/api/PersistentGraphHead.java
@@ -17,7 +17,7 @@ package org.gradoop.common.storage.api;
 
 import org.gradoop.common.model.api.entities.EPGMGraphHead;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Representation of vertex data on the storage level. We additionally store
@@ -29,14 +29,14 @@ public interface PersistentGraphHead extends EPGMGraphHead {
    *
    * @return vertex ids that are contained in that graph
    */
-  GradoopIds getVertexIds();
+  GradoopIdSet getVertexIds();
 
   /**
    * Sets the vertices that are contained in that graph.
    *
    * @param vertices vertex ids
    */
-  void setVertexIds(GradoopIds vertices);
+  void setVertexIds(GradoopIdSet vertices);
 
   /**
    * Adds a vertex identifier to the graph data.
@@ -57,14 +57,14 @@ public interface PersistentGraphHead extends EPGMGraphHead {
    *
    * @return edge ids that are contained in that graph
    */
-  GradoopIds getEdgeIds();
+  GradoopIdSet getEdgeIds();
 
   /**
    * Sets the edges that are contained in that graph.
    *
    * @param edges edge ids
    */
-  void setEdgeIds(GradoopIds edges);
+  void setEdgeIds(GradoopIdSet edges);
 
   /**
    * Adds an edge identifier to the graph data.

--- a/gradoop-hbase/src/main/java/org/gradoop/common/storage/api/PersistentGraphHeadFactory.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/common/storage/api/PersistentGraphHeadFactory.java
@@ -16,7 +16,7 @@
 package org.gradoop.common.storage.api;
 
 import org.gradoop.common.model.api.entities.EPGMGraphHead;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 import java.io.Serializable;
 
@@ -37,5 +37,5 @@ public interface PersistentGraphHeadFactory<G extends EPGMGraphHead>
    * @return graph data
    */
   PersistentGraphHead createGraphHead(G inputGraphData,
-    GradoopIds vertices, GradoopIds edges);
+    GradoopIdSet vertices, GradoopIdSet edges);
 }

--- a/gradoop-hbase/src/main/java/org/gradoop/common/storage/impl/hbase/HBaseGraphElement.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/common/storage/impl/hbase/HBaseGraphElement.java
@@ -17,7 +17,7 @@ package org.gradoop.common.storage.impl.hbase;
 
 import org.gradoop.common.model.api.entities.EPGMGraphElement;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Wraps an EPGM graph element data entity.
@@ -40,7 +40,7 @@ public abstract class HBaseGraphElement<T extends EPGMGraphElement>
    * {@inheritDoc}
    */
   @Override
-  public GradoopIds getGraphIds() {
+  public GradoopIdSet getGraphIds() {
     return getEpgmElement().getGraphIds();
   }
 
@@ -56,7 +56,7 @@ public abstract class HBaseGraphElement<T extends EPGMGraphElement>
    * {@inheritDoc}
    */
   @Override
-  public void setGraphIds(GradoopIds graphIds) {
+  public void setGraphIds(GradoopIdSet graphIds) {
     getEpgmElement().setGraphIds(graphIds);
   }
 

--- a/gradoop-hbase/src/main/java/org/gradoop/common/storage/impl/hbase/HBaseGraphElementHandler.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/common/storage/impl/hbase/HBaseGraphElementHandler.java
@@ -19,7 +19,7 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.gradoop.common.model.api.entities.EPGMGraphElement;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.storage.api.GraphElementHandler;
 import org.gradoop.common.util.HBaseConstants;
 
@@ -55,15 +55,15 @@ public abstract class HBaseGraphElementHandler extends
    * {@inheritDoc}
    */
   @Override
-  public GradoopIds readGraphIds(Result res) throws IOException {
+  public GradoopIdSet readGraphIds(Result res) throws IOException {
     byte[] graphBytes = res.getValue(CF_META_BYTES, COL_GRAPHS_BYTES);
 
-    GradoopIds graphIds;
+    GradoopIdSet graphIds;
 
     if (graphBytes != null) {
-      graphIds = GradoopIds.fromByteArray(graphBytes);
+      graphIds = GradoopIdSet.fromByteArray(graphBytes);
     } else {
-      graphIds = new GradoopIds();
+      graphIds = new GradoopIdSet();
     }
 
     return graphIds;

--- a/gradoop-hbase/src/main/java/org/gradoop/common/storage/impl/hbase/HBaseGraphHead.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/common/storage/impl/hbase/HBaseGraphHead.java
@@ -17,7 +17,7 @@ package org.gradoop.common.storage.impl.hbase;
 
 import org.gradoop.common.model.api.entities.EPGMGraphHead;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.storage.api.PersistentGraphHead;
 
 /**
@@ -31,12 +31,12 @@ public class HBaseGraphHead<G extends EPGMGraphHead> extends HBaseElement<G>
   /**
    * EPGMVertex identifiers contained in that logical graph.
    */
-  private GradoopIds vertexIds;
+  private GradoopIdSet vertexIds;
 
   /**
    * EPGMEdge identifiers contained in that logical graph.
    */
-  private GradoopIds edgeIds;
+  private GradoopIdSet edgeIds;
 
   /**
    * Creates  persistent graph data.
@@ -45,8 +45,8 @@ public class HBaseGraphHead<G extends EPGMGraphHead> extends HBaseElement<G>
    * @param vertexIds  vertexIds contained in that graph
    * @param edgeIds     edgeIds contained in that graph
    */
-  HBaseGraphHead(G graphHead, GradoopIds vertexIds,
-    GradoopIds edgeIds) {
+  HBaseGraphHead(G graphHead, GradoopIdSet vertexIds,
+    GradoopIdSet edgeIds) {
     super(graphHead);
     this.vertexIds = vertexIds;
     this.edgeIds = edgeIds;
@@ -56,7 +56,7 @@ public class HBaseGraphHead<G extends EPGMGraphHead> extends HBaseElement<G>
    * {@inheritDoc}
    */
   @Override
-  public GradoopIds getVertexIds() {
+  public GradoopIdSet getVertexIds() {
     return vertexIds;
   }
 
@@ -64,7 +64,7 @@ public class HBaseGraphHead<G extends EPGMGraphHead> extends HBaseElement<G>
    * {@inheritDoc}
    */
   @Override
-  public void setVertexIds(GradoopIds vertices) {
+  public void setVertexIds(GradoopIdSet vertices) {
     this.vertexIds = vertices;
   }
 
@@ -76,7 +76,7 @@ public class HBaseGraphHead<G extends EPGMGraphHead> extends HBaseElement<G>
     if (vertexIds != null) {
       vertexIds.add(vertexID);
     } else {
-      vertexIds = GradoopIds.fromExisting(vertexID);
+      vertexIds = GradoopIdSet.fromExisting(vertexID);
     }
   }
 
@@ -92,7 +92,7 @@ public class HBaseGraphHead<G extends EPGMGraphHead> extends HBaseElement<G>
    * {@inheritDoc}
    */
   @Override
-  public GradoopIds getEdgeIds() {
+  public GradoopIdSet getEdgeIds() {
     return edgeIds;
   }
 
@@ -100,7 +100,7 @@ public class HBaseGraphHead<G extends EPGMGraphHead> extends HBaseElement<G>
    * {@inheritDoc}
    */
   @Override
-  public void setEdgeIds(GradoopIds edgeIds) {
+  public void setEdgeIds(GradoopIdSet edgeIds) {
     this.edgeIds = edgeIds;
   }
 
@@ -112,7 +112,7 @@ public class HBaseGraphHead<G extends EPGMGraphHead> extends HBaseElement<G>
     if (edgeIds != null) {
       edgeIds.add(edgeID);
     } else {
-      edgeIds = GradoopIds.fromExisting(edgeID);
+      edgeIds = GradoopIdSet.fromExisting(edgeID);
     }
   }
 

--- a/gradoop-hbase/src/main/java/org/gradoop/common/storage/impl/hbase/HBaseGraphHeadFactory.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/common/storage/impl/hbase/HBaseGraphHeadFactory.java
@@ -16,7 +16,7 @@
 package org.gradoop.common.storage.impl.hbase;
 
 import org.gradoop.common.model.api.entities.EPGMGraphHead;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.storage.api.PersistentGraphHeadFactory;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -39,7 +39,7 @@ public class HBaseGraphHeadFactory<G extends EPGMGraphHead>
    */
   @Override
   public HBaseGraphHead<G> createGraphHead(G inputGraphHead,
-    GradoopIds vertices, GradoopIds edges) {
+    GradoopIdSet vertices, GradoopIdSet edges) {
     checkNotNull(inputGraphHead, "EPGMGraphHead was null");
     checkNotNull(vertices, "EPGMVertex identifiers were null");
     checkNotNull(edges, "EPGMEdge identifiers were null");

--- a/gradoop-hbase/src/main/java/org/gradoop/flink/io/impl/hbase/HBaseDataSink.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/flink/io/impl/hbase/HBaseDataSink.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.hadoop.hbase.mapreduce.TableOutputFormat;
 import org.apache.hadoop.mapreduce.Job;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -121,7 +121,7 @@ public class HBaseDataSink extends HBaseBase<GraphHead, Vertex, Edge>
 
     // co-group (graph-id, vertex-id) and (graph-id, edge-id) tuples to
     // (graph-id, {vertex-id}, {edge-id}) triples
-    DataSet<Tuple3<GradoopId, GradoopIds, GradoopIds>>
+    DataSet<Tuple3<GradoopId, GradoopIdSet, GradoopIdSet>>
       graphToVertexIdsAndEdgeIds = graphIdToVertexId
         .coGroup(graphIdToEdgeId)
         .where(0)

--- a/gradoop-hbase/src/main/java/org/gradoop/flink/io/impl/hbase/functions/BuildGraphTransactions.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/flink/io/impl/hbase/functions/BuildGraphTransactions.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 
 /**
  * Co-groups graph-id, vertex-id) and (graph-id, edge-id) tuples to
@@ -44,21 +44,21 @@ import org.gradoop.common.model.impl.id.GradoopIds;
 @FunctionAnnotation.ReadFieldsSecond("f1")
 public class BuildGraphTransactions implements CoGroupFunction<
   Tuple2<GradoopId, GradoopId>, Tuple2<GradoopId, GradoopId>,
-  Tuple3<GradoopId, GradoopIds, GradoopIds>> {
+  Tuple3<GradoopId, GradoopIdSet, GradoopIdSet>> {
   /**
    * Reduce object instantiations.
    */
-  private final Tuple3<GradoopId, GradoopIds, GradoopIds> reuseTuple =
+  private final Tuple3<GradoopId, GradoopIdSet, GradoopIdSet> reuseTuple =
     new Tuple3<>();
 
   @Override
   public void coGroup(Iterable<Tuple2<GradoopId, GradoopId>> graphToVertexIds,
     Iterable<Tuple2<GradoopId, GradoopId>> graphToEdgeIds,
-    Collector<Tuple3<GradoopId, GradoopIds, GradoopIds>> collector) throws
+    Collector<Tuple3<GradoopId, GradoopIdSet, GradoopIdSet>> collector) throws
     Exception {
 
-    GradoopIds vertexIds  = new GradoopIds();
-    GradoopIds edgeIds    = new GradoopIds();
+    GradoopIdSet vertexIds  = new GradoopIdSet();
+    GradoopIdSet edgeIds    = new GradoopIdSet();
     boolean initialized     = false;
 
     for (Tuple2<GradoopId, GradoopId> graphToVertexTuple : graphToVertexIds) {

--- a/gradoop-hbase/src/main/java/org/gradoop/flink/io/impl/hbase/functions/BuildPersistentGraphHead.java
+++ b/gradoop-hbase/src/main/java/org/gradoop/flink/io/impl/hbase/functions/BuildPersistentGraphHead.java
@@ -19,7 +19,7 @@ import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.gradoop.common.model.api.entities.EPGMGraphHead;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.storage.api.PersistentGraphHead;
 import org.gradoop.common.storage.api.PersistentGraphHeadFactory;
 
@@ -30,7 +30,7 @@ import org.gradoop.common.storage.api.PersistentGraphHeadFactory;
  */
 public class BuildPersistentGraphHead<G extends EPGMGraphHead>
   implements JoinFunction
-  <Tuple3<GradoopId, GradoopIds, GradoopIds>, G, PersistentGraphHead> {
+  <Tuple3<GradoopId, GradoopIdSet, GradoopIdSet>, G, PersistentGraphHead> {
 
   /**
    * Persistent graph data factory.
@@ -52,7 +52,7 @@ public class BuildPersistentGraphHead<G extends EPGMGraphHead>
    */
   @Override
   public PersistentGraphHead join(
-    Tuple3<GradoopId, GradoopIds, GradoopIds> longSetSetTuple3, G graphHead)
+    Tuple3<GradoopId, GradoopIdSet, GradoopIdSet> longSetSetTuple3, G graphHead)
       throws Exception {
     return graphHeadFactory.createGraphHead(graphHead, longSetSetTuple3.f1,
       longSetSetTuple3.f2);

--- a/gradoop-hbase/src/test/java/org/gradoop/common/storage/impl/hbase/GradoopHBaseTestUtils.java
+++ b/gradoop-hbase/src/test/java/org/gradoop/common/storage/impl/hbase/GradoopHBaseTestUtils.java
@@ -20,7 +20,7 @@ import org.gradoop.common.model.api.entities.EPGMEdge;
 import org.gradoop.common.model.api.entities.EPGMGraphHead;
 import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -99,8 +99,8 @@ public class GradoopHBaseTestUtils {
     for(G graphHead : loader.getGraphHeads()) {
 
       GradoopId graphId = graphHead.getId();
-      GradoopIds vertexIds = new GradoopIds();
-      GradoopIds edgeIds = new GradoopIds();
+      GradoopIdSet vertexIds = new GradoopIdSet();
+      GradoopIdSet edgeIds = new GradoopIdSet();
 
       for (EPGMVertex vertex : loader.getVertices()) {
         if (vertex.getGraphIds().contains(graphId)) {

--- a/gradoop-hbase/src/test/java/org/gradoop/common/storage/impl/hbase/HBaseGraphStoreTest.java
+++ b/gradoop-hbase/src/test/java/org/gradoop/common/storage/impl/hbase/HBaseGraphStoreTest.java
@@ -24,7 +24,7 @@ import org.gradoop.common.model.api.entities.EPGMGraphHead;
 import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.common.model.api.entities.EPGMVertexFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.id.GradoopIds;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
@@ -192,7 +192,7 @@ public class HBaseGraphStoreTest extends GradoopHBaseTestBase {
 
     final Set<Edge> outEdges = Sets.newHashSetWithExpectedSize(0);
     final Set<Edge> inEdges = Sets.newHashSetWithExpectedSize(0);
-    final GradoopIds graphs = new GradoopIds();
+    final GradoopIdSet graphs = new GradoopIdSet();
     PersistentVertex<Edge> v = persistentVertexFactory.createVertex(
         vertexFactory.initVertex(vertexID, label, props, graphs),
         outEdges, inEdges);
@@ -218,7 +218,7 @@ public class HBaseGraphStoreTest extends GradoopHBaseTestBase {
 
     final Set<Edge> outEdges = Sets.newHashSetWithExpectedSize(0);
     final Set<Edge> inEdges = Sets.newHashSetWithExpectedSize(0);
-    final GradoopIds graphs = new GradoopIds();
+    final GradoopIdSet graphs = new GradoopIdSet();
 
     // write to store
     graphStore.writeVertex(persistentVertexFactory.createVertex(
@@ -282,8 +282,8 @@ public class HBaseGraphStoreTest extends GradoopHBaseTestBase {
     HBaseEPGMStore<GraphHead, Vertex, Edge> graphStore, GraphHead graphHead,
     Vertex vertex, Edge edge) {
     graphStore.writeGraphHead(new HBaseGraphHeadFactory<>().createGraphHead(
-      graphHead, GradoopIds.fromExisting(vertex.getId()),
-      GradoopIds.fromExisting(edge.getId())
+      graphHead, GradoopIdSet.fromExisting(vertex.getId()),
+      GradoopIdSet.fromExisting(edge.getId())
       )
     );
   }


### PR DESCRIPTION
- more efficient `GradoopIds::containsAny` by always iterating over the smaller one
- replace several instances of `Collection<Gradoop>` with `GradoopIds` to prevent sequential iteration when calling `contains`

No test changes necessary.