### PR TITLE
[#1160] Provide functions to drop and truncate tables for the Accumulo store.

### DIFF
--- a/gradoop-store/gradoop-accumulo/src/main/java/org/gradoop/storage/impl/accumulo/io/AccumuloDataSink.java
+++ b/gradoop-store/gradoop-accumulo/src/main/java/org/gradoop/storage/impl/accumulo/io/AccumuloDataSink.java
@@ -26,6 +26,7 @@ import org.gradoop.storage.impl.accumulo.AccumuloEPGMStore;
 import org.gradoop.storage.impl.accumulo.io.outputformats.ElementOutputFormat;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
 
 /**
  * Write graph or graph collection into accumulo store
@@ -46,22 +47,25 @@ public class AccumuloDataSink extends AccumuloBase implements DataSink {
   }
 
   @Override
-  public void write(LogicalGraph logicalGraph) {
+  public void write(LogicalGraph logicalGraph) throws IOException {
     write(logicalGraph, false);
   }
 
   @Override
-  public void write(GraphCollection graphCollection) {
+  public void write(GraphCollection graphCollection) throws IOException {
     write(graphCollection, false);
   }
 
   @Override
-  public void write(LogicalGraph logicalGraph, boolean overwrite) {
+  public void write(LogicalGraph logicalGraph, boolean overwrite) throws IOException {
     write(getFlinkConfig().getGraphCollectionFactory().fromGraph(logicalGraph), overwrite);
   }
 
   @Override
-  public void write(GraphCollection graphCollection, boolean overWrite) {
+  public void write(GraphCollection graphCollection, boolean overWrite) throws IOException {
+    if (overWrite) {
+      getStore().truncateTables();
+    }
     graphCollection.getGraphHeads()
       .output(new ElementOutputFormat<>(GraphHead.class, getAccumuloConfig()));
     graphCollection.getVertices()

--- a/gradoop-store/gradoop-accumulo/src/test/java/org/gradoop/storage/impl/accumulo/AccumuloStoreTestBase.java
+++ b/gradoop-store/gradoop-accumulo/src/test/java/org/gradoop/storage/impl/accumulo/AccumuloStoreTestBase.java
@@ -96,13 +96,23 @@ public class AccumuloStoreTestBase extends GradoopFlinkTestBase {
     return ret;
   }
 
+  /**
+   * Wraps an test function.
+   */
   public interface SocialTestContext {
 
+    /**
+     * Run the test.
+     *
+     * @param loader The loader used for access to a test graph.
+     * @param store The store instance to test.
+     * @param config The gradoop flink config used to run tests.
+     * @throws Throwable an Exception thrown by the test.
+     */
     void test(
       AsciiGraphLoader<GraphHead, Vertex, Edge> loader,
       AccumuloEPGMStore store,
       GradoopFlinkConfig config
     ) throws Throwable;
-
   }
 }

--- a/gradoop-store/gradoop-accumulo/src/test/java/org/gradoop/storage/impl/accumulo/AccumuloStoreTestBase.java
+++ b/gradoop-store/gradoop-accumulo/src/test/java/org/gradoop/storage/impl/accumulo/AccumuloStoreTestBase.java
@@ -97,7 +97,7 @@ public class AccumuloStoreTestBase extends GradoopFlinkTestBase {
   }
 
   /**
-   * Wraps an test function.
+   * Wraps a test function.
    */
   public interface SocialTestContext {
 

--- a/gradoop-store/gradoop-accumulo/src/test/java/org/gradoop/storage/impl/accumulo/basic/StoreTest.java
+++ b/gradoop-store/gradoop-accumulo/src/test/java/org/gradoop/storage/impl/accumulo/basic/StoreTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.Connector;
 import org.gradoop.common.GradoopTestUtils;
 import org.gradoop.common.config.GradoopConfig;
 import org.gradoop.common.exceptions.UnsupportedTypeException;
@@ -83,8 +84,7 @@ import static org.gradoop.common.GradoopTestUtils.validateEPGMElementCollections
 import static org.gradoop.common.GradoopTestUtils.validateEPGMElements;
 import static org.gradoop.common.GradoopTestUtils.validateEPGMGraphElementCollections;
 import static org.gradoop.common.GradoopTestUtils.validateEPGMGraphElements;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Accumulo graph store test
@@ -97,6 +97,66 @@ public class StoreTest extends AccumuloStoreTestBase {
   private static final String TEST03 = "basic_03";
   private static final String TEST04 = "basic_04";
   private static final String TEST05 = "basic_05";
+
+  /**
+   * Creates tables, deletes them and checks if they were deleted.
+   *
+   * @throws AccumuloSecurityException when the user does not have permissions for some actions.
+   * @throws AccumuloException on general accumulo errors.
+   * @throws IOException when deleting tables fails.
+   */
+  @Test
+  public void deleteTablesTest() throws AccumuloSecurityException, AccumuloException, IOException {
+    final String table = "test_to_delete";
+    GradoopAccumuloConfig config = AccumuloTestSuite.getAcConfig(table);
+    AccumuloEPGMStore store = new AccumuloEPGMStore(config);
+    Connector connector = store.createConnector();
+    // Make sure that the tables were created.
+    assertTrue(connector.tableOperations().exists(store.getVertexTableName()));
+    assertTrue(connector.tableOperations().exists(store.getEdgeTableName()));
+    assertTrue(connector.tableOperations().exists(store.getGraphHeadName()));
+    // Delete tables.
+    store.dropTables();
+    // Check if they were deleted.
+    assertFalse(connector.tableOperations().exists(store.getVertexTableName()));
+    assertFalse(connector.tableOperations().exists(store.getEdgeTableName()));
+    assertFalse(connector.tableOperations().exists(store.getGraphHeadName()));
+  }
+
+  /**
+   * Stores a graph, truncates tables and checks if the tables still exist and if they are empty.
+   *
+   * @throws AccumuloSecurityException when the user does not have permissions for some actions.
+   * @throws AccumuloException on general accumulo errors.
+   */
+  @Test
+  public void truncateTablesTest() throws AccumuloSecurityException, AccumuloException,
+    IOException {
+    final String table = "test_to_truncate";
+    GradoopAccumuloConfig config = AccumuloTestSuite.getAcConfig(table);
+
+    AccumuloEPGMStore graphStore = new AccumuloEPGMStore(config);
+
+    AsciiGraphLoader<GraphHead, Vertex, Edge> loader = getMinimalFullFeaturedGraphLoader();
+
+    GraphHead graphHead = loader.getGraphHeads().iterator().next();
+    Vertex vertex = loader.getVertices().iterator().next();
+    Edge edge = loader.getEdges().iterator().next();
+
+    graphStore.writeGraphHead(graphHead);
+    graphStore.writeVertex(vertex);
+    graphStore.writeEdge(edge);
+
+    // re-open
+    graphStore.close();
+    graphStore = new AccumuloEPGMStore(config);
+    graphStore.truncateTables();
+
+    assertFalse(graphStore.getVertexSpace().hasNext());
+    assertFalse(graphStore.getEdgeSpace().hasNext());
+    assertFalse(graphStore.getGraphSpace().hasNext());
+    graphStore.close();
+  }
 
   /**
    * Creates persistent graph, vertex and edge data. Writes data to Accumulo,


### PR DESCRIPTION
Provides functions to drop and truncate tables on the accumulo store.

I had to add `IOException`s on the write functions, but those are declared on the `DataSink` interface anyway.

fixes #1160 