### PR TITLE
Fix JavaDoc of aggregation functions

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/functions/containment/HasEdgeLabel.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/functions/containment/HasEdgeLabel.java
@@ -20,7 +20,7 @@ import org.gradoop.common.model.impl.properties.PropertyValue;
 import org.gradoop.flink.model.api.functions.EdgeAggregateFunction;
 
 /**
- * aggregate and filter function to presence of an edge label in a graph.
+ * Aggregate and filter function to check presence of an edge label in a graph.
  *
  * Usage: First, aggregate and, second, filter using the same UDF instance.
  */

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/functions/containment/HasVertexLabel.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/functions/containment/HasVertexLabel.java
@@ -20,7 +20,7 @@ import org.gradoop.common.model.impl.properties.PropertyValue;
 import org.gradoop.flink.model.api.functions.VertexAggregateFunction;
 
 /**
- * aggregate and filter function to presence of a vertex label in a graph.
+ * Aggregate and filter function to check presence of a vertex label in a graph.
  *
  * Usage: First, aggregate and, second, filter using the same UDF instance.
  */

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/functions/max/MaxEdgeProperty.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/functions/max/MaxEdgeProperty.java
@@ -20,8 +20,8 @@ import org.gradoop.common.model.impl.properties.PropertyValue;
 import org.gradoop.flink.model.api.functions.EdgeAggregateFunction;
 
 /**
- * Aggregate function returning the minimum of a specified property over all
- * vertices.
+ * Aggregate function returning the maximum of a specified property over all
+ * edges.
  */
 public class MaxEdgeProperty extends MaxProperty implements EdgeAggregateFunction {
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/functions/max/MaxVertexProperty.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/functions/max/MaxVertexProperty.java
@@ -20,7 +20,7 @@ import org.gradoop.common.model.impl.properties.PropertyValue;
 import org.gradoop.flink.model.api.functions.VertexAggregateFunction;
 
 /**
- * Aggregate function returning the minimum of a specified property over all
+ * Aggregate function returning the maximum of a specified property over all
  * vertices.
  */
 public class MaxVertexProperty extends MaxProperty implements VertexAggregateFunction {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/functions/min/MinEdgeProperty.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/functions/min/MinEdgeProperty.java
@@ -21,7 +21,7 @@ import org.gradoop.flink.model.api.functions.EdgeAggregateFunction;
 
 /**
  * Aggregate function returning the minimum of a specified property over all
- * vertices.
+ * edges.
  */
 public class MinEdgeProperty extends MinProperty implements EdgeAggregateFunction {
 


### PR DESCRIPTION
Whilst working on the wiki page for the gradoop aggregate operator, i noticed some minor flaws in the code documentation.  
I propose this fixed version

* package: package org.gradoop.flink.model.impl.operators.aggregation.functions