### PR TITLE
Add a subinterface of filter to make filters combinable.

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/bool/False.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/bool/False.java
@@ -15,14 +15,14 @@
  */
 package org.gradoop.flink.model.impl.functions.bool;
 
-import org.apache.flink.api.common.functions.FilterFunction;
+import org.gradoop.flink.model.impl.functions.epgm.filters.CombineableFilter;
 
 /**
  * Logical false as Flink function.
  *
  * @param <T> data set type
  */
-public class False<T> implements FilterFunction<T> {
+public class False<T> implements CombineableFilter<T> {
 
   @Override
   public boolean filter(T t) throws Exception {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/bool/True.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/bool/True.java
@@ -15,15 +15,15 @@
  */
 package org.gradoop.flink.model.impl.functions.bool;
 
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.functions.MapFunction;
+import org.gradoop.flink.model.impl.functions.epgm.filters.CombineableFilter;
 
 /**
  * Logical "TRUE" as Flink function.
  *
  * @param <T> input element type
  */
-public class True<T> implements MapFunction<T, Boolean>, FilterFunction<T> {
+public class True<T> implements MapFunction<T, Boolean>, CombineableFilter<T> {
 
   @Override
   public Boolean map(T t) throws Exception {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ByDifferentGraphId.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ByDifferentGraphId.java
@@ -15,16 +15,16 @@
  */
 package org.gradoop.flink.model.impl.functions.epgm;
 
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.flink.model.impl.functions.epgm.filters.CombineableFilter;
 import org.gradoop.flink.model.impl.layouts.transactional.tuples.GraphTransaction;
 
 /**
  * Filters graph transactions if their graph head identifier is not equal to the given identifier.
  */
 @FunctionAnnotation.ReadFields("f0")
-public class ByDifferentGraphId implements FilterFunction<GraphTransaction> {
+public class ByDifferentGraphId implements CombineableFilter<GraphTransaction> {
   /**
    * Graph head id
    */

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ByDifferentId.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ByDifferentId.java
@@ -15,10 +15,10 @@
  */
 package org.gradoop.flink.model.impl.functions.epgm;
 
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
-import org.gradoop.common.model.impl.pojo.Element;
 import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.common.model.impl.pojo.Element;
+import org.gradoop.flink.model.impl.functions.epgm.filters.CombineableFilter;
 
 /**
  * Filters elements if their identifier is not equal to the given identifier.
@@ -26,8 +26,7 @@ import org.gradoop.common.model.impl.id.GradoopId;
  * @param <EL> EPGM element type
  */
 @FunctionAnnotation.ReadFields("id")
-public class ByDifferentId<EL extends Element>
-  implements FilterFunction<EL> {
+public class ByDifferentId<EL extends Element> implements CombineableFilter<EL> {
 
   /**
    * id

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ByLabel.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ByLabel.java
@@ -15,15 +15,15 @@
  */
 package org.gradoop.flink.model.impl.functions.epgm;
 
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.gradoop.common.model.api.entities.EPGMLabeled;
+import org.gradoop.flink.model.impl.functions.epgm.filters.CombineableFilter;
 
 /**
  * Accepts all elements which have the same label as specified.
  *
  * @param <L> EPGM labeled type
  */
-public class ByLabel<L extends EPGMLabeled> implements FilterFunction<L> {
+public class ByLabel<L extends EPGMLabeled> implements CombineableFilter<L> {
   /**
    * Label to be filtered on.
    */

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ByProperty.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ByProperty.java
@@ -15,18 +15,17 @@
  */
 package org.gradoop.flink.model.impl.functions.epgm;
 
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.gradoop.common.model.api.entities.EPGMElement;
 import org.gradoop.common.model.impl.properties.Property;
 import org.gradoop.common.model.impl.properties.PropertyValue;
+import org.gradoop.flink.model.impl.functions.epgm.filters.CombineableFilter;
 
 /**
  * Accepts all elements which have a property with the specified key or key value combination.
  *
  * @param <E> EPGM element
  */
-public class ByProperty<E extends EPGMElement>
-  implements FilterFunction<E> {
+public class ByProperty<E extends EPGMElement> implements CombineableFilter<E> {
   /**
    * PropertyKey to be filtered on.
    */

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/BySameId.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/BySameId.java
@@ -15,10 +15,10 @@
  */
 package org.gradoop.flink.model.impl.functions.epgm;
 
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
-import org.gradoop.common.model.impl.pojo.Element;
 import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.common.model.impl.pojo.Element;
+import org.gradoop.flink.model.impl.functions.epgm.filters.CombineableFilter;
 
 /**
  * Filters elements if their identifier is equal to the given identifier.
@@ -26,7 +26,7 @@ import org.gradoop.common.model.impl.id.GradoopId;
  * @param <EL> EPGM element type
  */
 @FunctionAnnotation.ReadFields("id")
-public class BySameId<EL extends Element> implements FilterFunction<EL> {
+public class BySameId<EL extends Element> implements CombineableFilter<EL> {
 
   /**
    * id

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/BySourceId.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/BySourceId.java
@@ -15,16 +15,16 @@
  */
 package org.gradoop.flink.model.impl.functions.epgm;
 
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.gradoop.common.model.impl.id.GradoopId;
 import org.gradoop.common.model.impl.pojo.Edge;
+import org.gradoop.flink.model.impl.functions.epgm.filters.CombineableFilter;
 
 /**
  * Filters edges having the specified source vertex id.
  *
  * @param <E> EPGM edge type
  */
-public class BySourceId<E extends Edge> implements FilterFunction<E> {
+public class BySourceId<E extends Edge> implements CombineableFilter<E> {
   /**
    * Vertex id to filter on
    */

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ByTargetId.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/ByTargetId.java
@@ -15,16 +15,16 @@
  */
 package org.gradoop.flink.model.impl.functions.epgm;
 
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.gradoop.common.model.impl.id.GradoopId;
 import org.gradoop.common.model.impl.pojo.Edge;
+import org.gradoop.flink.model.impl.functions.epgm.filters.CombineableFilter;
 
 /**
  * Filters edges having the specified target vertex id.
  *
  * @param <E> EPGM edge type
  */
-public class ByTargetId<E extends Edge> implements FilterFunction<E> {
+public class ByTargetId<E extends Edge> implements CombineableFilter<E> {
   /**
    * Vertex id to filter on
    */

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdInBroadcast.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdInBroadcast.java
@@ -19,13 +19,15 @@ import org.apache.flink.api.common.functions.RichFilterFunction;
 import org.apache.flink.configuration.Configuration;
 import org.gradoop.common.model.api.entities.EPGMElement;
 import org.gradoop.common.model.impl.id.GradoopIdSet;
+import org.gradoop.flink.model.impl.functions.epgm.filters.CombineableFilter;
 
 /**
  * Filters a dataset of EPGM elements to those whose id is contained in an id dataset.
  *
  * @param <EL> element type
  */
-public class IdInBroadcast<EL extends EPGMElement> extends RichFilterFunction<EL> {
+public class IdInBroadcast<EL extends EPGMElement> extends RichFilterFunction<EL>
+  implements CombineableFilter<EL> {
 
   /**
    * broadcast id set name

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdNotInBroadcast.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/IdNotInBroadcast.java
@@ -19,13 +19,15 @@ import org.apache.flink.api.common.functions.RichFilterFunction;
 import org.apache.flink.configuration.Configuration;
 import org.gradoop.common.model.api.entities.EPGMElement;
 import org.gradoop.common.model.impl.id.GradoopIdSet;
+import org.gradoop.flink.model.impl.functions.epgm.filters.CombineableFilter;
 
 /**
  * Filters a dataset of EPGM elements to those whose id is not contained in an id dataset.
  *
  * @param <EL> element type
  */
-public class IdNotInBroadcast<EL extends EPGMElement> extends RichFilterFunction<EL> {
+public class IdNotInBroadcast<EL extends EPGMElement> extends RichFilterFunction<EL>
+  implements CombineableFilter<EL> {
 
   /**
    * broadcast id set name

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/AbstractRichCombinedFilterFunction.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/AbstractRichCombinedFilterFunction.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gradoop.flink.model.impl.functions.epgm.filters;
 
 import org.apache.flink.api.common.functions.FilterFunction;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/AbstractRichCombinedFilterFunction.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/AbstractRichCombinedFilterFunction.java
@@ -16,55 +16,55 @@ import java.util.Objects;
  * @param <T> The type of elements to filter.
  */
 public abstract class AbstractRichCombinedFilterFunction<T>
-        extends RichFilterFunction<T> implements CombineableFilter<T> {
+  extends RichFilterFunction<T> implements CombineableFilter<T> {
 
-    /**
-     * The filters this filter is composed of.
-     */
-    protected final FilterFunction<? super T>[] components;
+  /**
+   * The filters this filter is composed of.
+   */
+  protected final FilterFunction<? super T>[] components;
 
-    /**
-     * Constructor setting the component filter functions that this filter is
-     * composed of.
-     *
-     * @param filters The filters.
-     */
-    @SafeVarargs
-    public AbstractRichCombinedFilterFunction(
-            FilterFunction<? super T>... filters) {
-        for (FilterFunction<? super T> filter : filters) {
-            Objects.requireNonNull(filter);
-        }
-        components = filters;
+  /**
+   * Constructor setting the component filter functions that this filter is
+   * composed of.
+   *
+   * @param filters The filters.
+   */
+  @SafeVarargs
+  public AbstractRichCombinedFilterFunction(
+  FilterFunction<? super T>... filters) {
+    for (FilterFunction<? super T> filter : filters) {
+      Objects.requireNonNull(filter);
     }
+    components = filters;
+  }
 
-    @Override
-    public void setRuntimeContext(RuntimeContext t) {
-        super.setRuntimeContext(t);
-        for (FilterFunction<? super T> component : components) {
-            if (component instanceof RichFunction) {
-                ((RichFunction) component).setRuntimeContext(t);
-            }
-        }
+  @Override
+  public void setRuntimeContext(RuntimeContext t) {
+    super.setRuntimeContext(t);
+    for (FilterFunction<? super T> component : components) {
+      if (component instanceof RichFunction) {
+        ((RichFunction) component).setRuntimeContext(t);
+      }
     }
+  }
 
-    @Override
-    public void open(Configuration parameters) throws Exception {
-        super.open(parameters);
-        for (FilterFunction<? super T> component : components) {
-            if (component instanceof RichFunction) {
-                ((RichFunction) component).open(parameters);
-            }
-        }
+  @Override
+  public void open(Configuration parameters) throws Exception {
+    super.open(parameters);
+    for (FilterFunction<? super T> component : components) {
+      if (component instanceof RichFunction) {
+        ((RichFunction) component).open(parameters);
+      }
     }
+  }
 
-    @Override
-    public void close() throws Exception {
-        super.close();
-        for (FilterFunction<? super T> component : components) {
-            if (component instanceof RichFunction) {
-                ((RichFunction) component).close();
-            }
-        }
+  @Override
+  public void close() throws Exception {
+    super.close();
+    for (FilterFunction<? super T> component : components) {
+      if (component instanceof RichFunction) {
+        ((RichFunction) component).close();
+      }
     }
+  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/AbstractRichCombinedFilterFunction.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/AbstractRichCombinedFilterFunction.java
@@ -1,0 +1,70 @@
+package org.gradoop.flink.model.impl.functions.epgm.filters;
+
+import org.apache.flink.api.common.functions.FilterFunction;
+import org.apache.flink.api.common.functions.RichFilterFunction;
+import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.configuration.Configuration;
+
+import java.util.Objects;
+
+/**
+ * A {@link RichFilterFunction} that can be combined like a
+ * {@link CombineableFilter}. The {@link RuntimeContext context} will be
+ * handled for each filter that is part of this combined filter.
+ *
+ * @param <T> The type of elements to filter.
+ */
+public abstract class AbstractRichCombinedFilterFunction<T>
+        extends RichFilterFunction<T> implements CombineableFilter<T> {
+
+    /**
+     * The filters this filter is composed of.
+     */
+    protected final FilterFunction<? super T>[] components;
+
+    /**
+     * Constructor setting the component filter functions that this filter is
+     * composed of.
+     *
+     * @param filters The filters.
+     */
+    @SafeVarargs
+    public AbstractRichCombinedFilterFunction(
+            FilterFunction<? super T>... filters) {
+        for (FilterFunction<? super T> filter : filters) {
+            Objects.requireNonNull(filter);
+        }
+        components = filters;
+    }
+
+    @Override
+    public void setRuntimeContext(RuntimeContext t) {
+        super.setRuntimeContext(t);
+        for (FilterFunction<? super T> component : components) {
+            if (component instanceof RichFunction) {
+                ((RichFunction) component).setRuntimeContext(t);
+            }
+        }
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        for (FilterFunction<? super T> component : components) {
+            if (component instanceof RichFunction) {
+                ((RichFunction) component).open(parameters);
+            }
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        for (FilterFunction<? super T> component : components) {
+            if (component instanceof RichFunction) {
+                ((RichFunction) component).close();
+            }
+        }
+    }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/And.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/And.java
@@ -1,0 +1,33 @@
+package org.gradoop.flink.model.impl.functions.epgm.filters;
+
+import org.apache.flink.api.common.functions.FilterFunction;
+
+/**
+ * A filter that combines multiple filters using a logical {@code and}.
+ * This filter will therefore accept all objects that are accepted by
+ * every component filter.
+ *
+ * @param <T> The type of objects to filter.
+ */
+public class And<T> extends AbstractRichCombinedFilterFunction<T> {
+
+    /**
+     * Constructor setting the filter to be combined with a logical {@code and}.
+     *
+     * @param filters The filters.
+     */
+    @SafeVarargs
+    public And(FilterFunction<? super T>... filters) {
+        super(filters);
+    }
+
+    @Override
+    public boolean filter(T value) throws Exception {
+        for (FilterFunction<? super T> componentFilter : components) {
+            if (!componentFilter.filter(value)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/And.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/And.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gradoop.flink.model.impl.functions.epgm.filters;
 
 import org.apache.flink.api.common.functions.FilterFunction;
@@ -11,23 +26,23 @@ import org.apache.flink.api.common.functions.FilterFunction;
  */
 public class And<T> extends AbstractRichCombinedFilterFunction<T> {
 
-    /**
-     * Constructor setting the filter to be combined with a logical {@code and}.
-     *
-     * @param filters The filters.
-     */
-    @SafeVarargs
-    public And(FilterFunction<? super T>... filters) {
-        super(filters);
-    }
+  /**
+   * Constructor setting the filter to be combined with a logical {@code and}.
+   *
+   * @param filters The filters.
+   */
+  @SafeVarargs
+  public And(FilterFunction<? super T>... filters) {
+    super(filters);
+  }
 
-    @Override
-    public boolean filter(T value) throws Exception {
-        for (FilterFunction<? super T> componentFilter : components) {
-            if (!componentFilter.filter(value)) {
-                return false;
-            }
-        }
-        return true;
+  @Override
+  public boolean filter(T value) throws Exception {
+    for (FilterFunction<? super T> componentFilter : components) {
+      if (!componentFilter.filter(value)) {
+        return false;
+      }
     }
+    return true;
+  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/CombineableFilter.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/CombineableFilter.java
@@ -1,0 +1,47 @@
+package org.gradoop.flink.model.impl.functions.epgm.filters;
+
+import org.apache.flink.api.common.functions.FilterFunction;
+
+/**
+ * A filter function that can be combined using a logical {@code and},
+ * {@code or} and {@code not}.
+ *
+ * @param <T> The type of elements to filter.
+ */
+public interface CombineableFilter<T> extends FilterFunction<T> {
+
+    /**
+     * Combine this filter with another filter using a logical {@code and}.
+     * Either filter may be a
+     * {@link org.apache.flink.api.common.functions.RichFunction}.
+     *
+     * @param other The filter that will be combined with this filter.
+     * @return The combined filter.
+     */
+    default CombineableFilter<T> and(FilterFunction<? super T> other) {
+        return new And<>(this, other);
+    }
+
+    /**
+     * Combine this filter with another filter using a logical {@code or}.
+     * Either filter may be a
+     * {@link org.apache.flink.api.common.functions.RichFunction}.
+     *
+     * @param other The filter that will be combined with this filter.
+     * @return The combined filter.
+     */
+    default CombineableFilter<T> or(FilterFunction<? super T> other) {
+        return new Or<>(this, other);
+    }
+
+    /**
+     * Invert this filter, i.e. get the logical {@code not} of this filter.
+     * This filter may be a
+     * {@link org.apache.flink.api.common.functions.RichFunction}.
+     *
+     * @return The inverted filter.
+     */
+    default CombineableFilter<T> negate() {
+        return new Not<>(this);
+    }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/CombineableFilter.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/CombineableFilter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gradoop.flink.model.impl.functions.epgm.filters;
 
 import org.apache.flink.api.common.functions.FilterFunction;
@@ -10,38 +25,38 @@ import org.apache.flink.api.common.functions.FilterFunction;
  */
 public interface CombineableFilter<T> extends FilterFunction<T> {
 
-    /**
-     * Combine this filter with another filter using a logical {@code and}.
-     * Either filter may be a
-     * {@link org.apache.flink.api.common.functions.RichFunction}.
-     *
-     * @param other The filter that will be combined with this filter.
-     * @return The combined filter.
-     */
-    default CombineableFilter<T> and(FilterFunction<? super T> other) {
-        return new And<>(this, other);
-    }
+  /**
+   * Combine this filter with another filter using a logical {@code and}.
+   * Either filter may be a
+   * {@link org.apache.flink.api.common.functions.RichFunction}.
+   *
+   * @param other The filter that will be combined with this filter.
+   * @return The combined filter.
+   */
+  default CombineableFilter<T> and(FilterFunction<? super T> other) {
+    return new And<>(this, other);
+  }
 
-    /**
-     * Combine this filter with another filter using a logical {@code or}.
-     * Either filter may be a
-     * {@link org.apache.flink.api.common.functions.RichFunction}.
-     *
-     * @param other The filter that will be combined with this filter.
-     * @return The combined filter.
-     */
-    default CombineableFilter<T> or(FilterFunction<? super T> other) {
-        return new Or<>(this, other);
-    }
+  /**
+   * Combine this filter with another filter using a logical {@code or}.
+   * Either filter may be a
+   * {@link org.apache.flink.api.common.functions.RichFunction}.
+   *
+   * @param other The filter that will be combined with this filter.
+   * @return The combined filter.
+   */
+  default CombineableFilter<T> or(FilterFunction<? super T> other) {
+    return new Or<>(this, other);
+  }
 
-    /**
-     * Invert this filter, i.e. get the logical {@code not} of this filter.
-     * This filter may be a
-     * {@link org.apache.flink.api.common.functions.RichFunction}.
-     *
-     * @return The inverted filter.
-     */
-    default CombineableFilter<T> negate() {
-        return new Not<>(this);
-    }
+  /**
+   * Invert this filter, i.e. get the logical {@code not} of this filter.
+   * This filter may be a
+   * {@link org.apache.flink.api.common.functions.RichFunction}.
+   *
+   * @return The inverted filter.
+   */
+  default CombineableFilter<T> negate() {
+    return new Not<>(this);
+  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/Not.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/Not.java
@@ -1,0 +1,27 @@
+package org.gradoop.flink.model.impl.functions.epgm.filters;
+
+import org.apache.flink.api.common.functions.FilterFunction;
+
+/**
+ * A filter that inverts a filter by using a logical {@code not}.
+ * This filter will therefore accept all objects that are not accepted by
+ * the original filter.
+ *
+ * @param <T> The type of objects to filter.
+ */
+public class Not<T> extends AbstractRichCombinedFilterFunction<T> {
+
+    /**
+     * Constructor setting the filter to invert using a logical {@code not}.
+     *
+     * @param filter The filter.
+     */
+    public Not(FilterFunction<? super T> filter) {
+        super(filter);
+    }
+
+    @Override
+    public boolean filter(T value) throws Exception {
+        return !components[0].filter(value);
+    }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/Not.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/Not.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gradoop.flink.model.impl.functions.epgm.filters;
 
 import org.apache.flink.api.common.functions.FilterFunction;
@@ -11,17 +26,17 @@ import org.apache.flink.api.common.functions.FilterFunction;
  */
 public class Not<T> extends AbstractRichCombinedFilterFunction<T> {
 
-    /**
-     * Constructor setting the filter to invert using a logical {@code not}.
-     *
-     * @param filter The filter.
-     */
-    public Not(FilterFunction<? super T> filter) {
-        super(filter);
-    }
+  /**
+   * Constructor setting the filter to invert using a logical {@code not}.
+   *
+   * @param filter The filter.
+   */
+  public Not(FilterFunction<? super T> filter) {
+    super(filter);
+  }
 
-    @Override
-    public boolean filter(T value) throws Exception {
-        return !components[0].filter(value);
-    }
+  @Override
+  public boolean filter(T value) throws Exception {
+    return !components[0].filter(value);
+  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/Or.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/Or.java
@@ -1,5 +1,19 @@
+/**
+ * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gradoop.flink.model.impl.functions.epgm.filters;
-
 
 import org.apache.flink.api.common.functions.FilterFunction;
 
@@ -12,23 +26,23 @@ import org.apache.flink.api.common.functions.FilterFunction;
  */
 public class Or<T> extends AbstractRichCombinedFilterFunction<T> {
 
-    /**
-     * Constructor setting the filter to be combined with a logical {@code or}.
-     *
-     * @param filters The filters.
-     */
-    @SafeVarargs
-    public Or(FilterFunction<? super T>... filters) {
-        super(filters);
-    }
+  /**
+   * Constructor setting the filter to be combined with a logical {@code or}.
+   *
+   * @param filters The filters.
+   */
+  @SafeVarargs
+  public Or(FilterFunction<? super T>... filters) {
+    super(filters);
+  }
 
-    @Override
-    public boolean filter(T value) throws Exception {
-        for (FilterFunction<? super T> componentFilter : components) {
-            if (componentFilter.filter(value)) {
-                return true;
-            }
-        }
-        return false;
+  @Override
+  public boolean filter(T value) throws Exception {
+    for (FilterFunction<? super T> componentFilter : components) {
+      if (componentFilter.filter(value)) {
+        return true;
+      }
     }
+    return false;
+  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/Or.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/Or.java
@@ -1,0 +1,34 @@
+package org.gradoop.flink.model.impl.functions.epgm.filters;
+
+
+import org.apache.flink.api.common.functions.FilterFunction;
+
+/**
+ * A filter that combines multiple filters using a logical {@code or}.
+ * This filter will therefore accept all objects that are accepted by
+ * any component filter.
+ *
+ * @param <T> The type of objects to filter.
+ */
+public class Or<T> extends AbstractRichCombinedFilterFunction<T> {
+
+    /**
+     * Constructor setting the filter to be combined with a logical {@code or}.
+     *
+     * @param filters The filters.
+     */
+    @SafeVarargs
+    public Or(FilterFunction<? super T>... filters) {
+        super(filters);
+    }
+
+    @Override
+    public boolean filter(T value) throws Exception {
+        for (FilterFunction<? super T> componentFilter : components) {
+            if (componentFilter.filter(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/package-info.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/epgm/filters/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Contains common filter functions and wrappers combining multiple filters.
+ */
+package org.gradoop.flink.model.impl.functions.epgm.filters;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/InAllGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/InAllGraphs.java
@@ -15,10 +15,10 @@
  */
 package org.gradoop.flink.model.impl.functions.graphcontainment;
 
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
-import org.gradoop.common.model.impl.pojo.GraphElement;
 import org.gradoop.common.model.impl.id.GradoopIdSet;
+import org.gradoop.common.model.impl.pojo.GraphElement;
+import org.gradoop.flink.model.impl.functions.epgm.filters.CombineableFilter;
 
 /**
  * True, if an element is contained in all of a set of given graphs.
@@ -26,8 +26,7 @@ import org.gradoop.common.model.impl.id.GradoopIdSet;
  * @param <GE> element type
  */
 @FunctionAnnotation.ReadFields("graphIds")
-public class InAllGraphs<GE extends GraphElement>
-  implements FilterFunction<GE> {
+public class InAllGraphs<GE extends GraphElement> implements CombineableFilter<GE> {
 
   /**
    * graph ids

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/InAnyGraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/InAnyGraph.java
@@ -15,10 +15,10 @@
  */
 package org.gradoop.flink.model.impl.functions.graphcontainment;
 
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
-import org.gradoop.common.model.impl.pojo.GraphElement;
 import org.gradoop.common.model.impl.id.GradoopIdSet;
+import org.gradoop.common.model.impl.pojo.GraphElement;
+import org.gradoop.flink.model.impl.functions.epgm.filters.CombineableFilter;
 
 /**
  * True, if an element is contained in any of a set of given graphs.
@@ -26,8 +26,7 @@ import org.gradoop.common.model.impl.id.GradoopIdSet;
  * @param <GE> element type
  */
 @FunctionAnnotation.ReadFields("graphIds")
-public class InAnyGraph<GE extends GraphElement>
-  implements FilterFunction<GE> {
+public class InAnyGraph<GE extends GraphElement> implements CombineableFilter<GE> {
 
   /**
    * graph ids

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/InGraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/InGraph.java
@@ -15,10 +15,10 @@
  */
 package org.gradoop.flink.model.impl.functions.graphcontainment;
 
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
-import org.gradoop.common.model.impl.pojo.GraphElement;
 import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.common.model.impl.pojo.GraphElement;
+import org.gradoop.flink.model.impl.functions.epgm.filters.CombineableFilter;
 
 /**
  * True, if an element is contained in a give graph.
@@ -26,8 +26,7 @@ import org.gradoop.common.model.impl.id.GradoopId;
  * @param <EL> element type
  */
 @FunctionAnnotation.ReadFields("graphIds")
-public class InGraph<EL extends GraphElement>
-  implements FilterFunction<EL> {
+public class InGraph<EL extends GraphElement> implements CombineableFilter<EL> {
 
   /**
    * graph id

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/InNoGraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/graphcontainment/InNoGraph.java
@@ -15,15 +15,15 @@
  */
 package org.gradoop.flink.model.impl.functions.graphcontainment;
 
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.gradoop.common.model.api.entities.EPGMGraphElement;
+import org.gradoop.flink.model.impl.functions.epgm.filters.CombineableFilter;
 
 /**
  * True, if the element has not graph ids.
  *
  * @param <EL> epgm graph element
  */
-public class InNoGraph<EL extends EPGMGraphElement> implements FilterFunction<EL> {
+public class InNoGraph<EL extends EPGMGraphElement> implements CombineableFilter<EL> {
 
   @Override
   public boolean filter(EL value) throws Exception {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/utils/IsInstance.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/functions/utils/IsInstance.java
@@ -15,7 +15,7 @@
  */
 package org.gradoop.flink.model.impl.functions.utils;
 
-import org.apache.flink.api.common.functions.FilterFunction;
+import org.gradoop.flink.model.impl.functions.epgm.filters.CombineableFilter;
 
 /**
  * Checks if a given object of type {@link IN} is instance of a specific class
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.functions.FilterFunction;
  * @param <IN>  input type
  * @param <T>   class type to check
  */
-public class IsInstance<IN, T> implements FilterFunction<IN> {
+public class IsInstance<IN, T> implements CombineableFilter<IN> {
   /**
    * Class for isInstance check
    */

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/functions/VertexRandomFilter.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/functions/VertexRandomFilter.java
@@ -15,8 +15,8 @@
  */
 package org.gradoop.flink.model.impl.operators.sampling.functions;
 
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.flink.model.impl.functions.epgm.filters.CombineableFilter;
 
 import java.util.Random;
 
@@ -27,7 +27,7 @@ import java.util.Random;
  * @param <V> EPGM vertex type
  */
 public class VertexRandomFilter<V extends Vertex>
-  implements FilterFunction<V> {
+  implements CombineableFilter<V> {
   /**
    * Threshold to decide if a vertex needs to be filtered.
    */

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/LabelIsIn.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/functions/LabelIsIn.java
@@ -16,8 +16,8 @@
 package org.gradoop.flink.model.impl.operators.subgraph.functions;
 
 import com.google.common.collect.Sets;
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.gradoop.common.model.impl.pojo.Element;
+import org.gradoop.flink.model.impl.functions.epgm.filters.CombineableFilter;
 
 import java.util.Collection;
 
@@ -26,7 +26,7 @@ import java.util.Collection;
  *
  * @param <EL> element type
  */
-public class LabelIsIn<EL extends Element> implements FilterFunction<EL> {
+public class LabelIsIn<EL extends Element> implements CombineableFilter<EL> {
 
   /**
    * White list of labels.

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/filters/AbstractRichCombinedFilterFunctionTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/filters/AbstractRichCombinedFilterFunctionTest.java
@@ -1,0 +1,98 @@
+package org.gradoop.flink.model.impl.functions.epgm.filters;
+
+import org.apache.flink.api.common.functions.RichFilterFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
+import org.apache.flink.configuration.Configuration;
+import org.gradoop.common.model.impl.id.GradoopIdSet;
+import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.pojo.VertexFactory;
+import org.gradoop.flink.model.GradoopFlinkTestBase;
+import org.gradoop.flink.model.impl.functions.epgm.IdInBroadcast;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class AbstractRichCombinedFilterFunctionTest
+        extends GradoopFlinkTestBase {
+
+    /**
+     * A test {@link RichFilterFunction} providing a method to check if
+     * {@link RichFilterFunction#open(Configuration)} and
+     * {@link RichFilterFunction#close()} were called.
+     */
+    private static class TestRichCombinableFilter
+            extends RichFilterFunction<Integer> {
+        private boolean wasOpenCalled = false;
+        private boolean wasCloseCalled = false;
+
+        @Override
+        public void open(Configuration parameters) throws Exception {
+            assertNotNull("Parameters not set", parameters);
+            assertNotNull("RuntimeContext not set", getRuntimeContext());
+            wasOpenCalled = true;
+        }
+
+        @Override
+        public void close() throws Exception {
+            super.close();
+            wasCloseCalled = true;
+        }
+
+        @Override
+        public boolean filter(Integer value) throws Exception {
+            if (wasOpenCalled) {
+                //
+            }
+            if (wasCloseCalled) {
+                //
+            }
+            assertNotNull("Context not set.", getRuntimeContext());
+            return true;
+        }
+
+        public void validate() {
+            assertTrue("open(Configuration) was not called", wasOpenCalled);
+            assertTrue("close() was not called", wasCloseCalled);
+        }
+    }
+
+    @Test
+    public void testIfContextIsSet() throws Exception {
+        DataSet<Integer> elements =
+                getExecutionEnvironment().fromElements(1, 2, 3, 4, 5);
+        TestRichCombinableFilter filter1 = new TestRichCombinableFilter();
+        TestRichCombinableFilter filter2 = new TestRichCombinableFilter();
+        Collection<Integer> collection = new ArrayList<>();
+        elements.filter(new And<Integer>(filter1, filter2))
+                .output(new LocalCollectionOutputFormat<>(collection));
+        getExecutionEnvironment().execute();
+        filter1.validate();
+        filter2.validate();
+    }
+
+    @Test
+    public void testAnd() throws Exception {
+        VertexFactory factory = getConfig().getVertexFactory();
+        Vertex vertex1 = factory.createVertex();
+        Vertex vertex2 = factory.createVertex();
+        GradoopIdSet both = GradoopIdSet.fromExisting(vertex1.getId(),
+                vertex2.getId());
+        List<Vertex> collect = Stream.generate(factory::createVertex).limit(100)
+                .collect(Collectors.toCollection(ArrayList::new));
+        collect.add(vertex1);
+        collect.add(vertex2);
+        getExecutionEnvironment().fromCollection(collect)
+                .filter(new And<>(new IdInBroadcast<>(), new IdInBroadcast<>()))
+                .withBroadcastSet(getExecutionEnvironment()
+                        .fromElements(vertex1.getId(), vertex2.getId()),
+                        IdInBroadcast.IDS).print();
+    }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/filters/AbstractRichCombinedFilterFunctionTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/filters/AbstractRichCombinedFilterFunctionTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gradoop.flink.model.impl.functions.epgm.filters;
 
 import org.apache.flink.api.common.functions.RichFilterFunction;

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/filters/CombineableFilterTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/filters/CombineableFilterTest.java
@@ -1,0 +1,37 @@
+package org.gradoop.flink.model.impl.functions.epgm.filters;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CombineableFilterTest {
+
+    private CombineableFilter<Object> alwaysTrue = e -> true;
+
+    private CombineableFilter<Object> alwaysFalse = e -> false;
+
+    private Object testObject = new Object();
+
+    @Test
+    public void testAnd() throws Exception {
+        assertTrue(alwaysTrue.and(alwaysTrue).filter(testObject));
+        assertFalse(alwaysFalse.and(alwaysTrue).filter(testObject));
+        assertFalse(alwaysTrue.and(alwaysFalse).filter(testObject));
+        assertFalse(alwaysFalse.and(alwaysFalse).filter(testObject));
+    }
+
+    @Test
+    public void testOr() throws Exception {
+        assertTrue(alwaysTrue.or(alwaysTrue).filter(testObject));
+        assertTrue(alwaysFalse.or(alwaysTrue).filter(testObject));
+        assertTrue(alwaysTrue.or(alwaysFalse).filter(testObject));
+        assertFalse(alwaysFalse.or(alwaysFalse).filter(testObject));
+    }
+
+    @Test
+    public void testNegate() throws Exception {
+        assertTrue(alwaysFalse.negate().filter(testObject));
+        assertFalse(alwaysTrue.negate().filter(testObject));
+    }
+
+}


### PR DESCRIPTION
* Add the `CombinableFilter` interface that provides methods similar to `java.util.function.Predicate`
* Add filters that combine multiple other filters using basic logical operators
* Simple tests

fixes #808 