### PR TITLE
[#915] Fix handling of large PropertyValues in HBase store.

### DIFF
--- a/gradoop-store/gradoop-hbase/src/main/java/org/gradoop/storage/impl/hbase/iterator/HBasePropertyValueWrapper.java
+++ b/gradoop-store/gradoop-hbase/src/main/java/org/gradoop/storage/impl/hbase/iterator/HBasePropertyValueWrapper.java
@@ -15,10 +15,7 @@
  */
 package org.gradoop.storage.impl.hbase.iterator;
 
-import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.io.Writable;
-import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.properties.DateTimeSerializer;
 import org.gradoop.common.model.impl.properties.PropertyValue;
 
 import java.io.DataInput;
@@ -62,61 +59,11 @@ public class HBasePropertyValueWrapper implements Writable {
    */
   @Override
   public void write(DataOutput dataOutput) throws IOException {
-    byte[] rawBytes = value.getRawBytes();
-
-    // null?
-    // type
-    dataOutput.writeByte(rawBytes[0]);
-    // dynamic type?
-    if (rawBytes[0] == PropertyValue.TYPE_STRING || rawBytes[0] == PropertyValue.TYPE_BIG_DECIMAL ||
-      rawBytes[0] == PropertyValue.TYPE_MAP || rawBytes[0] == PropertyValue.TYPE_LIST) {
-      // write length
-      dataOutput.writeShort(rawBytes.length - PropertyValue.OFFSET);
-    }
-    // write data
-    dataOutput.write(rawBytes, PropertyValue.OFFSET, rawBytes.length - PropertyValue.OFFSET);
+    value.write(dataOutput);
   }
 
   @Override
   public void readFields(DataInput dataInput) throws IOException {
-    short length = 0;
-    // type
-    byte type = dataInput.readByte();
-    // dynamic type?
-    if (type == PropertyValue.TYPE_STRING || type == PropertyValue.TYPE_BIG_DECIMAL ||
-      type == PropertyValue.TYPE_MAP || type == PropertyValue.TYPE_LIST) {
-      // read length
-      length = dataInput.readShort();
-    } else if (type == PropertyValue.TYPE_NULL) {
-      length = 0;
-    } else if (type == PropertyValue.TYPE_BOOLEAN) {
-      length = Bytes.SIZEOF_BOOLEAN;
-    } else if (type == PropertyValue.TYPE_INTEGER) {
-      length = Bytes.SIZEOF_INT;
-    } else if (type == PropertyValue.TYPE_LONG) {
-      length = Bytes.SIZEOF_LONG;
-    } else if (type == PropertyValue.TYPE_FLOAT) {
-      length = Bytes.SIZEOF_FLOAT;
-    } else if (type == PropertyValue.TYPE_DOUBLE) {
-      length = Bytes.SIZEOF_DOUBLE;
-    } else if (type == PropertyValue.TYPE_GRADOOP_ID) {
-      length = GradoopId.ID_SIZE;
-    } else if (type == PropertyValue.TYPE_DATE) {
-      length = DateTimeSerializer.SIZEOF_DATE;
-    } else if (type == PropertyValue.TYPE_TIME) {
-      length = DateTimeSerializer.SIZEOF_TIME;
-    } else if (type == PropertyValue.TYPE_DATETIME) {
-      length = DateTimeSerializer.SIZEOF_DATETIME;
-    }
-    // init new array
-    byte[] rawBytes = new byte[PropertyValue.OFFSET + length];
-    // read type info
-    rawBytes[0] = type;
-    // read data
-    for (int i = PropertyValue.OFFSET; i < rawBytes.length; i++) {
-      rawBytes[i] = dataInput.readByte();
-    }
-
-    value.setBytes(rawBytes);
+    value.read(dataInput);
   }
 }


### PR DESCRIPTION
- Add a test case (that previously would have failed).
- Remove duplicate code and use the methods in `PropertyValue`

I had to overload the methods. (`DataInputView` is a subclass of `DataInput` providing some extra functions we don't use, same for `DataOutputView`)