### PR TITLE
[#1066] Add missing dependency to the iterator JAR.

### DIFF
--- a/gradoop-store/gradoop-accumulo/pom.xml
+++ b/gradoop-store/gradoop-accumulo/pom.xml
@@ -126,6 +126,7 @@
                                     <include>com.esotericsoftware.kryo:*</include>
                                     <include>org.apache.flink:flink-core</include>
                                     <include>org.apache.hbase:hbase-common</include>
+                                    <include>org.objenesis:objenesis</include>
                                 </includes>
                             </artifactSet>
                         </configuration>


### PR DESCRIPTION
Adds a missing dependency used by Kryo to the shade rules.

edit: Problem not fixed completely.