### PR TITLE
[#947] Fix PageRank wrapper.

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/pagerank/PageRank.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/pagerank/PageRank.java
@@ -24,6 +24,7 @@ import org.gradoop.flink.algorithms.gelly.GellyAlgorithm;
 import org.gradoop.flink.algorithms.gelly.functions.EdgeToGellyEdgeWithNullValue;
 import org.gradoop.flink.algorithms.gelly.functions.VertexToGellyVertexWithNullValue;
 import org.gradoop.flink.algorithms.gelly.pagerank.functions.PageRankToAttribute;
+import org.gradoop.flink.algorithms.gelly.pagerank.functions.PageRankResultKey;
 import org.gradoop.flink.model.api.epgm.LogicalGraph;
 import org.gradoop.flink.model.impl.functions.epgm.Id;
 
@@ -69,7 +70,7 @@ public class PageRank extends GellyAlgorithm<NullValue, NullValue> {
         dampingFactor, iterations)
       .run(graph)
       .join(currentGraph.getVertices())
-      .where(0)
+      .where(new PageRankResultKey())
       .equalTo(new Id<>())
       .with(new PageRankToAttribute(propertyKey));
     return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(newVertices,

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/pagerank/functions/PageRankResultKey.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/pagerank/functions/PageRankResultKey.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.algorithms.gelly.pagerank.functions;
+
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.graph.library.linkanalysis.PageRank;
+import org.gradoop.common.model.impl.id.GradoopId;
+
+/**
+ * Select the vertex id of an Page Rank result.
+ */
+public class PageRankResultKey implements KeySelector<PageRank.Result<GradoopId>, GradoopId> {
+
+  @Override
+  public GradoopId getKey(PageRank.Result<GradoopId> result) throws Exception {
+    return result.getVertexId0();
+  }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/algorithms/gelly/pagerank/PageRankTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/algorithms/gelly/pagerank/PageRankTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.algorithms.gelly.pagerank;
+
+import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.flink.model.GradoopFlinkTestBase;
+import org.gradoop.flink.model.api.epgm.LogicalGraph;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * A test for {@link PageRank}, calling the operator and checking if the result was set.
+ */
+public class PageRankTest extends GradoopFlinkTestBase {
+
+  /**
+   * The property key used to store the page rank result.
+   */
+  public static final String PROPERTY_KEY = "pageRank";
+
+  /**
+   * Execute the {@link PageRank} operator and check if the property was set for all vertices.
+   *
+   * @throws Exception If the execution fails.
+   */
+  @Test
+  public void testPageRankExecution() throws Exception {
+    LogicalGraph input = getSocialNetworkLoader().getLogicalGraphByVariable("g0");
+    input.print();
+    long inputVertexCount = input.getVertices().count();
+    LogicalGraph result = new PageRank(PROPERTY_KEY, 0.3, 20).execute(input);
+    List<Vertex> resultVertices = result.getVertices().collect();
+    assertEquals(inputVertexCount, resultVertices.size());
+    for (Vertex vertex : resultVertices) {
+      assertTrue(vertex.hasProperty(PROPERTY_KEY));
+    }
+  }
+}


### PR DESCRIPTION
The wrapper for the PageRank Gelly algorithm was broken in recent Flink versions, because the result type was changed from a `Tuple` to an `UnaryResult`.
Added a new `KeySelector` to fix the implementation.
Added a test calling the operator and checking if the results were set as the correct property.

The `KeySelector` is basically the same as `org.gradoop.flink.algorithms.gelly.hits.functions.HitsResultKeySelector` and may be generalized to something like
```java
org.gradoop.flink.algorithms.gelly.functions.UnaryResultKey<T> extends KeySelector<UnaryResult<T>, T>
```
Should I do this (this would remove a duplicate) or leave it for now?
