### PR TITLE
Use an int to store the size of the internal representation of a large PropertyValue.

### DIFF
--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValue.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValue.java
@@ -858,7 +858,7 @@ public class PropertyValue implements Value, Serializable, Comparable<PropertyVa
     if (isString() || isBigDecimal() || isMap() || isList()) {
       // Write length as an int if the "large" flag is set.
       if ((type & FLAG_LARGE) == FLAG_LARGE) {
-        outputView.writeInt(rawBytes.length);
+        outputView.writeInt(rawBytes.length - OFFSET);
       } else {
         outputView.writeShort(rawBytes.length - OFFSET);
       }

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValue.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValue.java
@@ -83,7 +83,7 @@ public class PropertyValue implements Value, Serializable, Comparable<PropertyVa
    */
   public static final transient byte TYPE_STRING       = 0x06;
   /**
-   * {@code <property-type>} for {@link java.lang.String}
+   * {@code <property-type>} for {@link BigDecimal}
    */
   public static final transient byte TYPE_BIG_DECIMAL  = 0x07;
   /**
@@ -119,20 +119,16 @@ public class PropertyValue implements Value, Serializable, Comparable<PropertyVa
   /**
    * Bit flag indicating a "large" property. The length of the byte representation will be stored
    * as an {@code int} instead.
+   *
+   * @see #write(DataOutputView)
    */
   public static final transient byte FLAG_LARGE = 0x10;
 
   /**
-   * Was previously used to indicate maximum size of the internal byte representation.
-   *
-   * @deprecated The new maximum size is depending on the JVM implementation.
-   */
-  @Deprecated
-  public static final transient int MAX_BINARY_LENGTH = Short.MAX_VALUE - OFFSET;
-
-  /**
    * If the length of the byte representation is larger than this value, the length will be
-   * stored as an {@code int} instead of a {@code short},
+   * stored as an {@code int} instead of a {@code short}.
+   *
+   * @see #write(DataOutputView)
    */
   public static final transient int LARGE_PROPERTY_THRESHOLD = Short.MAX_VALUE;
 
@@ -838,6 +834,16 @@ public class PropertyValue implements Value, Serializable, Comparable<PropertyVa
    * byte 2       : length (short)
    * byte 3       : length (short)
    * byte 4 - end : value bytes
+   *
+   * If the size of the internal byte representation if larger than
+   * {@link #LARGE_PROPERTY_THRESHOLD} (i.e. if a {@code short} is too small to store the length),
+   * then the {@link #FLAG_LARGE} bit will be set in the first byte and the byte representation
+   * will be:
+   * byte 2       ; length (int)
+   * byte 3       : length (int)
+   * byte 4       : length (int)
+   * byte 5       : length (int)
+   * byte 6 - end : value bytes
    *
    * for fixed length types (e.g. int, long, float, ...)
    * byte 2 - end : value bytes

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValue.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValue.java
@@ -123,8 +123,16 @@ public class PropertyValue implements Value, Serializable, Comparable<PropertyVa
   public static final transient byte FLAG_LARGE = 0x10;
 
   /**
+   * Was previously used to indicate maximum size of the internal byte representation.
+   *
+   * @deprecated The new maximum size is depending on the JVM implementation.
+   */
+  @Deprecated
+  public static final transient int MAX_BINARY_LENGTH = Short.MAX_VALUE - OFFSET;
+
+  /**
    * If the length of the byte representation is larger than this value, the length will be
-   * stored as an {@link int} instead of a {@link short},
+   * stored as an {@code int} instead of a {@code short},
    */
   public static final transient int LARGE_PROPERTY_THRESHOLD = Short.MAX_VALUE;
 

--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/properties/PropertyValueTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/properties/PropertyValueTest.java
@@ -777,28 +777,28 @@ public class PropertyValueTest {
   @Test
   public void testArrayValueMaxSize() {
     PropertyValue property = new PropertyValue();
-    property.setBytes(new byte[PropertyValue.MAX_BINARY_LENGTH]);
+    property.setBytes(new byte[PropertyValue.LARGE_PROPERTY_THRESHOLD]);
   }
   
-  @Test(expected = IllegalStateException.class)
-  public void testArrayValueTooBig() {
+  @Test
+  public void testLargeArrayValu() {
     PropertyValue property = new PropertyValue();
-    property.setBytes(new byte[PropertyValue.MAX_BINARY_LENGTH + 1]);
+    property.setBytes(new byte[PropertyValue.LARGE_PROPERTY_THRESHOLD + 1]);
   }
 
   @Test
   public void testStringValueMaxSize() {
-    create(new String(new byte[PropertyValue.MAX_BINARY_LENGTH - 1]));
+    create(new String(new byte[PropertyValue.LARGE_PROPERTY_THRESHOLD]));
   }
   
-  @Test(expected = IllegalStateException.class)
-  public void testStringValueTooBig() {
-    create(new String(new byte[PropertyValue.MAX_BINARY_LENGTH]));
+  @Test
+  public void testLargeString() {
+    create(new String(new byte[PropertyValue.LARGE_PROPERTY_THRESHOLD + 10]));
   }
   
   @Test
   public void testListValueMaxSize() {
-    int n = PropertyValue.MAX_BINARY_LENGTH / 9;
+    int n = PropertyValue.LARGE_PROPERTY_THRESHOLD / 9;
     List<PropertyValue> list = new ArrayList<>(n);
     while ( n-- > 0 ){
       list.add(create(Math.random()));
@@ -806,10 +806,10 @@ public class PropertyValueTest {
     create(list);
   }
   
-  @Test(expected = IllegalStateException.class)
-  public void testListValueTooBig() {
+  @Test
+  public void testLargeListValue() {
     // 8 bytes per double + 1 byte overhead
-    int n = PropertyValue.MAX_BINARY_LENGTH / 9 + 1;
+    int n = PropertyValue.LARGE_PROPERTY_THRESHOLD / 9 + 1;
     List<PropertyValue> list = new ArrayList<>(n);
     while ( n-- > 0 ){
       list.add(create(Math.random()));
@@ -821,18 +821,18 @@ public class PropertyValueTest {
   public void testMapValueMaxSize() {
     Map<PropertyValue, PropertyValue> m = new HashMap<>();
     // 8 bytes per double + 1 byte overhead
-    for (int i = 0; i < PropertyValue.MAX_BINARY_LENGTH / 18; i++) {
+    for (int i = 0; i < PropertyValue.LARGE_PROPERTY_THRESHOLD / 18; i++) {
       PropertyValue p = create(Math.random());
       m.put(p, p);
     }
     create(m);
   }
   
-  @Test(expected = IllegalStateException.class)
-  public void testMapValueTooBig() {
+  @Test
+  public void testLargeMapValue() {
     Map<PropertyValue, PropertyValue> m = new HashMap<>();
     // 8 bytes per double + 1 byte overhead
-    for (int i = 0; i < PropertyValue.MAX_BINARY_LENGTH / 18 + 1; i++) {
+    for (int i = 0; i < PropertyValue.LARGE_PROPERTY_THRESHOLD / 18 + 1; i++) {
       PropertyValue p = create(Math.random());
       m.put(p, p);
     }
@@ -842,14 +842,14 @@ public class PropertyValueTest {
   @Test
   public void testBigDecimalValueMaxSize() {
     // internal representation of BigInteger needs 5 bytes
-    byte [] bigendian = new byte[PropertyValue.MAX_BINARY_LENGTH - 5];
+    byte [] bigendian = new byte[PropertyValue.LARGE_PROPERTY_THRESHOLD];
     Arrays.fill(bigendian, (byte) 121);
     create(new BigDecimal(new BigInteger(bigendian)));
   }
   
-  @Test(expected = IllegalStateException.class)
-  public void testBigDecimalValueTooBig() {
-    byte [] bigendian = new byte[PropertyValue.MAX_BINARY_LENGTH - 4];
+  @Test
+  public void testLargeBigDecimal() {
+    byte [] bigendian = new byte[Short.MAX_VALUE + 10];
     Arrays.fill(bigendian, (byte) 121);
     create(new BigDecimal(new BigInteger(bigendian)));
   }

--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/properties/PropertyValueTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/properties/PropertyValueTest.java
@@ -781,7 +781,7 @@ public class PropertyValueTest {
   }
   
   @Test
-  public void testLargeArrayValu() {
+  public void testLargeArrayValue() {
     PropertyValue property = new PropertyValue();
     property.setBytes(new byte[PropertyValue.LARGE_PROPERTY_THRESHOLD + 1]);
   }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/properties/PropertiesSerializationTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/properties/PropertiesSerializationTest.java
@@ -23,7 +23,13 @@ import org.gradoop.flink.model.GradoopFlinkTestBase;
 import org.gradoop.flink.model.impl.GradoopFlinkTestUtils;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class PropertiesSerializationTest extends GradoopFlinkTestBase {
 
@@ -47,5 +53,50 @@ public class PropertiesSerializationTest extends GradoopFlinkTestBase {
       GradoopTestUtils.SUPPORTED_PROPERTIES);
     assertEquals("Property Lists were not equal", pIn,
       GradoopFlinkTestUtils.writeAndRead(pIn, getExecutionEnvironment()));
+  }
+
+  @Test
+  public void testLargePropertyValueString() throws Exception {
+    // Create a large String. (Fill that String with copies of any char.)
+    char[] stringData = new char[PropertyValue.LARGE_PROPERTY_THRESHOLD + 1];
+    Arrays.fill(stringData, 'A');
+    String largeString = new String(stringData);
+    PropertyValue largeValue = PropertyValue.create(largeString);
+    // Make sure the String actually uses a "large" Property
+    assertTrue("PropertyValue not large enough.",
+      largeValue.getByteSize() > PropertyValue.LARGE_PROPERTY_THRESHOLD);
+    assertEquals("Property values were not equal.", largeValue,
+      GradoopFlinkTestUtils.writeAndRead(largeValue, getExecutionEnvironment()));
+  }
+
+  @Test
+  public void testSmallPropertyValueString() throws Exception {
+    char[] stringData = new char[PropertyValue.LARGE_PROPERTY_THRESHOLD - 1];
+    Arrays.fill(stringData, 'A');
+    String smallString = new String(stringData);
+    PropertyValue smallValue = PropertyValue.create(smallString);
+    // Make sure the String actually uses a "small" Property
+    assertTrue("PropertyValue not large enough.",
+    smallValue.getByteSize() <= PropertyValue.LARGE_PROPERTY_THRESHOLD);
+    assertEquals("Property values were not equal.", smallValue,
+    GradoopFlinkTestUtils.writeAndRead(smallValue, getExecutionEnvironment()));
+  }
+
+  @Test
+  public void testLargePropertyList() throws Exception {
+    // Create a large List of test Strings.
+    String testString = "Some test String.";
+    long neededCopies = PropertyValue.LARGE_PROPERTY_THRESHOLD /
+    // String length + 1 byte offset.
+      (testString.toCharArray().length + 1);
+    List<PropertyValue> largeList = Stream.generate(() -> testString).limit(neededCopies + 1)
+      .map(PropertyValue::create)
+      .collect(Collectors.toList());
+    PropertyValue largeValue = PropertyValue.create(largeList);
+    // Make sure the List was large enough.
+    assertTrue("PropertyValue to large enough.",
+     largeValue.byteSize() > PropertyValue.LARGE_PROPERTY_THRESHOLD);
+    assertEquals("Property values were not equal.", largeValue,
+      GradoopFlinkTestUtils.writeAndRead(largeValue, getExecutionEnvironment()));
   }
 }


### PR DESCRIPTION
When writing a `PropertyValue` of a variable length where the size is larger than `Short.MAX_VALUE`, an `int` is used instead. In that case an additional bit-flag is set in the type byte. (`PropertyValue.FLAG_LARGE`)

Change test cases for larger properties to not expect an Exception.
Add test cases for serialization of larger properties.
Remove `validateBytesLength` method as the new maximum size is large enough to support any array. (The JVM does not support larger arrays.)

Some additional testing for larger Maps and BigDecimals may be necessary.

fixes #776 