### PR TITLE
[#1105] Updated Maven Shade version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <plugin.maven-jar.version>2.3.2</plugin.maven-jar.version>
         <plugin.maven-release.version>2.5.3</plugin.maven-release.version>
         <plugin.maven-surefire.version>2.19.1</plugin.maven-surefire.version>
-        <plugin.maven-shade.version>2.4.3</plugin.maven-shade.version>
+        <plugin.maven-shade.version>3.2.1</plugin.maven-shade.version>
         <plugin.maven-source.version>3.0.1</plugin.maven-source.version>
         <plugin.maven-javadoc.version>3.0.1</plugin.maven-javadoc.version>
         <plugin.maven-gpg.version>1.6</plugin.maven-gpg.version>


### PR DESCRIPTION
Updated the version of the Maven Shade Plugin from 2.4.3 to 3.2.1. This enables Java 9+ support in the future and avoids some possible bugs that may occur.