### PR TITLE
[#677] added entity type to csv metadata

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVConstants.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVConstants.java
@@ -31,4 +31,12 @@ public class CSVConstants {
    * Used to separate lines in the output CSV files.
    */
   public static final String ROW_DELIMITER = System.getProperty("line.separator");
+  /**
+   * Used to specify labels in metadata (vertex or edge label)
+   */
+  public static final String VERTEX_PREFIX = "v_";
+  /**
+   * Used to specify labels in metadata (vertex or edge label)
+   */
+  public static final String EDGE_PREFIX = "e_";
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/CSVLineToEdge.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/CSVLineToEdge.java
@@ -18,6 +18,7 @@ package org.gradoop.flink.io.impl.csv.functions;
 import org.gradoop.common.model.api.entities.EPGMEdgeFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
 import org.gradoop.common.model.impl.pojo.Edge;
+import org.gradoop.flink.io.impl.csv.CSVConstants;
 import org.gradoop.flink.io.impl.csv.metadata.MetaData;
 
 /**
@@ -51,5 +52,10 @@ public class CSVLineToEdge extends CSVLineToElement<Edge> {
       GradoopId.fromString(tokens[1]),
       GradoopId.fromString(tokens[2]),
       parseProperties(tokens[3], tokens[4]));
+  }
+
+  @Override
+  String getPrefix() {
+    return CSVConstants.EDGE_PREFIX;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/CSVLineToElement.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/CSVLineToElement.java
@@ -55,6 +55,13 @@ abstract class CSVLineToElement<E extends Element> extends RichMapFunction<Strin
     this.properties = Properties.create();
   }
 
+  /**
+   * Returns prefix for labels used in metadata
+   *
+   * @return prefix of the given elements
+   */
+  abstract String getPrefix();
+
   @Override
   public void open(Configuration parameters) throws Exception {
     super.open(parameters);
@@ -72,7 +79,7 @@ abstract class CSVLineToElement<E extends Element> extends RichMapFunction<Strin
    */
   Properties parseProperties(String label, String propertyValueString) {
     String[] propertyValues = propertyValueString.split(valueDelimiter);
-    List<PropertyMetaData> metaDataList = metaData.getPropertyMetaData(label);
+    List<PropertyMetaData> metaDataList = metaData.getPropertyMetaData(getPrefix() + label);
     properties.clear();
     for (int i = 0; i < propertyValues.length; i++) {
       if (propertyValues[i].length() > 0) {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/CSVLineToVertex.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/CSVLineToVertex.java
@@ -18,6 +18,7 @@ package org.gradoop.flink.io.impl.csv.functions;
 import org.gradoop.common.model.api.entities.EPGMVertexFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
 import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.flink.io.impl.csv.CSVConstants;
 import org.gradoop.flink.io.impl.csv.metadata.MetaData;
 
 /**
@@ -51,5 +52,10 @@ public class CSVLineToVertex extends CSVLineToElement<Vertex> {
       GradoopId.fromString(tokens[0]),
       tokens[1],
       parseProperties(tokens[1], tokens[2]));
+  }
+
+  @Override
+  String getPrefix() {
+    return CSVConstants.VERTEX_PREFIX;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/EdgeToCSVEdge.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/EdgeToCSVEdge.java
@@ -17,6 +17,7 @@ package org.gradoop.flink.io.impl.csv.functions;
 
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.gradoop.common.model.impl.pojo.Edge;
+import org.gradoop.flink.io.impl.csv.CSVConstants;
 import org.gradoop.flink.io.impl.csv.tuples.CSVEdge;
 
 /**
@@ -41,5 +42,10 @@ public class EdgeToCSVEdge extends ElementToCSV<Edge, CSVEdge> {
     csvEdge.setLabel(edge.getLabel());
     csvEdge.setProperties(getPropertyString(edge));
     return csvEdge;
+  }
+
+  @Override
+  String getPrefix() {
+    return CSVConstants.EDGE_PREFIX;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/ElementToCSV.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/ElementToCSV.java
@@ -50,13 +50,20 @@ public abstract class ElementToCSV<E extends Element, T extends Tuple> extends R
   }
 
   /**
+   * Returns prefix for labels used in metadata
+   *
+   * @return prefix of the given elements
+   */
+  abstract String getPrefix();
+
+  /**
    * Returns the concatenated property values of the specified element according to the meta data.
    *
    * @param element EPGM element
    * @return property value string
    */
   String getPropertyString(E element) {
-    return metaData.getPropertyMetaData(element.getLabel()).stream()
+    return metaData.getPropertyMetaData(getPrefix() + element.getLabel()).stream()
       .map(metaData -> element.getPropertyValue(metaData.getKey()))
       .map(value -> value == null ? EMPTY_STRING : value.toString())
       .collect(Collectors.joining(CSVConstants.VALUE_DELIMITER));

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/ElementToPropertyMetaData.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/ElementToPropertyMetaData.java
@@ -18,8 +18,11 @@ package org.gradoop.flink.io.impl.csv.functions;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.Element;
+import org.gradoop.common.model.impl.pojo.Vertex;
 import org.gradoop.common.model.impl.properties.Property;
+import org.gradoop.flink.io.impl.csv.CSVConstants;
 import org.gradoop.flink.io.impl.csv.metadata.MetaDataParser;
 
 import java.util.HashSet;
@@ -46,7 +49,14 @@ public class ElementToPropertyMetaData<E extends Element> implements MapFunction
 
   @Override
   public Tuple2<String, Set<String>> map(E e) throws Exception {
-    reuseTuple.f0 = e.getLabel();
+    if (e.getClass() == Edge.class) {
+      reuseTuple.f0 = CSVConstants.EDGE_PREFIX + e.getLabel();
+    } else if (e.getClass() == Vertex.class) {
+      reuseTuple.f0 = CSVConstants.VERTEX_PREFIX + e.getLabel();
+    } else {
+      throw new Exception("Unsupported element class");
+    }
+
     reuseTuple.f1.clear();
     if (e.getProperties() != null) {
       for (Property property : e.getProperties()) {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/VertexToCSVVertex.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/VertexToCSVVertex.java
@@ -17,6 +17,7 @@ package org.gradoop.flink.io.impl.csv.functions;
 
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.flink.io.impl.csv.CSVConstants;
 import org.gradoop.flink.io.impl.csv.tuples.CSVVertex;
 
 /**
@@ -39,5 +40,10 @@ public class VertexToCSVVertex extends ElementToCSV<Vertex, CSVVertex> {
     csvVertex.setLabel(vertex.getLabel());
     csvVertex.setProperties(getPropertyString(vertex));
     return csvVertex;
+  }
+
+  @Override
+  String getPrefix() {
+    return CSVConstants.VERTEX_PREFIX;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/metadata/MetaData.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/metadata/MetaData.java
@@ -92,24 +92,26 @@ public class MetaData {
   }
 
   /**
-   * Returns the vertex labels available in the meta data.
+   * Returns the vertex labels available in the meta data. Only IndexedCSV.
    *
    * @return vertex labels
    */
   public Set<String> getVertexLabels() {
     return metaData.keySet().stream()
-      .filter(l -> Character.isUpperCase(l.charAt(0)))
+      .filter(l -> l.substring(0, 2).equals(CSVConstants.VERTEX_PREFIX))
+      .map(l -> l.substring(2, l.length()))
       .collect(Collectors.toSet());
   }
 
   /**
-   * Returns the edge labels available in the meta data.
+   * Returns the edge labels available in the meta data.Only IndexedCSV.
    *
    * @return edge labels
    */
   public Set<String> getEdgeLabels() {
     return metaData.keySet().stream()
-      .filter(l -> Character.isLowerCase(l.charAt(0)))
+      .filter(l -> l.substring(0, 2).equals(CSVConstants.EDGE_PREFIX))
+      .map(l -> l.substring(2, l.length()))
       .collect(Collectors.toSet());
   }
 

--- a/gradoop-flink/src/test/resources/data/csv/input/metadata.csv
+++ b/gradoop-flink/src/test/resources/data/csv/input/metadata.csv
@@ -1,4 +1,4 @@
-A;a:string,b:int,c:float
-B;a:long,b:boolean,c:double
-a;a:int,b:float
-b;a:long
+v_A;a:string,b:int,c:float
+v_B;a:long,b:boolean,c:double
+e_a;a:int,b:float
+e_b;a:long

--- a/gradoop-flink/src/test/resources/data/csv/input_extended_properties/metadata.csv
+++ b/gradoop-flink/src/test/resources/data/csv/input_extended_properties/metadata.csv
@@ -1,3 +1,3 @@
-User;key0:boolean,key1:int,key2:long,key3:float,key4:double,key5:string,key6:gradoopid,key7:localdate,key8:localtime,key9:localdatetime,keya:bigdecimal,keyb:map:string:double,keyc:list:string,keyd:list:int,keye:short
-Post;key0:boolean,key1:int,key2:long,key3:float,key4:double,key5:string,key6:gradoopid,key7:localdate,key8:localtime,key9:localdatetime,keya:bigdecimal,keyb:map:string:double,keyc:list:string,keyd:list:int,keye:short
-creatorOf;key0:boolean,key1:int,key2:long,key3:float,key4:double,key5:string,key6:gradoopid,key7:localdate,key8:localtime,key9:localdatetime,keya:bigdecimal,keyb:map:string:double,keyc:list:string,keyd:list:int,keye:short
+v_User;key0:boolean,key1:int,key2:long,key3:float,key4:double,key5:string,key6:gradoopid,key7:localdate,key8:localtime,key9:localdatetime,keya:bigdecimal,keyb:map:string:double,keyc:list:string,keyd:list:int,keye:short
+v_Post;key0:boolean,key1:int,key2:long,key3:float,key4:double,key5:string,key6:gradoopid,key7:localdate,key8:localtime,key9:localdatetime,keya:bigdecimal,keyb:map:string:double,keyc:list:string,keyd:list:int,keye:short
+e_creatorOf;key0:boolean,key1:int,key2:long,key3:float,key4:double,key5:string,key6:gradoopid,key7:localdate,key8:localtime,key9:localdatetime,keya:bigdecimal,keyb:map:string:double,keyc:list:string,keyd:list:int,keye:short

--- a/gradoop-flink/src/test/resources/data/csv/input_indexed/metadata.csv
+++ b/gradoop-flink/src/test/resources/data/csv/input_indexed/metadata.csv
@@ -1,4 +1,4 @@
-A;a:string,b:int,c:float
-B;a:long,b:boolean,c:double
-a;a:int,b:float
-b;a:long
+v_A;a:string,b:int,c:float
+v_B;a:long,b:boolean,c:double
+e_a;a:int,b:float
+e_b;a:long


### PR DESCRIPTION
Prefix are used to distinguish between vertex and edge files in csv metadata.
fixes, #677 