### PR TITLE
[#865] Better handling of PropertyValues with non uniform types in CSVDataSink

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/ElementToCSV.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/ElementToCSV.java
@@ -27,8 +27,6 @@ import org.gradoop.flink.io.impl.csv.metadata.MetaDataParser;
 
 import java.util.stream.Collectors;
 
-import static org.gradoop.flink.io.impl.csv.metadata.MetaDataParser.getTypeString;
-
 /**
  * Base class to convert an EPGM element into a CSV representation.
  *
@@ -63,8 +61,9 @@ public abstract class ElementToCSV<E extends Element, T extends Tuple>
     return metaData.getPropertyMetaData(element.getLabel()).stream()
       .map(propertyMetaData -> {
           PropertyValue p = element.getPropertyValue(propertyMetaData.getKey());
-          return (p == null || !getTypeString(p).equals(propertyMetaData.getTypeString())) ?
-            EMPTY_STRING : p.toString();
+          return (p == null ||
+            !MetaDataParser.getTypeString(p).equals(propertyMetaData.getTypeString())) ?
+              EMPTY_STRING : p.toString();
         })
       .collect(Collectors.joining(CSVConstants.VALUE_DELIMITER));
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/ElementToCSV.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/ElementToCSV.java
@@ -74,7 +74,8 @@ public abstract class ElementToCSV<E extends Element, T extends Tuple>
    */
   private String getPropertyValueString(PropertyMetaData propertyMetaData, E element) {
     PropertyValue p = element.getPropertyValue(propertyMetaData.getKey());
-    // Only properties with matching type get returned to prevent writing values with the wrong type metadata
+    // Only properties with matching type get returned
+    // to prevent writing values with the wrong type metadata
     if (p != null && MetaDataParser.getTypeString(p).equals(propertyMetaData.getTypeString())) {
       return p.toString();
     }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/ElementToCSV.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/ElementToCSV.java
@@ -19,12 +19,15 @@ import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.configuration.Configuration;
 import org.gradoop.common.model.impl.pojo.Element;
+import org.gradoop.common.model.impl.properties.PropertyValue;
 import org.gradoop.flink.io.impl.csv.CSVConstants;
 import org.gradoop.flink.io.impl.csv.CSVDataSource;
 import org.gradoop.flink.io.impl.csv.metadata.MetaData;
 import org.gradoop.flink.io.impl.csv.metadata.MetaDataParser;
 
 import java.util.stream.Collectors;
+
+import static org.gradoop.flink.io.impl.csv.metadata.MetaDataParser.getTypeString;
 
 /**
  * Base class to convert an EPGM element into a CSV representation.
@@ -58,8 +61,11 @@ public abstract class ElementToCSV<E extends Element, T extends Tuple>
    */
   String getPropertyString(E element) {
     return metaData.getPropertyMetaData(element.getLabel()).stream()
-      .map(metaData -> element.getPropertyValue(metaData.getKey()))
-      .map(value -> value == null ? EMPTY_STRING : value.toString())
+      .map(propertyMetaData -> {
+          PropertyValue p = element.getPropertyValue(propertyMetaData.getKey());
+          return (p == null || !getTypeString(p).equals(propertyMetaData.getTypeString())) ?
+            EMPTY_STRING : p.toString();
+        })
       .collect(Collectors.joining(CSVConstants.VALUE_DELIMITER));
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/ElementToCSV.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/functions/ElementToCSV.java
@@ -24,6 +24,7 @@ import org.gradoop.flink.io.impl.csv.CSVConstants;
 import org.gradoop.flink.io.impl.csv.CSVDataSource;
 import org.gradoop.flink.io.impl.csv.metadata.MetaData;
 import org.gradoop.flink.io.impl.csv.metadata.MetaDataParser;
+import org.gradoop.flink.io.impl.csv.metadata.PropertyMetaData;
 
 import java.util.stream.Collectors;
 
@@ -59,12 +60,24 @@ public abstract class ElementToCSV<E extends Element, T extends Tuple>
    */
   String getPropertyString(E element) {
     return metaData.getPropertyMetaData(element.getLabel()).stream()
-      .map(propertyMetaData -> {
-          PropertyValue p = element.getPropertyValue(propertyMetaData.getKey());
-          return (p == null ||
-            !MetaDataParser.getTypeString(p).equals(propertyMetaData.getTypeString())) ?
-              EMPTY_STRING : p.toString();
-        })
+      .map(propertyMetaData -> this.getPropertyValueString(propertyMetaData, element))
       .collect(Collectors.joining(CSVConstants.VALUE_DELIMITER));
+  }
+
+  /**
+   * Returns the string representation of the property value matching the given property metadata.
+   * If no matching property is found, an empty string is returned.
+   *
+   * @param propertyMetaData property metadata of the wanted property value
+   * @param element EPGM element containing the property value
+   * @return string representation of matched property value or empty string
+   */
+  private String getPropertyValueString(PropertyMetaData propertyMetaData, E element) {
+    PropertyValue p = element.getPropertyValue(propertyMetaData.getKey());
+    // Only properties with matching type get returned to prevent writing values with the wrong type metadata
+    if (p != null && MetaDataParser.getTypeString(p).equals(propertyMetaData.getTypeString())) {
+      return p.toString();
+    }
+    return EMPTY_STRING;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/metadata/MetaDataParser.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/metadata/MetaDataParser.java
@@ -97,23 +97,25 @@ public class MetaDataParser {
         propertyMetaDataList = new ArrayList<>(propertyStrings.length);
         for (String propertyString : propertyStrings) {
           String[] propertyTokens = propertyString.split(PROPERTY_TOKEN_DELIMITER);
+          String propertyType = propertyString.split(PROPERTY_TOKEN_DELIMITER, 2)[1];
           if (propertyTokens.length == 3 &&
             propertyTokens[1].equals(TypeString.LIST.getTypeString())) {
             // it's a list with one additional data type (type of list items)
             propertyMetaDataList.add(new PropertyMetaData(
-              propertyTokens[0], getListValueParser(propertyTokens[2])));
+              propertyTokens[0], propertyType, getListValueParser(propertyTokens[2])));
           } else if (propertyTokens.length == 4 &&
             propertyTokens[1].equals(TypeString.MAP.getTypeString())) {
             // it's a map with two additional data types (key type + value type)
             propertyMetaDataList.add(
               new PropertyMetaData(
                 propertyTokens[0],
+                propertyType,
                 getMapValueParser(propertyTokens[2], propertyTokens[3])
               )
             );
           } else {
             propertyMetaDataList.add(new PropertyMetaData(
-              propertyTokens[0], getValueParser(propertyTokens[1])));
+              propertyTokens[0], propertyType, getValueParser(propertyTokens[1])));
           }
         }
       } else {
@@ -288,7 +290,7 @@ public class MetaDataParser {
    * @param propertyValue property value
    * @return property type string
    */
-  private static String getTypeString(PropertyValue propertyValue) {
+  public static String getTypeString(PropertyValue propertyValue) {
     if (propertyValue.isShort()) {
       return TypeString.SHORT.getTypeString();
     } else if (propertyValue.isInt()) {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/metadata/MetaDataParser.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/metadata/MetaDataParser.java
@@ -96,26 +96,26 @@ public class MetaDataParser {
         String[] propertyStrings = tuple.f2.split(PROPERTY_DELIMITER);
         propertyMetaDataList = new ArrayList<>(propertyStrings.length);
         for (String propertyString : propertyStrings) {
-          String[] propertyTokens = propertyString.split(PROPERTY_TOKEN_DELIMITER);
-          String propertyType = propertyString.split(PROPERTY_TOKEN_DELIMITER, 2)[1];
-          if (propertyTokens.length == 3 &&
-            propertyTokens[1].equals(TypeString.LIST.getTypeString())) {
+          String[] propertyMetadata = propertyString.split(PROPERTY_TOKEN_DELIMITER, 2);
+          String[] propertyTypeTokens = propertyMetadata[1].split(PROPERTY_TOKEN_DELIMITER);
+          if (propertyTypeTokens.length == 2 &&
+            propertyTypeTokens[0].equals(TypeString.LIST.getTypeString())) {
             // it's a list with one additional data type (type of list items)
             propertyMetaDataList.add(new PropertyMetaData(
-              propertyTokens[0], propertyType, getListValueParser(propertyTokens[2])));
-          } else if (propertyTokens.length == 4 &&
-            propertyTokens[1].equals(TypeString.MAP.getTypeString())) {
+              propertyMetadata[0], propertyMetadata[1], getListValueParser(propertyTypeTokens[1])));
+          } else if (propertyTypeTokens.length == 3 &&
+            propertyTypeTokens[0].equals(TypeString.MAP.getTypeString())) {
             // it's a map with two additional data types (key type + value type)
             propertyMetaDataList.add(
               new PropertyMetaData(
-                propertyTokens[0],
-                propertyType,
-                getMapValueParser(propertyTokens[2], propertyTokens[3])
+                propertyMetadata[0],
+                propertyMetadata[1],
+                getMapValueParser(propertyTypeTokens[1], propertyTypeTokens[2])
               )
             );
           } else {
             propertyMetaDataList.add(new PropertyMetaData(
-              propertyTokens[0], propertyType, getValueParser(propertyTokens[1])));
+              propertyMetadata[0], propertyMetadata[1], getValueParser(propertyMetadata[1])));
           }
         }
       } else {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/metadata/PropertyMetaData.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/metadata/PropertyMetaData.java
@@ -26,6 +26,10 @@ public class PropertyMetaData {
    */
   private String key;
   /**
+   * Property type string
+   */
+  private String typeString;
+  /**
    * A function that parses a string to the typed property value
    */
   private Function<String, Object> valueParser;
@@ -34,10 +38,12 @@ public class PropertyMetaData {
    * Constructor.
    *
    * @param key property key
+   * @param typeString property type string
    * @param valueParser property value parser
    */
-  public PropertyMetaData(String key, Function<String, Object> valueParser) {
+  public PropertyMetaData(String key, String typeString, Function<String, Object> valueParser) {
     this.key = key;
+    this.typeString = typeString;
     this.valueParser = valueParser;
   }
 
@@ -48,6 +54,15 @@ public class PropertyMetaData {
    */
   public String getKey() {
     return key;
+  }
+
+  /**
+   * Returns the property type string
+   *
+   * @return property type string
+   */
+  public String getTypeString() {
+    return typeString;
   }
 
   /**

--- a/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSinkTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSinkTest.java
@@ -48,19 +48,18 @@ public class CSVDataSinkTest extends CSVTestBase {
     String tmpPath = temporaryFolder.getRoot().getPath();
 
     FlinkAsciiGraphLoader loader = getLoaderFromString(
-      "intFloat[(v1:a {key:1})-->(v2:a {key:1})]" +
-      "intStr[(v3:a {key:1})-->(v4:a {key:\"Foo\"})]" +
-      "strFloat[(v5:a {key:\"Bar\"})-->(v6:a {key:1.1})]" +
-      "intFloatStr[(v7:a {key:1})-->(v8:a {key:1.1})-->(v9:a {key:\"BarBar\"})]" +
+      "vertices[" +
+      "(v1:A {keya:1, keyb:2, keyc:\"Foo\"})," +
+      "(v2:B {keya:1.2f, keyb:\"Bar\", keyc:2.3f})," +
+      "(v3:C {keya:\"Bar\", keyb:true})" +
+      "]" +
       "edges[" +
-      "(v10:A)-[e1:a {keya:14, keyb:3, keyc:\"Foo\"}]->(v10:B)," +
-      "(v11:B)-[e2:b {keya:1.1f, keyb:\"Bar\", keyc:2.5f}]->(v11:A)" +
+      "(v1)-[e1:a {keya:14, keyb:3, keyc:\"Foo\"}]->(v1)," +
+      "(v1)-[e2:b {keya:1.1f, keyb:\"Bar\", keyc:2.5f}]->(v1)" +
+      "(v1)-[e3:c {keya:true, keyb:3.13f}]->(v1)" +
       "]");
 
-    checkCSVWrite(tmpPath, loader.getLogicalGraphByVariable("intFloat"));
-    checkCSVWrite(tmpPath, loader.getLogicalGraphByVariable("intStr"));
-    checkCSVWrite(tmpPath, loader.getLogicalGraphByVariable("strFloat"));
-    checkCSVWrite(tmpPath, loader.getLogicalGraphByVariable("intFloatStr"));
+    checkCSVWrite(tmpPath, loader.getLogicalGraphByVariable("vertices"));
     checkCSVWrite(tmpPath, loader.getLogicalGraphByVariable("edges"));
   }
 

--- a/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSinkTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSinkTest.java
@@ -50,13 +50,13 @@ public class CSVDataSinkTest extends CSVTestBase {
     FlinkAsciiGraphLoader loader = getLoaderFromString(
       "vertices[" +
       "(v1:A {keya:1, keyb:2, keyc:\"Foo\"})," +
-      "(v2:B {keya:1.2f, keyb:\"Bar\", keyc:2.3f})," +
-      "(v3:C {keya:\"Bar\", keyb:true})" +
+      "(v2:A {keya:1.2f, keyb:\"Bar\", keyc:2.3f})," +
+      "(v3:A {keya:\"Bar\", keyb:true})" +
       "]" +
       "edges[" +
       "(v1)-[e1:a {keya:14, keyb:3, keyc:\"Foo\"}]->(v1)," +
-      "(v1)-[e2:b {keya:1.1f, keyb:\"Bar\", keyc:2.5f}]->(v1)," +
-      "(v1)-[e3:c {keya:true, keyb:3.13f}]->(v1)" +
+      "(v1)-[e2:a {keya:1.1f, keyb:\"Bar\", keyc:2.5f}]->(v1)," +
+      "(v1)-[e3:a {keya:true, keyb:3.13f}]->(v1)" +
       "]");
 
     checkCSVWrite(tmpPath, loader.getLogicalGraphByVariable("vertices"));

--- a/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSinkTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSinkTest.java
@@ -55,7 +55,7 @@ public class CSVDataSinkTest extends CSVTestBase {
       "]" +
       "edges[" +
       "(v1)-[e1:a {keya:14, keyb:3, keyc:\"Foo\"}]->(v1)," +
-      "(v1)-[e2:b {keya:1.1f, keyb:\"Bar\", keyc:2.5f}]->(v1)" +
+      "(v1)-[e2:b {keya:1.1f, keyb:\"Bar\", keyc:2.5f}]->(v1)," +
       "(v1)-[e3:c {keya:true, keyb:3.13f}]->(v1)" +
       "]");
 

--- a/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSinkTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSinkTest.java
@@ -43,6 +43,12 @@ public class CSVDataSinkTest extends CSVTestBase {
     checkCSVWrite(tmpPath, input);
   }
 
+  /**
+   * Test CSVDataSink to write a graph with different property types
+   * using the same label on different elements with the same label.
+   *
+   * @throws Exception on failure
+   */
   @Test
   public void testWriteWithDifferentPropertyTypes() throws Exception {
     String tmpPath = temporaryFolder.getRoot().getPath();
@@ -137,6 +143,13 @@ public class CSVDataSinkTest extends CSVTestBase {
     }
   }
 
+  /**
+   * Test writing and reading the given graph to and from CSV
+   *
+   * @param tmpPath path to write csv
+   * @param input logical graph
+   * @throws Exception on failure
+   */
   private void checkCSVWrite(String tmpPath, LogicalGraph input) throws Exception {
     DataSink csvDataSink = new CSVDataSink(tmpPath, getConfig());
     csvDataSink.write(input, true);

--- a/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSinkTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSinkTest.java
@@ -48,15 +48,20 @@ public class CSVDataSinkTest extends CSVTestBase {
     String tmpPath = temporaryFolder.getRoot().getPath();
 
     FlinkAsciiGraphLoader loader = getLoaderFromString(
-      "intFloat[(v1:a {a:1})-->(v2:a {a:1})]" +
-      "intStr[(v3:a {key:1})-->(v4:a {key:\"Test\"})]" +
-      "strFloat[(v5:a {key:\"Test\"})-->(v6:a {key:1.1})]" +
-      "intFloatStr[(v7:a {key:1})-->(v8:a {key:1.1})-->(v9:a {key:\"Test\"})]");
+      "intFloat[(v1:a {key:1})-->(v2:a {key:1})]" +
+      "intStr[(v3:a {key:1})-->(v4:a {key:\"Foo\"})]" +
+      "strFloat[(v5:a {key:\"Bar\"})-->(v6:a {key:1.1})]" +
+      "intFloatStr[(v7:a {key:1})-->(v8:a {key:1.1})-->(v9:a {key:\"BarBar\"})]" +
+      "edges[" +
+      "(v10:A)-[e1:a {keya:14, keyb:3, keyc:\"Foo\"}]->(v10:B)," +
+      "(v11:B)-[e2:b {keya:1.1f, keyb:\"Bar\", keyc:2.5f}]->(v11:A)" +
+      "]");
 
     checkCSVWrite(tmpPath, loader.getLogicalGraphByVariable("intFloat"));
     checkCSVWrite(tmpPath, loader.getLogicalGraphByVariable("intStr"));
     checkCSVWrite(tmpPath, loader.getLogicalGraphByVariable("strFloat"));
     checkCSVWrite(tmpPath, loader.getLogicalGraphByVariable("intFloatStr"));
+    checkCSVWrite(tmpPath, loader.getLogicalGraphByVariable("edges"));
   }
 
   @Test

--- a/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSinkTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSinkTest.java
@@ -48,14 +48,14 @@ public class CSVDataSinkTest extends CSVTestBase {
     String tmpPath = temporaryFolder.getRoot().getPath();
 
     FlinkAsciiGraphLoader loader = getLoaderFromString(
-      "intFloat[(v1 {key:1})-->(v2 {key:1.1})]" +
-      "intStr[(v3 {key:1})-->(v4 {key:\"Test\"})]" +
-      "floatStr[(v5 {key:\"Test\"})-->(v6 {key:1.1})]" +
-      "intFloatStr[(v7 {key:1})-->(v8 {key:1.1})-->(v9 {key:\"Test\"})]");
+      "intFloat[(v1:a {a:1})-->(v2:a {a:1})]" +
+      "intStr[(v3:a {key:1})-->(v4:a {key:\"Test\"})]" +
+      "strFloat[(v5:a {key:\"Test\"})-->(v6:a {key:1.1})]" +
+      "intFloatStr[(v7:a {key:1})-->(v8:a {key:1.1})-->(v9:a {key:\"Test\"})]");
 
     checkCSVWrite(tmpPath, loader.getLogicalGraphByVariable("intFloat"));
     checkCSVWrite(tmpPath, loader.getLogicalGraphByVariable("intStr"));
-    checkCSVWrite(tmpPath, loader.getLogicalGraphByVariable("floatStr"));
+    checkCSVWrite(tmpPath, loader.getLogicalGraphByVariable("strFloat"));
     checkCSVWrite(tmpPath, loader.getLogicalGraphByVariable("intFloatStr"));
   }
 

--- a/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVTestBase.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVTestBase.java
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertTrue;
  * Abstract parent class of csv test classes with common functions for source and sink tests
  */
 abstract class CSVTestBase extends GradoopFlinkTestBase {
-  
+
   /**
    * Global map to define properties of vertices and edges
    */


### PR DESCRIPTION
When a PropertyValue type does not match its metadata type, an empty string is written. Fixes #865 