### PR TITLE
[#780] Add tests for RenameLabel and RenamePropertyKeys UDFs.

### DIFF
--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/RenameLabelTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/RenameLabelTest.java
@@ -1,0 +1,75 @@
+package org.gradoop.flink.model.impl.functions.epgm;
+
+import static org.junit.Assert.assertEquals;
+
+import org.gradoop.common.model.api.entities.EPGMEdge;
+import org.gradoop.common.model.api.entities.EPGMGraphHead;
+import org.gradoop.common.model.api.entities.EPGMVertex;
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.common.model.impl.pojo.EdgeFactory;
+import org.gradoop.common.model.impl.pojo.GraphHeadFactory;
+import org.gradoop.common.model.impl.pojo.VertexFactory;
+import org.gradoop.common.model.impl.properties.Properties;
+import org.gradoop.flink.model.GradoopFlinkTestBase;
+import org.gradoop.flink.model.api.functions.TransformationFunction;
+import org.junit.Test;
+
+public class RenameLabelTest extends GradoopFlinkTestBase {
+
+  @Test
+  public void testGraphHead() {
+
+    GradoopId graphId = GradoopId.get();
+    String label = "A";
+
+    EPGMGraphHead graphHead = new GraphHeadFactory().initGraphHead(graphId, label);
+
+    String newLabel = "B";
+
+    TransformationFunction<EPGMGraphHead> renameFunction = new RenameLabel<>(label, newLabel);
+
+    renameFunction.apply(graphHead, graphHead);
+
+    assertEquals(newLabel, graphHead.getLabel());
+  }
+
+  @Test
+  public void testEdge() {
+
+    GradoopId edgeId = GradoopId.get();
+    GradoopId sourceId = GradoopId.get();
+    GradoopId targetId = GradoopId.get();
+
+    String label = "A";
+    Properties props = Properties.create();
+    props.set("k1", "v1");
+    props.set("k2", "v2");
+
+    EPGMEdge edge = new EdgeFactory().initEdge(edgeId, label, sourceId, targetId);
+
+    String newLabel = "B";
+
+    TransformationFunction<EPGMEdge> renameFunction = new RenameLabel<>(label, newLabel);
+
+    renameFunction.apply(edge, edge);
+
+    assertEquals(newLabel, edge.getLabel());
+  }
+
+  @Test
+  public void testVertex() {
+
+    GradoopId vertexId = GradoopId.get();
+    String label = "A";
+
+    EPGMVertex vertex = new VertexFactory().initVertex(vertexId, label);
+
+    String newLabel = "B";
+
+    TransformationFunction<EPGMVertex> renameFunction = new RenameLabel<>(label, newLabel);
+
+    renameFunction.apply(vertex, vertex);
+ 
+    assertEquals(newLabel, vertex.getLabel());
+  }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/RenameLabelTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/RenameLabelTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gradoop.flink.model.impl.functions.epgm;
 
 import static org.junit.Assert.assertEquals;

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/RenameLabelTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/RenameLabelTest.java
@@ -16,6 +16,8 @@
 package org.gradoop.flink.model.impl.functions.epgm;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 import org.gradoop.common.model.api.entities.EPGMEdge;
 import org.gradoop.common.model.api.entities.EPGMGraphHead;
@@ -27,6 +29,7 @@ import org.gradoop.common.model.impl.pojo.VertexFactory;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
 import org.gradoop.flink.model.api.functions.TransformationFunction;
+import org.hamcrest.core.Is;
 import org.junit.Test;
 
 public class RenameLabelTest extends GradoopFlinkTestBase {
@@ -35,9 +38,13 @@ public class RenameLabelTest extends GradoopFlinkTestBase {
   public void testGraphHead() {
 
     GradoopId graphId = GradoopId.get();
-    String label = "A";
 
-    EPGMGraphHead graphHead = new GraphHeadFactory().initGraphHead(graphId, label);
+    String label = "A";
+    Properties props = Properties.create();
+    props.set("k1", "v1");
+    props.set("k2", "v2");
+
+    EPGMGraphHead graphHead = new GraphHeadFactory().initGraphHead(graphId, label, props);
 
     String newLabel = "B";
 
@@ -46,6 +53,8 @@ public class RenameLabelTest extends GradoopFlinkTestBase {
     renameFunction.apply(graphHead, graphHead);
 
     assertEquals(newLabel, graphHead.getLabel());
+    assertThat(graphHead.getPropertyValue("k1").toString(), Is.<Object>is("v1"));
+    assertThat(graphHead.getPropertyValue("k2").toString(), Is.<Object>is("v2"));
   }
 
   @Test
@@ -60,7 +69,7 @@ public class RenameLabelTest extends GradoopFlinkTestBase {
     props.set("k1", "v1");
     props.set("k2", "v2");
 
-    EPGMEdge edge = new EdgeFactory().initEdge(edgeId, label, sourceId, targetId);
+    EPGMEdge edge = new EdgeFactory().initEdge(edgeId, label, sourceId, targetId, props);
 
     String newLabel = "B";
 
@@ -69,15 +78,21 @@ public class RenameLabelTest extends GradoopFlinkTestBase {
     renameFunction.apply(edge, edge);
 
     assertEquals(newLabel, edge.getLabel());
+    assertThat(edge.getPropertyValue("k1").toString(), Is.<Object>is("v1"));
+    assertThat(edge.getPropertyValue("k2").toString(), Is.<Object>is("v2"));
   }
 
   @Test
   public void testVertex() {
 
     GradoopId vertexId = GradoopId.get();
-    String label = "A";
 
-    EPGMVertex vertex = new VertexFactory().initVertex(vertexId, label);
+    String label = "A";
+    Properties props = Properties.create();
+    props.set("k1", "v1");
+    props.set("k2", "v2");
+
+    EPGMVertex vertex = new VertexFactory().initVertex(vertexId, label, props);
 
     String newLabel = "B";
 
@@ -86,5 +101,7 @@ public class RenameLabelTest extends GradoopFlinkTestBase {
     renameFunction.apply(vertex, vertex);
  
     assertEquals(newLabel, vertex.getLabel());
+    assertThat(vertex.getPropertyValue("k1").toString(), Is.<Object>is("v1"));
+    assertThat(vertex.getPropertyValue("k2").toString(), Is.<Object>is("v2"));
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/RenamePropertyKeysTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/RenamePropertyKeysTest.java
@@ -16,6 +16,7 @@
 package org.gradoop.flink.model.impl.functions.epgm;
 
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
@@ -29,7 +30,6 @@ import org.gradoop.common.model.impl.pojo.EdgeFactory;
 import org.gradoop.common.model.impl.pojo.GraphHeadFactory;
 import org.gradoop.common.model.impl.pojo.VertexFactory;
 import org.gradoop.common.model.impl.properties.Properties;
-import org.gradoop.common.util.GradoopConstants;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
 import org.gradoop.flink.model.api.functions.TransformationFunction;
 import org.hamcrest.core.Is;
@@ -41,12 +41,14 @@ public class RenamePropertyKeysTest extends GradoopFlinkTestBase {
   public void testGraphHead() throws Exception {
 
     GradoopId graphID = GradoopId.get();
+
+    String label = "A";
     Properties props = Properties.create();
     props.set("k1", "v1");
     props.set("k2", "v2");
 
     EPGMGraphHead graphHead =
-        new GraphHeadFactory().initGraphHead(graphID, GradoopConstants.DEFAULT_GRAPH_LABEL, props);
+        new GraphHeadFactory().initGraphHead(graphID, label, props);
 
     HashMap<String, String> newProps = new HashMap<>();
     newProps.put("k1", "new_k1");
@@ -56,6 +58,7 @@ public class RenamePropertyKeysTest extends GradoopFlinkTestBase {
     renameFunction.apply(graphHead, graphHead);
 
     assertThat(graphHead.getPropertyCount(), is(2));
+    assertEquals(label, graphHead.getLabel());
     assertThat(graphHead.getPropertyValue("new_k1").toString(), Is.<Object>is("v1"));
     assertThat(graphHead.getPropertyValue("k2").toString(), Is.<Object>is("v2"));
     assertNull(graphHead.getPropertyValue("k1"));
@@ -68,12 +71,13 @@ public class RenamePropertyKeysTest extends GradoopFlinkTestBase {
     GradoopId sourceId = GradoopId.get();
     GradoopId targetId = GradoopId.get();
 
+    String label = "A";
     Properties props = Properties.create();
     props.set("k1", "v1");
     props.set("k2", "v2");
 
     EPGMEdge edge = 
-        new EdgeFactory().initEdge(edgeId, GradoopConstants.DEFAULT_GRAPH_LABEL, sourceId, targetId, props);
+        new EdgeFactory().initEdge(edgeId, label, sourceId, targetId, props);
 
     HashMap<String, String> newProps = new HashMap<>();
     newProps.put("k1", "new_k1");
@@ -83,6 +87,7 @@ public class RenamePropertyKeysTest extends GradoopFlinkTestBase {
     renameFunction.apply(edge, edge);
 
     assertThat(edge.getPropertyCount(), is(2));
+    assertEquals(label, edge.getLabel());
     assertThat(edge.getPropertyValue("new_k1").toString(), Is.<Object>is("v1"));
     assertThat(edge.getPropertyValue("k2").toString(), Is.<Object>is("v2"));
     assertNull(edge.getPropertyValue("k1"));
@@ -93,12 +98,13 @@ public class RenamePropertyKeysTest extends GradoopFlinkTestBase {
 
     GradoopId vertexId = GradoopId.get();
 
+    String label = "A";
     Properties props = Properties.create();
     props.set("k1", "v1");
     props.set("k2", "v2");
 
     EPGMVertex vertex =
-        new VertexFactory().initVertex(vertexId, GradoopConstants.DEFAULT_GRAPH_LABEL, props);
+        new VertexFactory().initVertex(vertexId, label, props);
 
     HashMap<String, String> newProps = new HashMap<>();
     newProps.put("k1", "new_k1");
@@ -108,6 +114,7 @@ public class RenamePropertyKeysTest extends GradoopFlinkTestBase {
     renameFunction.apply(vertex, vertex);
 
     assertThat(vertex.getPropertyCount(), is(2));
+    assertEquals(label, vertex.getLabel());
     assertThat(vertex.getPropertyValue("new_k1").toString(), Is.<Object>is("v1"));
     assertThat(vertex.getPropertyValue("k2").toString(), Is.<Object>is("v2"));
     assertNull(vertex.getPropertyValue("k1"));

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/RenamePropertyKeysTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/RenamePropertyKeysTest.java
@@ -1,0 +1,100 @@
+package org.gradoop.flink.model.impl.functions.epgm;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import java.util.HashMap;
+
+import org.gradoop.common.model.api.entities.EPGMEdge;
+import org.gradoop.common.model.api.entities.EPGMGraphHead;
+import org.gradoop.common.model.api.entities.EPGMVertex;
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.common.model.impl.pojo.EdgeFactory;
+import org.gradoop.common.model.impl.pojo.GraphHeadFactory;
+import org.gradoop.common.model.impl.pojo.VertexFactory;
+import org.gradoop.common.model.impl.properties.Properties;
+import org.gradoop.common.util.GradoopConstants;
+import org.gradoop.flink.model.GradoopFlinkTestBase;
+import org.gradoop.flink.model.api.functions.TransformationFunction;
+import org.hamcrest.core.Is;
+import org.junit.Test;
+
+public class RenamePropertyKeysTest extends GradoopFlinkTestBase {
+
+  @Test
+  public void testGraphHead() throws Exception {
+
+    GradoopId graphID = GradoopId.get();
+    Properties props = Properties.create();
+    props.set("k1", "v1");
+    props.set("k2", "v2");
+
+    EPGMGraphHead graphHead =
+        new GraphHeadFactory().initGraphHead(graphID, GradoopConstants.DEFAULT_GRAPH_LABEL, props);
+
+    HashMap<String, String> newProps = new HashMap<>();
+    newProps.put("k1", "new_k1");
+
+    TransformationFunction<EPGMGraphHead> renameFunction = new RenamePropertyKeys<>(newProps);
+
+    renameFunction.apply(graphHead, graphHead);
+
+    assertThat(graphHead.getPropertyCount(), is(2));
+    assertThat(graphHead.getPropertyValue("new_k1").toString(), Is.<Object>is("v1"));
+    assertThat(graphHead.getPropertyValue("k2").toString(), Is.<Object>is("v2"));
+    assertNull(graphHead.getPropertyValue("k1"));
+  }
+
+  @Test
+  public void testEdges() throws Exception {
+
+    GradoopId edgeId = GradoopId.get();
+    GradoopId sourceId = GradoopId.get();
+    GradoopId targetId = GradoopId.get();
+
+    Properties props = Properties.create();
+    props.set("k1", "v1");
+    props.set("k2", "v2");
+
+    EPGMEdge edge = 
+        new EdgeFactory().initEdge(edgeId, GradoopConstants.DEFAULT_GRAPH_LABEL, sourceId, targetId, props);
+
+    HashMap<String, String> newProps = new HashMap<>();
+    newProps.put("k1", "new_k1");
+
+    TransformationFunction<EPGMEdge> renameFunction = new RenamePropertyKeys<>(newProps);
+
+    renameFunction.apply(edge, edge);
+
+    assertThat(edge.getPropertyCount(), is(2));
+    assertThat(edge.getPropertyValue("new_k1").toString(), Is.<Object>is("v1"));
+    assertThat(edge.getPropertyValue("k2").toString(), Is.<Object>is("v2"));
+    assertNull(edge.getPropertyValue("k1"));
+  }
+
+  @Test
+  public void testVertex() throws Exception {
+
+    GradoopId vertexId = GradoopId.get();
+
+    Properties props = Properties.create();
+    props.set("k1", "v1");
+    props.set("k2", "v2");
+
+    EPGMVertex vertex =
+        new VertexFactory().initVertex(vertexId, GradoopConstants.DEFAULT_GRAPH_LABEL, props);
+
+    HashMap<String, String> newProps = new HashMap<>();
+    newProps.put("k1", "new_k1");
+
+    TransformationFunction<EPGMVertex> renameFunction = new RenamePropertyKeys<>(newProps);
+ 
+    renameFunction.apply(vertex, vertex);
+
+    assertThat(vertex.getPropertyCount(), is(2));
+    assertThat(vertex.getPropertyValue("new_k1").toString(), Is.<Object>is("v1"));
+    assertThat(vertex.getPropertyValue("k2").toString(), Is.<Object>is("v2"));
+    assertNull(vertex.getPropertyValue("k1"));
+  }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/RenamePropertyKeysTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/RenamePropertyKeysTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gradoop.flink.model.impl.functions.epgm;
 
 import static org.hamcrest.core.Is.is;


### PR DESCRIPTION
Test the functionality of `RenameLabel` and  `RenamePropertyKey` for GraphHeads, Edges and Vertex.

fixed #780