### PR TITLE
Fix overlap operator for two graphs overlapping by vertex set only.

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/overlap/Overlap.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/overlap/Overlap.java
@@ -21,8 +21,6 @@ import org.gradoop.common.model.impl.pojo.Vertex;
 import org.gradoop.flink.model.api.epgm.LogicalGraph;
 import org.gradoop.flink.model.api.operators.BinaryGraphToGraphOperator;
 import org.gradoop.flink.model.impl.functions.epgm.Id;
-import org.gradoop.flink.model.impl.functions.epgm.SourceId;
-import org.gradoop.flink.model.impl.functions.epgm.TargetId;
 import org.gradoop.flink.model.impl.functions.utils.LeftSide;
 
 /**
@@ -50,12 +48,8 @@ public class Overlap implements BinaryGraphToGraphOperator {
       .with(new LeftSide<>());
 
     DataSet<Edge> newEdges = firstGraph.getEdges()
-      .join(newVertices)
-      .where(new SourceId<>())
-      .equalTo(new Id<>())
-      .with(new LeftSide<>())
-      .join(newVertices)
-      .where(new TargetId<>())
+      .join(secondGraph.getEdges())
+      .where(new Id<>())
       .equalTo(new Id<>())
       .with(new LeftSide<>());
 

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/overlap/OverlapTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/overlap/OverlapTest.java
@@ -106,6 +106,19 @@ public class OverlapTest extends ReducibleBinaryOperatorsTestBase {
   }
 
   @Test
+  public void testVertexOnlyOverlappingGraphs() throws Exception {
+    FlinkAsciiGraphLoader loader = getLoaderFromString(
+      "g1[(a)-[e1]->(b)]" +
+      "g2[(a)-[e2]->(b)]" +
+      "expected[(a)(b)]");
+    LogicalGraph g1 = loader.getLogicalGraphByVariable("g1");
+    LogicalGraph g2 = loader.getLogicalGraphByVariable("g2");
+    LogicalGraph expected = loader.getLogicalGraphByVariable("expected");
+
+    collectAndAssertTrue(g1.overlap(g2).equalsByElementIds(expected));
+  }
+
+  @Test
   public void testGraphContainment() throws Exception {
     FlinkAsciiGraphLoader loader = getSocialNetworkLoader();
 

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/overlap/OverlapTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/overlap/OverlapTest.java
@@ -156,8 +156,10 @@ public class OverlapTest extends ReducibleBinaryOperatorsTestBase {
   @Test
   public void testReduceCollection() throws Exception {
     FlinkAsciiGraphLoader loader = getLoaderFromString("" +
-        "g1[(a)-[e1]->(b)];g2[(b)-[e2]->(c)]" +
-        "g3[(c)-[e3]->(d)];g4[(a)-[e1]->(b)]" +
+        "g1[(a)-[e1]->(b)]" +
+        "g2[(b)-[e2]->(c)]" +
+        "g3[(c)-[e3]->(d)]" +
+        "g4[(a)-[e1]->(b)]" +
         "exp12[(b)]" +
         "exp13[]" +
         "exp14[(a)-[e1]->(b)]"


### PR DESCRIPTION
The new implementations computes the overlap by getting the intersection of both vertex and edge sets.
Edges are considered equal if their IDs are equal, their source, target ID and properties are ignored.

Added a new test case to check the new implementation by overlapping two graphs with equal vertex sets and disjoint edge sets.

fixes #786 