### PR TITLE
[#1030] Replace Runtime.exec with a ProcessBuilder

### DIFF
--- a/gradoop-examples/src/main/java/org/gradoop/examples/biiig/FrequentLossPatterns.java
+++ b/gradoop-examples/src/main/java/org/gradoop/examples/biiig/FrequentLossPatterns.java
@@ -211,9 +211,7 @@ public class FrequentLossPatterns
     // trigger execution
     getExecutionEnvironment().execute();
 
-    String cmd = "dot -Tps " + dotPath + " -o " + psPath;
-
-    Runtime.getRuntime().exec(cmd);
+    new ProcessBuilder("dot", "-Tps", dotPath, "-o", psPath).inheritIO().start();
   }
 
   // AGGREGATE FUNCTIONS


### PR DESCRIPTION
Replace an unsafe `exec` with a `ProcessBuilder`.

fixes #1030 