### PR TITLE
[ #731] SingleSourceShortestPaths algorithm from Gelly Flink

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/functions/EdgeToGellyEdgeWithDouble.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/functions/EdgeToGellyEdgeWithDouble.java
@@ -49,7 +49,17 @@ public class EdgeToGellyEdgeWithDouble implements EdgeToGellyEdge<Double> {
     throws Exception {
     reuseEdge.setSource(epgmEdge.getSourceId());
     reuseEdge.setTarget(epgmEdge.getTargetId());
-    reuseEdge.setValue(epgmEdge.getPropertyValue(propertyKey).getDouble());
+
+    //cast incoming numeric value to double
+    if(epgmEdge.getPropertyValue(propertyKey).isDouble()) {
+    	reuseEdge.setValue(epgmEdge.getPropertyValue(propertyKey).getDouble());
+    } else if(epgmEdge.getPropertyValue(propertyKey).isFloat()) {
+    	reuseEdge.setValue((double) epgmEdge.getPropertyValue(propertyKey).getFloat());
+    } else if(epgmEdge.getPropertyValue(propertyKey).isInt()) {
+    	reuseEdge.setValue((double) epgmEdge.getPropertyValue(propertyKey).getInt());
+    } else if(epgmEdge.getPropertyValue(propertyKey).isLong()) {
+    	reuseEdge.setValue((double) epgmEdge.getPropertyValue(propertyKey).getLong());
+    }
     return reuseEdge;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/functions/EdgeToGellyEdgeWithDouble.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/functions/EdgeToGellyEdgeWithDouble.java
@@ -17,6 +17,7 @@ package org.gradoop.flink.algorithms.gelly.functions;
 
 import org.apache.flink.graph.Edge;
 import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.common.model.impl.properties.PropertyValue;
 
 /**
  * Maps EPGM edge to a Gelly edge consisting of EPGM source and target
@@ -51,14 +52,15 @@ public class EdgeToGellyEdgeWithDouble implements EdgeToGellyEdge<Double> {
     reuseEdge.setTarget(epgmEdge.getTargetId());
 
     //cast incoming numeric value to double
-    if(epgmEdge.getPropertyValue(propertyKey).isDouble()) {
-    	reuseEdge.setValue(epgmEdge.getPropertyValue(propertyKey).getDouble());
-    } else if(epgmEdge.getPropertyValue(propertyKey).isFloat()) {
-    	reuseEdge.setValue((double) epgmEdge.getPropertyValue(propertyKey).getFloat());
-    } else if(epgmEdge.getPropertyValue(propertyKey).isInt()) {
-    	reuseEdge.setValue((double) epgmEdge.getPropertyValue(propertyKey).getInt());
-    } else if(epgmEdge.getPropertyValue(propertyKey).isLong()) {
-    	reuseEdge.setValue((double) epgmEdge.getPropertyValue(propertyKey).getLong());
+    PropertyValue value = epgmEdge.getPropertyValue(propertyKey);
+    if (value.isDouble()) {
+      reuseEdge.setValue(value.getDouble());
+    } else if (value.isFloat()) {
+      reuseEdge.setValue((double) value.getFloat());
+    } else if (value.isInt()) {
+      reuseEdge.setValue((double) value.getInt());
+    } else if (value.isLong()) {
+      reuseEdge.setValue((double) value.getLong());
     }
     return reuseEdge;
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/functions/EdgeToGellyEdgeWithDouble.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/functions/EdgeToGellyEdgeWithDouble.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2014 - 2017 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/functions/EdgeToGellyEdgeWithDouble.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/functions/EdgeToGellyEdgeWithDouble.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2014 - 2017 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gradoop.flink.algorithms.gelly.functions;
 
 import org.apache.flink.graph.Edge;
@@ -9,27 +24,32 @@ import org.gradoop.common.model.impl.id.GradoopId;
  */
 public class EdgeToGellyEdgeWithDouble implements EdgeToGellyEdge<Double> {
 
-	/**
-	 * Property key to get the value for.
-	 */
-	private final String propertyKey;
+  /**
+   * Property key to get the value for.
+   */
+  private final String propertyKey;
 
-	/**
-	 * Reduce object instantiations.
-	 */
-	private final org.apache.flink.graph.Edge<GradoopId, Double> reuseEdge;
+  /**
+   * Reduce object instantiations.
+   */
+  private final org.apache.flink.graph.Edge<GradoopId, Double> reuseEdge;
 
-	public EdgeToGellyEdgeWithDouble(String propertyKey) {
-		this.propertyKey = propertyKey;
-		this.reuseEdge = new org.apache.flink.graph.Edge<>();
-	}
+  /**
+   * Constructor.
+   *
+   * @param propertyKey property key to get the property value.
+   */
+  public EdgeToGellyEdgeWithDouble(String propertyKey) {
+    this.propertyKey = propertyKey;
+    this.reuseEdge = new org.apache.flink.graph.Edge<>();
+  }
 
-	@Override
-	public Edge<GradoopId, Double> map(org.gradoop.common.model.impl.pojo.Edge epgmEdge) throws Exception {
-		reuseEdge.setSource(epgmEdge.getSourceId());
-		reuseEdge.setTarget(epgmEdge.getTargetId());
-		reuseEdge.setValue(epgmEdge.getPropertyValue(propertyKey).getDouble());
-		return reuseEdge;
-	}
-
+  @Override
+  public Edge<GradoopId, Double> map(org.gradoop.common.model.impl.pojo.Edge epgmEdge)
+    throws Exception {
+    reuseEdge.setSource(epgmEdge.getSourceId());
+    reuseEdge.setTarget(epgmEdge.getTargetId());
+    reuseEdge.setValue(epgmEdge.getPropertyValue(propertyKey).getDouble());
+    return reuseEdge;
+  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/functions/EdgeToGellyEdgeWithDouble.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/functions/EdgeToGellyEdgeWithDouble.java
@@ -1,0 +1,35 @@
+package org.gradoop.flink.algorithms.gelly.functions;
+
+import org.apache.flink.graph.Edge;
+import org.gradoop.common.model.impl.id.GradoopId;
+
+/**
+ * Maps EPGM edge to a Gelly edge consisting of EPGM source and target
+ * identifier and {@link Double} as edge value.
+ */
+public class EdgeToGellyEdgeWithDouble implements EdgeToGellyEdge<Double> {
+
+	/**
+	 * Property key to get the value for.
+	 */
+	private final String propertyKey;
+
+	/**
+	 * Reduce object instantiations.
+	 */
+	private final org.apache.flink.graph.Edge<GradoopId, Double> reuseEdge;
+
+	public EdgeToGellyEdgeWithDouble(String propertyKey) {
+		this.propertyKey = propertyKey;
+		this.reuseEdge = new org.apache.flink.graph.Edge<>();
+	}
+
+	@Override
+	public Edge<GradoopId, Double> map(org.gradoop.common.model.impl.pojo.Edge epgmEdge) throws Exception {
+		reuseEdge.setSource(epgmEdge.getSourceId());
+		reuseEdge.setTarget(epgmEdge.getTargetId());
+		reuseEdge.setValue(epgmEdge.getPropertyValue(propertyKey).getDouble());
+		return reuseEdge;
+	}
+
+}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/SingleSourceShortestPaths.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/SingleSourceShortestPaths.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2014 - 2017 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gradoop.flink.algorithms.gelly.shortestpaths;
 
 import org.apache.flink.api.java.DataSet;
@@ -5,7 +20,6 @@ import org.apache.flink.graph.Graph;
 import org.apache.flink.types.NullValue;
 import org.gradoop.common.model.impl.id.GradoopId;
 import org.gradoop.common.model.impl.pojo.Vertex;
-import org.gradoop.common.model.impl.properties.PropertyValue;
 import org.gradoop.flink.algorithms.gelly.GellyAlgorithm;
 import org.gradoop.flink.algorithms.gelly.functions.EdgeToGellyEdgeWithDouble;
 import org.gradoop.flink.algorithms.gelly.functions.VertexToGellyVertexWithNullValue;
@@ -13,55 +27,66 @@ import org.gradoop.flink.algorithms.gelly.shortestpaths.functions.SingleSourceSh
 import org.gradoop.flink.model.api.epgm.LogicalGraph;
 import org.gradoop.flink.model.impl.functions.epgm.Id;
 
+/**
+ * A gradoop operator wrapping {@link org.apache.flink.graph.library.SingleSourceShortestPaths}.
+ *
+ */
 public class SingleSourceShortestPaths extends GellyAlgorithm<NullValue, Double> {
 
-	/**
-	 * ID of the source vertex
-	 */
-	private final GradoopId srcVertexId;
-	/**
-	 * Number of iterations.
-	 */
-	private final int iterations;
-	
-	/**
-	 * Property key to store the vertex id in.
-	 */
-	private final String propertyKeyVertex;
-	
-	/**
-	 * Property key to store the edge id in.
-	 */
-	private final String propertyKeyEdge;
-	
+  /**
+   * ID of the source vertex
+   */
+  private final GradoopId srcVertexId;
+  /**
+   * Number of iterations.
+   */
+  private final int iterations;
 
-	public SingleSourceShortestPaths(GradoopId srcVertexId, String propertyKeyEdge, int iterations, String propertyKeyVertex) {
-		super(new VertexToGellyVertexWithNullValue(), new EdgeToGellyEdgeWithDouble(propertyKeyEdge));
-		this.propertyKeyVertex = propertyKeyVertex;
-		this.propertyKeyEdge = propertyKeyEdge;
-		this.iterations = iterations;
-		this.srcVertexId = srcVertexId;
-	}
-	
-	
-	@Override
-	protected LogicalGraph executeInGelly(Graph<GradoopId, NullValue, Double> graph) 
-		throws Exception {
-		
-		DataSet<Vertex> newVertices = new org.apache.flink.graph.library.SingleSourceShortestPaths<GradoopId, 
-			NullValue>(srcVertexId, iterations)
-			.run(graph)
-			.join(currentGraph.getVertices())
-			.where(0)
-			.equalTo(new Id<>())
-			.with(new SingleSourceShortestPathsAttribute(propertyKeyVertex));
-		return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(newVertices,
-			currentGraph.getEdges());
+  /**
+   * Property key to store the vertex id in.
+   */
+  private final String propertyKeyVertex;
 
-	}
-	
-	@Override
-	public String getName() {
-		return SingleSourceShortestPaths.class.getName();
-	}
+  /**
+   * Property key to store the edge id in.
+   */
+  private final String propertyKeyEdge;
+
+  /**
+   * Constructor for single source shortest paths with the {@link GradoopId} of the source vertex
+   * and a maximum number of iterations.
+   *
+   * @param srcVertexId Id of the source vertex.
+   * @param propertyKeyEdge Property key to store the edge value in.
+   * @param iterations The maximum number of iterations.
+   * @param propertyKeyVertex Property key to store the vertex value in.
+   */
+  public SingleSourceShortestPaths(GradoopId srcVertexId, String propertyKeyEdge,
+    int iterations, String propertyKeyVertex) {
+    super(new VertexToGellyVertexWithNullValue(), new EdgeToGellyEdgeWithDouble(propertyKeyEdge));
+    this.propertyKeyVertex = propertyKeyVertex;
+    this.propertyKeyEdge = propertyKeyEdge;
+    this.iterations = iterations;
+    this.srcVertexId = srcVertexId;
+  }
+
+  @Override
+  protected LogicalGraph executeInGelly(Graph<GradoopId, NullValue, Double> graph)
+    throws Exception {
+
+    DataSet<Vertex> newVertices = new org.apache.flink.graph.library.SingleSourceShortestPaths
+      <GradoopId, NullValue>(srcVertexId, iterations)
+      .run(graph)
+      .join(currentGraph.getVertices())
+      .where(0)
+      .equalTo(new Id<>())
+      .with(new SingleSourceShortestPathsAttribute(propertyKeyVertex));
+    return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(newVertices,
+      currentGraph.getEdges());
+  }
+
+  @Override
+  public String getName() {
+    return SingleSourceShortestPaths.class.getName();
+  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/SingleSourceShortestPaths.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/SingleSourceShortestPaths.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2014 - 2017 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/SingleSourceShortestPaths.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/SingleSourceShortestPaths.java
@@ -1,0 +1,67 @@
+package org.gradoop.flink.algorithms.gelly.shortestpaths;
+
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.graph.Graph;
+import org.apache.flink.types.NullValue;
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.properties.PropertyValue;
+import org.gradoop.flink.algorithms.gelly.GellyAlgorithm;
+import org.gradoop.flink.algorithms.gelly.functions.EdgeToGellyEdgeWithDouble;
+import org.gradoop.flink.algorithms.gelly.functions.VertexToGellyVertexWithNullValue;
+import org.gradoop.flink.algorithms.gelly.shortestpaths.functions.SingleSourceShortestPathsAttribute;
+import org.gradoop.flink.model.api.epgm.LogicalGraph;
+import org.gradoop.flink.model.impl.functions.epgm.Id;
+
+public class SingleSourceShortestPaths extends GellyAlgorithm<NullValue, Double> {
+
+	/**
+	 * ID of the source vertex
+	 */
+	private final GradoopId srcVertexId;
+	/**
+	 * Number of iterations.
+	 */
+	private final int iterations;
+	
+	/**
+	 * Property key to store the vertex id in.
+	 */
+	private final String propertyKeyVertex;
+	
+	/**
+	 * Property key to store the edge id in.
+	 */
+	private final String propertyKeyEdge;
+	
+
+	public SingleSourceShortestPaths(GradoopId srcVertexId, String propertyKeyEdge, int iterations, String propertyKeyVertex) {
+		super(new VertexToGellyVertexWithNullValue(), new EdgeToGellyEdgeWithDouble(propertyKeyEdge));
+		this.propertyKeyVertex = propertyKeyVertex;
+		this.propertyKeyEdge = propertyKeyEdge;
+		this.iterations = iterations;
+		this.srcVertexId = srcVertexId;
+	}
+	
+	
+	@Override
+	protected LogicalGraph executeInGelly(Graph<GradoopId, NullValue, Double> graph) 
+		throws Exception {
+		
+		DataSet<Vertex> newVertices = new org.apache.flink.graph.library.SingleSourceShortestPaths<GradoopId, 
+			NullValue>(srcVertexId, iterations)
+			.run(graph)
+			.join(currentGraph.getVertices())
+			.where(0)
+			.equalTo(new Id<>())
+			.with(new SingleSourceShortestPathsAttribute(propertyKeyVertex));
+		return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(newVertices,
+			currentGraph.getEdges());
+
+	}
+	
+	@Override
+	public String getName() {
+		return SingleSourceShortestPaths.class.getName();
+	}
+}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/functions/SingleSourceShortestPathsAttribute.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/functions/SingleSourceShortestPathsAttribute.java
@@ -1,30 +1,48 @@
+/**
+ * Copyright © 2014 - 2017 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gradoop.flink.algorithms.gelly.shortestpaths.functions;
 
 import org.apache.flink.api.common.functions.JoinFunction;
 import org.gradoop.common.model.impl.id.GradoopId;
 import org.gradoop.common.model.impl.pojo.Vertex;
-import org.gradoop.common.model.impl.properties.PropertyValue;
 
 /**
  * Stores the minimum distance as a property in vertex.
  */
-public class SingleSourceShortestPathsAttribute 
-	implements JoinFunction<org.apache.flink.graph.Vertex<GradoopId, Double>, Vertex, Vertex> {
+public class SingleSourceShortestPathsAttribute
+  implements JoinFunction<org.apache.flink.graph.Vertex<GradoopId, Double>, Vertex, Vertex> {
 
-	/**
-	 * Property to store the minimum distance in.
-	 */
-	private final String shortestPathProperty;
-	
-	public SingleSourceShortestPathsAttribute(String shortestPathProperty) {
-		this.shortestPathProperty = shortestPathProperty;
-	}
-	
-	@Override
-	public Vertex join(org.apache.flink.graph.Vertex<GradoopId, Double> gellyVertex,
-			Vertex gradoopVertex) 
-		{
-	    gradoopVertex.setProperty(shortestPathProperty, gellyVertex.getValue());
-	    return gradoopVertex;
-	  }
+  /**
+   * Property to store the minimum distance in.
+   */
+  private final String shortestPathProperty;
+
+  /**
+   * Stores the shortest distance to the source vertex as a property.
+   *
+   * @param shortestPathProperty property key to store shortest path in
+   */
+  public SingleSourceShortestPathsAttribute(String shortestPathProperty) {
+    this.shortestPathProperty = shortestPathProperty;
+  }
+
+  @Override
+  public Vertex join(org.apache.flink.graph.Vertex<GradoopId, Double> gellyVertex,
+    Vertex gradoopVertex) {
+    gradoopVertex.setProperty(shortestPathProperty, gellyVertex.getValue());
+    return gradoopVertex;
+  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/functions/SingleSourceShortestPathsAttribute.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/functions/SingleSourceShortestPathsAttribute.java
@@ -1,0 +1,30 @@
+package org.gradoop.flink.algorithms.gelly.shortestpaths.functions;
+
+import org.apache.flink.api.common.functions.JoinFunction;
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.properties.PropertyValue;
+
+/**
+ * Stores the minimum distance as a property in vertex.
+ */
+public class SingleSourceShortestPathsAttribute 
+	implements JoinFunction<org.apache.flink.graph.Vertex<GradoopId, Double>, Vertex, Vertex> {
+
+	/**
+	 * Property to store the minimum distance in.
+	 */
+	private final String shortestPathProperty;
+	
+	public SingleSourceShortestPathsAttribute(String shortestPathProperty) {
+		this.shortestPathProperty = shortestPathProperty;
+	}
+	
+	@Override
+	public Vertex join(org.apache.flink.graph.Vertex<GradoopId, Double> gellyVertex,
+			Vertex gradoopVertex) 
+		{
+	    gradoopVertex.setProperty(shortestPathProperty, gellyVertex.getValue());
+	    return gradoopVertex;
+	  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/functions/SingleSourceShortestPathsAttribute.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/functions/SingleSourceShortestPathsAttribute.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2014 - 2017 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/functions/package-info.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/functions/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2014 - 2017 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/functions/package-info.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/functions/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright © 2014 - 2017 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Contains functions related to the Single Source Shortest Path algorithm.
+ */
+package org.gradoop.flink.algorithms.gelly.shortestpaths.functions;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/package-info.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2014 - 2017 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/package-info.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright © 2014 - 2017 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Contains classes related to the Single Source Shortest Path algorithm.
+ */
+package org.gradoop.flink.algorithms.gelly.shortestpaths;

--- a/gradoop-flink/src/test/java/org/gradoop/flink/algorithms/gelly/shortestpaths/SingleSourceShortestPathsTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/algorithms/gelly/shortestpaths/SingleSourceShortestPathsTest.java
@@ -26,7 +26,7 @@ public class SingleSourceShortestPathsTest extends GradoopFlinkTestBase {
   @Test
   public void testByElementData() throws Exception {
 
-    String graphs = "input[" +
+    String graphsDouble = "input[" +
       "(v0 {id:0, vertexValue:0.0d})" +
       "(v1 {id:1, vertexValue:NULL})" +
       "(v2 {id:2, vertexValue:NULL})" +
@@ -54,7 +54,49 @@ public class SingleSourceShortestPathsTest extends GradoopFlinkTestBase {
       "(v7)-[e12 {edgeValue:5.0d}]->(v9)" +
       "(v8)-[e13 {edgeValue:1.0d}]->(v9)" +
       "]";
+    
+    String graphs = "input[" +
+        "(v0 {id:0, vertexValue:0.0})" +
+        "(v1 {id:1, vertexValue:NULL})" +
+        "(v2 {id:2, vertexValue:NULL})" +
+        "(v3 {id:3, vertexValue:NULL})" +
+        "(v4 {id:4, vertexValue:NULL})" +
+        "(v0)-[e0 {edgeValue:2.0}]->(v1)" +
+        "(v0)-[e1 {edgeValue:7.0}]->(v2)" +
+        "(v0)-[e2 {edgeValue:6.0}]->(v3)" +
+        "(v1)-[e3 {edgeValue:3.0}]->(v2)" +
+        "(v1)-[e4 {edgeValue:6.0}]->(v4)" +
+        "(v2)-[e5 {edgeValue:5.0}]->(v4)" +
+        "(v3)-[e6 {edgeValue:1.0}]->(v4)" +
+        "]" +
+        "result[" +
+        "(v5 {id:0, vertexValue:0.0d})" +
+        "(v6 {id:1, vertexValue:2.0d})" +
+        "(v7 {id:2, vertexValue:5.0d})" +
+        "(v8 {id:3, vertexValue:6.0d})" +
+        "(v9 {id:4, vertexValue:7.0d})" +
+        "(v5)-[e7 {edgeValue:2.0}]->(v6)" +
+        "(v5)-[e8 {edgeValue:7.0}]->(v7)" +
+        "(v5)-[e9 {edgeValue:6.0}]->(v8)" +
+        "(v6)-[e10 {edgeValue:3.0}]->(v7)" +
+        "(v6)-[e11 {edgeValue:6.0}]->(v9)" +
+        "(v7)-[e12 {edgeValue:5.0}]->(v9)" +
+        "(v8)-[e13 {edgeValue:1.0}]->(v9)" +
+        "]";
 
+    //test a graph with double values as input
+    FlinkAsciiGraphLoader loaderDouble = getLoaderFromString(graphsDouble);
+    LogicalGraph inputDouble = loaderDouble.getLogicalGraphByVariable("input");
+    Vertex srcVertexDouble = loaderDouble.getVertexByVariable("v0");
+    GradoopId srcVertexIdDouble = srcVertexDouble.getId();
+
+    LogicalGraph outputGraphDouble = inputDouble.callForGraph(new SingleSourceShortestPaths(srcVertexIdDouble,
+      "edgeValue", 10, "vertexValue"));
+    LogicalGraph expectDouble = loaderDouble.getLogicalGraphByVariable("result");
+    
+    collectAndAssertTrue(outputGraphDouble.equalsByElementData(expectDouble));
+
+  //test a graph with float values as input
     FlinkAsciiGraphLoader loader = getLoaderFromString(graphs);
     LogicalGraph input = loader.getLogicalGraphByVariable("input");
     Vertex srcVertex = loader.getVertexByVariable("v0");
@@ -63,7 +105,7 @@ public class SingleSourceShortestPathsTest extends GradoopFlinkTestBase {
     LogicalGraph outputGraph = input.callForGraph(new SingleSourceShortestPaths(srcVertexId,
       "edgeValue", 10, "vertexValue"));
     LogicalGraph expect = loader.getLogicalGraphByVariable("result");
-
+    
     collectAndAssertTrue(outputGraph.equalsByElementData(expect));
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/algorithms/gelly/shortestpaths/SingleSourceShortestPathsTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/algorithms/gelly/shortestpaths/SingleSourceShortestPathsTest.java
@@ -1,63 +1,69 @@
+/**
+ * Copyright © 2014 - 2017 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gradoop.flink.algorithms.gelly.shortestpaths;
 
-import java.util.List;
-
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.Vertex;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
 import org.gradoop.flink.model.api.epgm.LogicalGraph;
-import org.gradoop.flink.model.api.functions.TransformationFunction;
 import org.gradoop.flink.util.FlinkAsciiGraphLoader;
 import org.junit.Test;
 
 public class SingleSourceShortestPathsTest extends GradoopFlinkTestBase {
+  @Test
+  public void testByElementData() throws Exception {
 
-	public TransformationFunction<Vertex> transformVertex;
-	
-	@Test
-	public void testByElementData() throws Exception {
-		
-		String graphs = "input[" +
-		"(v0 {id:0, vertexValue:0.0d})" +
-		"(v1 {id:1, vertexValue:NULL})" +
-		"(v2 {id:2, vertexValue:NULL})" +
-		"(v3 {id:3, vertexValue:NULL})" +
-		"(v4 {id:4, vertexValue:NULL})" +
-		"(v0)-[e0 {edgeValue:2.0d}]->(v1)" +
-		"(v0)-[e1 {edgeValue:7.0d}]->(v2)" +
-		"(v0)-[e2 {edgeValue:6.0d}]->(v3)" +
-		"(v1)-[e3 {edgeValue:3.0d}]->(v2)" +
-		"(v1)-[e4 {edgeValue:6.0d}]->(v4)" +
-		"(v2)-[e5 {edgeValue:5.0d}]->(v4)" +
-		"(v3)-[e6 {edgeValue:1.0d}]->(v4)" +
-		"]" +
-		"result[" +
-		"(v5 {id:0, vertexValue:0.0d})" +
-		"(v6 {id:1, vertexValue:2.0d})" +
-		"(v7 {id:2, vertexValue:5.0d})" +
-		"(v8 {id:3, vertexValue:6.0d})" +
-		"(v9 {id:4, vertexValue:7.0d})" +
-		"(v5)-[e0 {edgeValue:2.0d}]->(v6)" +
-		"(v5)-[e1 {edgeValue:7.0d}]->(v7)" +
-		"(v5)-[e2 {edgeValue:6.0d}]->(v8)" +
-		"(v6)-[e3 {edgeValue:3.0d}]->(v7)" +
-		"(v6)-[e4 {edgeValue:6.0d}]->(v9)" +
-		"(v7)-[e5 {edgeValue:5.0d}]->(v9)" +
-		"(v8)-[e6 {edgeValue:1.0d}]->(v9)" +
-		"]";
-		
-		FlinkAsciiGraphLoader loader = getLoaderFromString(graphs);
-		LogicalGraph input = loader.getLogicalGraphByVariable("input");
-		Vertex srcVertex = loader.getVertexByVariable("v0");
-		GradoopId srcVertexId = srcVertex.getId();
-		
-		LogicalGraph outputGraph = input.callForGraph(new SingleSourceShortestPaths(srcVertexId, "edgeValue", 10, "vertexValue"));
-		LogicalGraph expect = loader.getLogicalGraphByVariable("result");
-		
-		
-	
-		collectAndAssertTrue(outputGraph.equalsByElementData(expect));
-		
-	}
+    String graphs = "input[" +
+      "(v0 {id:0, vertexValue:0.0d})" +
+      "(v1 {id:1, vertexValue:NULL})" +
+      "(v2 {id:2, vertexValue:NULL})" +
+      "(v3 {id:3, vertexValue:NULL})" +
+      "(v4 {id:4, vertexValue:NULL})" +
+      "(v0)-[e0 {edgeValue:2.0d}]->(v1)" +
+      "(v0)-[e1 {edgeValue:7.0d}]->(v2)" +
+      "(v0)-[e2 {edgeValue:6.0d}]->(v3)" +
+      "(v1)-[e3 {edgeValue:3.0d}]->(v2)" +
+      "(v1)-[e4 {edgeValue:6.0d}]->(v4)" +
+      "(v2)-[e5 {edgeValue:5.0d}]->(v4)" +
+      "(v3)-[e6 {edgeValue:1.0d}]->(v4)" +
+      "]" +
+      "result[" +
+      "(v5 {id:0, vertexValue:0.0d})" +
+      "(v6 {id:1, vertexValue:2.0d})" +
+      "(v7 {id:2, vertexValue:5.0d})" +
+      "(v8 {id:3, vertexValue:6.0d})" +
+      "(v9 {id:4, vertexValue:7.0d})" +
+      "(v5)-[e7 {edgeValue:2.0d}]->(v6)" +
+      "(v5)-[e8 {edgeValue:7.0d}]->(v7)" +
+      "(v5)-[e9 {edgeValue:6.0d}]->(v8)" +
+      "(v6)-[e10 {edgeValue:3.0d}]->(v7)" +
+      "(v6)-[e11 {edgeValue:6.0d}]->(v9)" +
+      "(v7)-[e12 {edgeValue:5.0d}]->(v9)" +
+      "(v8)-[e13 {edgeValue:1.0d}]->(v9)" +
+      "]";
+
+    FlinkAsciiGraphLoader loader = getLoaderFromString(graphs);
+    LogicalGraph input = loader.getLogicalGraphByVariable("input");
+    Vertex srcVertex = loader.getVertexByVariable("v0");
+    GradoopId srcVertexId = srcVertex.getId();
+
+    LogicalGraph outputGraph = input.callForGraph(new SingleSourceShortestPaths(srcVertexId,
+      "edgeValue", 10, "vertexValue"));
+    LogicalGraph expect = loader.getLogicalGraphByVariable("result");
+
+    collectAndAssertTrue(outputGraph.equalsByElementData(expect));
+  }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/algorithms/gelly/shortestpaths/SingleSourceShortestPathsTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/algorithms/gelly/shortestpaths/SingleSourceShortestPathsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2014 - 2017 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-flink/src/test/java/org/gradoop/flink/algorithms/gelly/shortestpaths/SingleSourceShortestPathsTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/algorithms/gelly/shortestpaths/SingleSourceShortestPathsTest.java
@@ -1,0 +1,63 @@
+package org.gradoop.flink.algorithms.gelly.shortestpaths;
+
+import java.util.List;
+
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.common.model.impl.pojo.Edge;
+import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.flink.model.GradoopFlinkTestBase;
+import org.gradoop.flink.model.api.epgm.LogicalGraph;
+import org.gradoop.flink.model.api.functions.TransformationFunction;
+import org.gradoop.flink.util.FlinkAsciiGraphLoader;
+import org.junit.Test;
+
+public class SingleSourceShortestPathsTest extends GradoopFlinkTestBase {
+
+	public TransformationFunction<Vertex> transformVertex;
+	
+	@Test
+	public void testByElementData() throws Exception {
+		
+		String graphs = "input[" +
+		"(v0 {id:0, vertexValue:0.0d})" +
+		"(v1 {id:1, vertexValue:NULL})" +
+		"(v2 {id:2, vertexValue:NULL})" +
+		"(v3 {id:3, vertexValue:NULL})" +
+		"(v4 {id:4, vertexValue:NULL})" +
+		"(v0)-[e0 {edgeValue:2.0d}]->(v1)" +
+		"(v0)-[e1 {edgeValue:7.0d}]->(v2)" +
+		"(v0)-[e2 {edgeValue:6.0d}]->(v3)" +
+		"(v1)-[e3 {edgeValue:3.0d}]->(v2)" +
+		"(v1)-[e4 {edgeValue:6.0d}]->(v4)" +
+		"(v2)-[e5 {edgeValue:5.0d}]->(v4)" +
+		"(v3)-[e6 {edgeValue:1.0d}]->(v4)" +
+		"]" +
+		"result[" +
+		"(v5 {id:0, vertexValue:0.0d})" +
+		"(v6 {id:1, vertexValue:2.0d})" +
+		"(v7 {id:2, vertexValue:5.0d})" +
+		"(v8 {id:3, vertexValue:6.0d})" +
+		"(v9 {id:4, vertexValue:7.0d})" +
+		"(v5)-[e0 {edgeValue:2.0d}]->(v6)" +
+		"(v5)-[e1 {edgeValue:7.0d}]->(v7)" +
+		"(v5)-[e2 {edgeValue:6.0d}]->(v8)" +
+		"(v6)-[e3 {edgeValue:3.0d}]->(v7)" +
+		"(v6)-[e4 {edgeValue:6.0d}]->(v9)" +
+		"(v7)-[e5 {edgeValue:5.0d}]->(v9)" +
+		"(v8)-[e6 {edgeValue:1.0d}]->(v9)" +
+		"]";
+		
+		FlinkAsciiGraphLoader loader = getLoaderFromString(graphs);
+		LogicalGraph input = loader.getLogicalGraphByVariable("input");
+		Vertex srcVertex = loader.getVertexByVariable("v0");
+		GradoopId srcVertexId = srcVertex.getId();
+		
+		LogicalGraph outputGraph = input.callForGraph(new SingleSourceShortestPaths(srcVertexId, "edgeValue", 10, "vertexValue"));
+		LogicalGraph expect = loader.getLogicalGraphByVariable("result");
+		
+		
+	
+		collectAndAssertTrue(outputGraph.equalsByElementData(expect));
+		
+	}
+}


### PR DESCRIPTION
Create an operator to wrap the gelly flink SingleSourceShortestPaths implementation. Added the new function EdgeToGellyEdgeWithDouble to cast incoming numeric values for edges to double to prepare the gelly algorithm. Tested the implementation with double and float input on equals by element data.