### PR TITLE
[#1163] Replace Operator.getName with a default implementation.

### DIFF
--- a/gradoop-data-integration/src/main/java/org/gradoop/dataintegration/transformation/impl/ExtractPropertyFromVertex.java
+++ b/gradoop-data-integration/src/main/java/org/gradoop/dataintegration/transformation/impl/ExtractPropertyFromVertex.java
@@ -169,9 +169,4 @@ public class ExtractPropertyFromVertex implements UnaryGraphToGraphOperator {
       .getLogicalGraphFactory()
       .fromDataSets(logicalGraph.getGraphHead(), vertices, edges);
   }
-
-  @Override
-  public String getName() {
-    return ExtractPropertyFromVertex.class.getName();
-  }
 }

--- a/gradoop-data-integration/src/main/java/org/gradoop/dataintegration/transformation/impl/PropertyTransformation.java
+++ b/gradoop-data-integration/src/main/java/org/gradoop/dataintegration/transformation/impl/PropertyTransformation.java
@@ -140,9 +140,4 @@ public class PropertyTransformation<
       .execute(graph);
   }
 
-  @Override
-  public String getName() {
-    return PropertyTransformation.class.getName();
-  }
-
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/BusinessTransactionGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/BusinessTransactionGraphs.java
@@ -147,9 +147,4 @@ public class BusinessTransactionGraphs implements
     return iig.getConfig().getGraphCollectionFactory()
       .fromDataSets(graphHeads, transVertices.union(masterVertices), btgEdges);
   }
-
-  @Override
-  public String getName() {
-    return BusinessTransactionGraphs.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/fsm/transactional/CategoryCharacteristicSubgraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/fsm/transactional/CategoryCharacteristicSubgraphs.java
@@ -248,9 +248,4 @@ public class CategoryCharacteristicSubgraphs
       .withBroadcastSet(categoryMinFrequencies, DIMSpanConstants.MIN_FREQUENCY);
   }
 
-  @Override
-  public String getName() {
-    return this.getClass().getSimpleName();
-  }
-
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/fsm/transactional/ThinkLikeAnEmbeddingTFSM.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/fsm/transactional/ThinkLikeAnEmbeddingTFSM.java
@@ -125,9 +125,4 @@ public class ThinkLikeAnEmbeddingTFSM
         .withBroadcastSet(minFrequency, DIMSpanConstants.MIN_FREQUENCY);
   }
 
-  @Override
-  public String getName() {
-    return this.getClass().getSimpleName();
-  }
-
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/clusteringcoefficient/ClusteringCoefficientBase.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/clusteringcoefficient/ClusteringCoefficientBase.java
@@ -72,9 +72,4 @@ public abstract class ClusteringCoefficientBase extends
    */
   protected abstract LogicalGraph executeInternal(Graph<GradoopId, NullValue, NullValue> gellyGraph)
     throws Exception;
-
-  @Override
-  public String getName() {
-    return ClusteringCoefficientBase.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/clusteringcoefficient/GellyGlobalClusteringCoefficientDirected.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/clusteringcoefficient/GellyGlobalClusteringCoefficientDirected.java
@@ -64,9 +64,4 @@ public class GellyGlobalClusteringCoefficientDirected extends ClusteringCoeffici
     return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(
       resultHead, currentGraph.getVertices(), currentGraph.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return GellyGlobalClusteringCoefficientDirected.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/clusteringcoefficient/GellyGlobalClusteringCoefficientUndirected.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/clusteringcoefficient/GellyGlobalClusteringCoefficientUndirected.java
@@ -65,9 +65,4 @@ public class GellyGlobalClusteringCoefficientUndirected extends ClusteringCoeffi
     return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(
       resultHead, currentGraph.getVertices(), currentGraph.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return GellyGlobalClusteringCoefficientUndirected.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/clusteringcoefficient/GellyLocalClusteringCoefficientDirected.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/clusteringcoefficient/GellyLocalClusteringCoefficientDirected.java
@@ -60,9 +60,4 @@ public class GellyLocalClusteringCoefficientDirected extends ClusteringCoefficie
     return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(
       currentGraph.getGraphHead(), resultVertices, currentGraph.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return GellyLocalClusteringCoefficientDirected.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/clusteringcoefficient/GellyLocalClusteringCoefficientUndirected.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/clusteringcoefficient/GellyLocalClusteringCoefficientUndirected.java
@@ -61,9 +61,4 @@ public class GellyLocalClusteringCoefficientUndirected extends ClusteringCoeffic
     return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(
       currentGraph.getGraphHead(), resultVertices, currentGraph.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return GellyLocalClusteringCoefficientUndirected.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/connectedcomponents/AnnotateWeaklyConnectedComponents.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/connectedcomponents/AnnotateWeaklyConnectedComponents.java
@@ -107,9 +107,4 @@ public class AnnotateWeaklyConnectedComponents extends GradoopGellyAlgorithm<Gra
     return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(
       currentGraph.getGraphHead(), annotatedVertices, edges);
   }
-
-  @Override
-  public String getName() {
-    return AnnotateWeaklyConnectedComponents.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/connectedcomponents/ValueWeaklyConnectedComponents.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/connectedcomponents/ValueWeaklyConnectedComponents.java
@@ -99,9 +99,4 @@ public class ValueWeaklyConnectedComponents
     return new ConnectedComponents<Long, Long, NullValue>(maxIteration)
       .run(graph).map(new MapVertexIdComponentId());
   }
-
-  @Override
-  public String getName() {
-    return ValueWeaklyConnectedComponents.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/connectedcomponents/WeaklyConnectedComponentsAsCollection.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/connectedcomponents/WeaklyConnectedComponentsAsCollection.java
@@ -78,9 +78,4 @@ public class WeaklyConnectedComponentsAsCollection implements UnaryGraphToCollec
       split.getVertices().map(new PropertyRemover<>(propertyKey)),
       split.getEdges().map(new PropertyRemover<>(propertyKey)));
   }
-
-  @Override
-  public String getName() {
-    return WeaklyConnectedComponentsAsCollection.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/hits/HITS.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/hits/HITS.java
@@ -114,9 +114,4 @@ public class HITS extends GradoopGellyAlgorithm<NullValue, NullValue> {
       .fromDataSets(newVertices, currentGraph.getEdges());
   }
 
-  @Override
-  public String getName() {
-    return HITS.class.getName();
-  }
-
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/labelpropagation/LabelPropagation.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/labelpropagation/LabelPropagation.java
@@ -97,9 +97,4 @@ public abstract class LabelPropagation extends GradoopGellyAlgorithm<PropertyVal
   protected int getMaxIterations() {
     return maxIterations;
   }
-
-  @Override
-  public String getName() {
-    return LabelPropagation.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/pagerank/PageRank.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/pagerank/PageRank.java
@@ -99,9 +99,4 @@ public class PageRank extends GradoopGellyAlgorithm<NullValue, NullValue> {
     return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(
       currentGraph.getGraphHead(), newVertices, currentGraph.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return PageRank.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/SingleSourceShortestPaths.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/shortestpaths/SingleSourceShortestPaths.java
@@ -86,9 +86,4 @@ public class SingleSourceShortestPaths extends GradoopGellyAlgorithm<NullValue, 
     return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(newVertices,
       currentGraph.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return SingleSourceShortestPaths.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/trianglecounting/GellyTriangleCounting.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/trianglecounting/GellyTriangleCounting.java
@@ -65,9 +65,4 @@ public class GellyTriangleCounting extends GradoopGellyAlgorithm<NullValue, Null
     return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(
       resultHead, currentGraph.getVertices(), currentGraph.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return GellyTriangleCounting.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/vertexdegrees/DistinctVertexDegrees.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/vertexdegrees/DistinctVertexDegrees.java
@@ -99,9 +99,4 @@ public class DistinctVertexDegrees extends GradoopGellyAlgorithm<NullValue, Null
     return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(newVertices,
       currentGraph.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return DistinctVertexDegrees.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/operators/Operator.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/operators/Operator.java
@@ -21,8 +21,11 @@ package org.gradoop.flink.model.api.operators;
 public interface Operator {
   /**
    * Returns the operators name.
+   * The operator name is the same as the class name, per default.
    *
    * @return operator name
    */
-  String getName();
+  default String getName() {
+    return this.getClass().getName();
+  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/Aggregation.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/Aggregation.java
@@ -100,9 +100,4 @@ public class Aggregation implements UnaryGraphToGraphOperator {
       .filter(AggregateFunction::isEdgeAggregation)
       .collect(Collectors.toSet())));
   }
-
-  @Override
-  public String getName() {
-    return Aggregation.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/ApplyAggregation.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/ApplyAggregation.java
@@ -129,9 +129,4 @@ public class ApplyAggregation
         .filter(AggregateFunction::isEdgeAggregation)
         .collect(Collectors.toSet())));
   }
-
-  @Override
-  public String getName() {
-    return ApplyAggregation.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/cloning/Cloning.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/cloning/Cloning.java
@@ -89,9 +89,4 @@ public class Cloning implements UnaryGraphToGraphOperator {
     return graph.getConfig().getLogicalGraphFactory()
       .fromDataSets(graphHead, vertices, edges);
   }
-
-  @Override
-  public String getName() {
-    return Cloning.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/combination/Combination.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/combination/Combination.java
@@ -51,9 +51,4 @@ public class Combination implements BinaryGraphToGraphOperator {
     return firstGraph.getConfig().getLogicalGraphFactory().fromDataSets(newVertexSet, newEdgeSet);
   }
 
-  @Override
-  public String getName() {
-    return Combination.class.getName();
-  }
-
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/combination/ReduceCombination.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/combination/ReduceCombination.java
@@ -36,9 +36,4 @@ public class ReduceCombination implements ReducibleBinaryGraphToGraphOperator {
     return collection.getConfig().getLogicalGraphFactory().fromDataSets(
       collection.getVertices(), collection.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return ReduceCombination.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/difference/Difference.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/difference/Difference.java
@@ -55,9 +55,4 @@ public class Difference extends SetOperatorBase {
       .groupBy(new IdOf0InTuple2<GraphHead, Long>())
       .reduceGroup(new RemoveCut<GraphHead>());
   }
-
-  @Override
-  public String getName() {
-    return Difference.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/difference/DifferenceBroadcast.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/difference/DifferenceBroadcast.java
@@ -53,9 +53,4 @@ public class DifferenceBroadcast extends Difference {
       .withBroadcastSet(identifiers,
         GraphsContainmentFilterBroadcast.GRAPH_IDS);
   }
-
-  @Override
-  public String getName() {
-    return DifferenceBroadcast.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/distinction/DistinctById.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/distinction/DistinctById.java
@@ -32,9 +32,4 @@ public class DistinctById implements UnaryCollectionToCollectionOperator {
       collection.getVertices(),
       collection.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return DistinctById.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/distinction/DistinctByIsomorphism.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/distinction/DistinctByIsomorphism.java
@@ -49,9 +49,4 @@ public class DistinctByIsomorphism extends GroupByIsomorphism {
 
     return selectVerticesAndEdges(collection, graphHeads);
   }
-
-  @Override
-  public String getName() {
-    return DistinctByIsomorphism.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/distinction/GroupByIsomorphism.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/distinction/GroupByIsomorphism.java
@@ -75,9 +75,4 @@ public class GroupByIsomorphism extends SelectionBase {
     return camBuilder
       .getGraphHeadStrings(collection);
   }
-
-  @Override
-  public String getName() {
-    return GroupByIsomorphism.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/equality/CollectionEquality.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/equality/CollectionEquality.java
@@ -65,9 +65,4 @@ public class CollectionEquality
       canonicalAdjacencyMatrixBuilder.execute(secondCollection)
     );
   }
-
-  @Override
-  public String getName() {
-    return this.getClass().getSimpleName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/equality/CollectionEqualityByGraphIds.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/equality/CollectionEqualityByGraphIds.java
@@ -60,9 +60,4 @@ public class CollectionEqualityByGraphIds
 
     return Not.map(Or.reduce(d));
   }
-
-  @Override
-  public String getName() {
-    return this.getClass().getSimpleName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/equality/GraphEquality.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/equality/GraphEquality.java
@@ -64,9 +64,4 @@ public class GraphEquality implements BinaryGraphToValueOperator<Boolean> {
     return collectionEquality
       .execute(collectionFactory.fromGraph(firstGraph), collectionFactory.fromGraph(secondGraph));
   }
-
-  @Override
-  public String getName() {
-    return this.getClass().getSimpleName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/exclusion/Exclusion.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/exclusion/Exclusion.java
@@ -78,9 +78,4 @@ public class Exclusion implements BinaryGraphToGraphOperator {
 
     return firstGraph.getConfig().getLogicalGraphFactory().fromDataSets(newVertexSet, newEdgeSet);
   }
-
-  @Override
-  public String getName() {
-    return Exclusion.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/exclusion/ReduceExclusion.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/exclusion/ReduceExclusion.java
@@ -75,9 +75,4 @@ public class ReduceExclusion implements ReducibleBinaryGraphToGraphOperator {
 
     return collection.getConfig().getLogicalGraphFactory().fromDataSets(vertices, edges);
   }
-
-  @Override
-  public String getName() {
-    return ReduceExclusion.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/fusion/VertexFusion.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/fusion/VertexFusion.java
@@ -149,11 +149,4 @@ public class VertexFusion implements BinaryGraphToGraphOperator {
 
     return searchGraph.getConfig().getLogicalGraphFactory().fromDataSets(gh, vToRet, edges);
   }
-
-
-
-  @Override
-  public String getName() {
-    return VertexFusion.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/GroupingGroupCombine.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/GroupingGroupCombine.java
@@ -121,9 +121,4 @@ public class GroupingGroupCombine extends Grouping {
 
     return config.getLogicalGraphFactory().fromDataSets(superVertices, superEdges);
   }
-
-  @Override
-  public String getName() {
-    return GroupingGroupCombine.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/GroupingGroupReduce.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/GroupingGroupReduce.java
@@ -101,9 +101,4 @@ public class GroupingGroupReduce extends Grouping {
 
     return config.getLogicalGraphFactory().fromDataSets(superVertices, superEdges);
   }
-
-  @Override
-  public String getName() {
-    return GroupingGroupReduce.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/intersection/Intersection.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/intersection/Intersection.java
@@ -43,9 +43,4 @@ public class Intersection extends SetOperatorBase {
       .groupBy(new Id<GraphHead>())
       .reduceGroup(new GroupCountEquals<GraphHead>(2));
   }
-
-  @Override
-  public String getName() {
-    return Intersection.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/intersection/IntersectionBroadcast.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/intersection/IntersectionBroadcast.java
@@ -44,9 +44,4 @@ public class IntersectionBroadcast extends Intersection {
       .filter(new InAnyGraphBroadcast<Vertex>())
       .withBroadcastSet(ids, GraphsContainmentFilterBroadcast.GRAPH_IDS);
   }
-
-  @Override
-  public String getName() {
-    return IntersectionBroadcast.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/limit/Limit.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/limit/Limit.java
@@ -66,9 +66,4 @@ public class Limit implements UnaryCollectionToCollectionOperator {
     return collection.getConfig().getGraphCollectionFactory()
       .fromDataSets(graphHeads, filteredVertices, filteredEdges);
   }
-
-  @Override
-  public String getName() {
-    return Limit.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/CypherPatternMatching.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/CypherPatternMatching.java
@@ -203,9 +203,4 @@ public class CypherPatternMatching extends PatternMatching {
     }
     return newMetaData;
   }
-
-  @Override
-  public String getName() {
-    return CypherPatternMatching.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativePatternMatching.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativePatternMatching.java
@@ -224,11 +224,6 @@ public class ExplorativePatternMatching
       PostProcessor.extractGraphCollection(elements, graph.getConfig(), true);
   }
 
-  @Override
-  public String getName() {
-    return ExplorativePatternMatching.class.getName();
-  }
-
 
   /**
    * Used for configuring and creating a new {@link ExplorativePatternMatching}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/simulation/dual/DualSimulation.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/simulation/dual/DualSimulation.java
@@ -294,9 +294,4 @@ public class DualSimulation extends PatternMatching {
     return config.getGraphCollectionFactory().fromGraph(
       config.getLogicalGraphFactory().fromDataSets(matchVertices, matchEdges));
   }
-
-  @Override
-  public String getName() {
-    return DualSimulation.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/TransactionalPatternMatching.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/TransactionalPatternMatching.java
@@ -219,9 +219,4 @@ public class TransactionalPatternMatching implements UnaryCollectionToCollection
     return collection.getConfig().getGraphCollectionFactory()
       .fromDataSets(newHeads, newVertices, newEdges);
   }
-
-  @Override
-  public String getName() {
-    return TransactionalPatternMatching.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/neighborhood/ReduceEdgeNeighborhood.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/neighborhood/ReduceEdgeNeighborhood.java
@@ -86,9 +86,4 @@ public class ReduceEdgeNeighborhood extends EdgeNeighborhood {
     return graph.getConfig().getLogicalGraphFactory().fromDataSets(graph.getGraphHead(),
       vertices, graph.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return ReduceEdgeNeighborhood.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/neighborhood/ReduceVertexNeighborhood.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/neighborhood/ReduceVertexNeighborhood.java
@@ -110,9 +110,4 @@ public class ReduceVertexNeighborhood extends VertexNeighborhood {
     return graph.getConfig().getLogicalGraphFactory()
       .fromDataSets(graph.getGraphHead(), vertices, graph.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return ReduceVertexNeighborhood.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/overlap/Overlap.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/overlap/Overlap.java
@@ -56,10 +56,5 @@ public class Overlap implements BinaryGraphToGraphOperator {
     return firstGraph.getConfig().getLogicalGraphFactory().fromDataSets(newVertices, newEdges);
   }
 
-  @Override
-  public String getName() {
-    return Overlap.class.getName();
-  }
-
 
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/overlap/ReduceOverlap.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/overlap/ReduceOverlap.java
@@ -48,9 +48,4 @@ public class ReduceOverlap extends OverlapBase implements
       getEdges(collection.getEdges(), graphIDs)
     );
   }
-
-  @Override
-  public String getName() {
-    return ReduceOverlap.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/rollup/EdgeRollUp.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/rollup/EdgeRollUp.java
@@ -67,9 +67,4 @@ public class EdgeRollUp extends RollUp {
   List<List<String>> getGroupingKeyCombinations() {
     return createGroupingKeyCombinations(edgeGroupingKeys);
   }
-
-  @Override
-  public String getName() {
-    return EdgeRollUp.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/rollup/VertexRollUp.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/rollup/VertexRollUp.java
@@ -68,9 +68,4 @@ public class VertexRollUp extends RollUp {
   List<List<String>> getGroupingKeyCombinations() {
     return createGroupingKeyCombinations(vertexGroupingKeys);
   }
-
-  @Override
-  public String getName() {
-    return VertexRollUp.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSampling.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSampling.java
@@ -143,9 +143,4 @@ public class PageRankSampling extends SamplingAlgorithm {
 
     return graph;
   }
-
-  @Override
-  public String getName() {
-    return PageRankSampling.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/RandomEdgeSampling.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/RandomEdgeSampling.java
@@ -81,9 +81,4 @@ public class RandomEdgeSampling extends SamplingAlgorithm {
     DataSet<Vertex> newVertices = newSourceVertices.union(newTargetVertices).distinct(new Id<>());
     return graph.getConfig().getLogicalGraphFactory().fromDataSets(newVertices, newEdges);
   }
-
-  @Override
-  public String getName() {
-    return RandomEdgeSampling.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/RandomLimitedDegreeVertexSampling.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/RandomLimitedDegreeVertexSampling.java
@@ -139,9 +139,4 @@ public class RandomLimitedDegreeVertexSampling extends SamplingAlgorithm {
       .fromDataSets(graph.getGraphHead(), newVertices, newEdges);
   }
 
-  @Override
-  public String getName() {
-    return RandomLimitedDegreeVertexSampling.class.getName();
-  }
-
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/RandomNonUniformVertexSampling.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/RandomNonUniformVertexSampling.java
@@ -106,9 +106,4 @@ public class RandomNonUniformVertexSampling extends SamplingAlgorithm {
     return graph.getConfig().getLogicalGraphFactory()
       .fromDataSets(graph.getGraphHead(), newVertices, newEdges);
   }
-
-  @Override
-  public String getName() {
-    return RandomNonUniformVertexSampling.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/RandomVertexEdgeSampling.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/RandomVertexEdgeSampling.java
@@ -134,9 +134,4 @@ public class RandomVertexEdgeSampling extends SamplingAlgorithm {
 
     return graph;
   }
-
-  @Override
-  public String getName() {
-    return RandomVertexEdgeSampling.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/RandomVertexNeighborhoodSampling.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/RandomVertexNeighborhoodSampling.java
@@ -122,9 +122,4 @@ public class RandomVertexNeighborhoodSampling extends SamplingAlgorithm {
 
     return graph;
   }
-
-  @Override
-  public String getName() {
-    return RandomVertexNeighborhoodSampling.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/RandomVertexSampling.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/RandomVertexSampling.java
@@ -78,9 +78,4 @@ public class RandomVertexSampling extends SamplingAlgorithm {
 
     return graph.getConfig().getLogicalGraphFactory().fromDataSets(newVertices, newEdges);
   }
-
-  @Override
-  public String getName() {
-    return RandomVertexSampling.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/functions/FilterVerticesWithDegreeOtherThanGiven.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/functions/FilterVerticesWithDegreeOtherThanGiven.java
@@ -60,9 +60,4 @@ public class FilterVerticesWithDegreeOtherThanGiven implements UnaryGraphToGraph
     return graph.getConfig().getLogicalGraphFactory().fromDataSets(
       graph.getGraphHead(), newVertices, graph.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return FilterVerticesWithDegreeOtherThanGiven.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/statistics/AverageClusteringCoefficient.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/statistics/AverageClusteringCoefficient.java
@@ -54,9 +54,4 @@ public class AverageClusteringCoefficient implements UnaryGraphToGraphOperator {
     return graph.getConfig().getLogicalGraphFactory().fromDataSets(
       graphHead, graph.getVertices(), graph.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return AverageClusteringCoefficient.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/statistics/AverageDegree.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/statistics/AverageDegree.java
@@ -50,9 +50,4 @@ public class AverageDegree implements UnaryGraphToGraphOperator {
     return graph.getConfig().getLogicalGraphFactory()
       .fromDataSets(newGraphHead, graph.getVertices(), graph.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return AverageDegree.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/statistics/AverageIncomingDegree.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/statistics/AverageIncomingDegree.java
@@ -50,9 +50,4 @@ public class AverageIncomingDegree implements UnaryGraphToGraphOperator {
     return graph.getConfig().getLogicalGraphFactory()
       .fromDataSets(newGraphHead, graph.getVertices(), graph.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return AverageIncomingDegree.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/statistics/AverageOutgoingDegree.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/statistics/AverageOutgoingDegree.java
@@ -50,9 +50,4 @@ public class AverageOutgoingDegree implements UnaryGraphToGraphOperator {
     return graph.getConfig().getLogicalGraphFactory()
       .fromDataSets(newGraphHead, graph.getVertices(), graph.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return AverageOutgoingDegree.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/statistics/ConnectedComponentsDistribution.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/statistics/ConnectedComponentsDistribution.java
@@ -109,9 +109,4 @@ public class ConnectedComponentsDistribution
     return graphWithWccIds.getGraphHead().flatMap(
       new GetConnectedComponentDistributionFlatMap(propertyKey, annotateEdges));
   }
-
-  @Override
-  public String getName() {
-    return ConnectedComponentsDistribution.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/statistics/GraphDensity.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/statistics/GraphDensity.java
@@ -39,9 +39,4 @@ public class GraphDensity implements UnaryGraphToGraphOperator {
     return graph.getConfig().getLogicalGraphFactory()
       .fromDataSets(newGraphHead, graph.getVertices(), graph.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return GraphDensity.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/statistics/ValueConnectedComponentsDistribution.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/statistics/ValueConnectedComponentsDistribution.java
@@ -48,9 +48,4 @@ public class ValueConnectedComponentsDistribution
   public DataSet<Tuple2<Long, Long>> execute(LogicalGraph graph) {
     return new ValueWeaklyConnectedComponents(maxIteration).execute(graph);
   }
-
-  @Override
-  public String getName() {
-    return ValueConnectedComponentsDistribution.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/selection/Selection.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/selection/Selection.java
@@ -78,9 +78,4 @@ public class Selection extends SelectionBase {
     return collection.getConfig().getGraphCollectionFactory()
       .fromTransactions(filteredTransactions);
   }
-
-  @Override
-  public String getName() {
-    return Selection.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/selection/SelectionBase.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/selection/SelectionBase.java
@@ -62,7 +62,4 @@ public abstract class SelectionBase implements UnaryCollectionToCollectionOperat
     return collection.getConfig().getGraphCollectionFactory()
       .fromDataSets(graphHeads, vertices, edges);
   }
-
-  @Override
-  public abstract String getName();
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/Split.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/Split.java
@@ -143,9 +143,4 @@ public class Split implements UnaryGraphToCollectionOperator, Serializable {
     return graph.getConfig().getGraphCollectionFactory()
       .fromDataSets(newGraphs, vertices, edges);
   }
-
-  @Override
-  public String getName() {
-    return Split.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/DistinctEdgeProperties.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/DistinctEdgeProperties.java
@@ -33,9 +33,4 @@ public class DistinctEdgeProperties extends DistinctProperties<Edge, String> {
   protected DataSet<Tuple2<String, Set<PropertyValue>>> extractValuePairs(LogicalGraph graph) {
     return graph.getEdges().flatMap(new ExtractPropertyValues<>());
   }
-
-  @Override
-  public String getName() {
-    return DistinctEdgeProperties.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/DistinctEdgePropertiesByLabel.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/DistinctEdgePropertiesByLabel.java
@@ -35,9 +35,4 @@ public class DistinctEdgePropertiesByLabel
     LogicalGraph graph) {
     return graph.getEdges().flatMap(new ExtractPropertyValuesByLabel<>());
   }
-
-  @Override
-  public String getName() {
-    return DistinctEdgePropertiesByLabel.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/DistinctSourceIds.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/DistinctSourceIds.java
@@ -34,9 +34,4 @@ public class DistinctSourceIds implements UnaryGraphToValueOperator<DataSet<Long
         .distinct()
     );
   }
-
-  @Override
-  public String getName() {
-    return DistinctSourceIds.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/DistinctSourceIdsByEdgeLabel.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/DistinctSourceIdsByEdgeLabel.java
@@ -42,9 +42,4 @@ public class DistinctSourceIdsByEdgeLabel
       .sum(1)
       .map(new Tuple2ToWithCount<>());
   }
-
-  @Override
-  public String getName() {
-    return DistinctSourceIdsByEdgeLabel.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/DistinctTargetIds.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/DistinctTargetIds.java
@@ -34,9 +34,4 @@ public class DistinctTargetIds implements UnaryGraphToValueOperator<DataSet<Long
         .distinct()
     );
   }
-
-  @Override
-  public String getName() {
-    return DistinctTargetIds.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/DistinctTargetIdsByEdgeLabel.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/DistinctTargetIdsByEdgeLabel.java
@@ -42,9 +42,4 @@ public class DistinctTargetIdsByEdgeLabel
       .sum(1)
       .map(new Tuple2ToWithCount<>());
   }
-
-  @Override
-  public String getName() {
-    return DistinctTargetIdsByEdgeLabel.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/DistinctVertexProperties.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/DistinctVertexProperties.java
@@ -33,9 +33,4 @@ public class DistinctVertexProperties extends DistinctProperties<Vertex, String>
   protected DataSet<Tuple2<String, Set<PropertyValue>>> extractValuePairs(LogicalGraph graph) {
     return graph.getVertices().flatMap(new ExtractPropertyValues<>());
   }
-
-  @Override
-  public String getName() {
-    return DistinctVertexProperties.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/DistinctVertexPropertiesByLabel.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/DistinctVertexPropertiesByLabel.java
@@ -35,9 +35,4 @@ public class DistinctVertexPropertiesByLabel
     LogicalGraph graph) {
     return graph.getVertices().flatMap(new ExtractPropertyValuesByLabel<>());
   }
-
-  @Override
-  public String getName() {
-    return DistinctVertexPropertiesByLabel.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/EdgeCount.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/EdgeCount.java
@@ -29,9 +29,4 @@ public class EdgeCount implements UnaryGraphToValueOperator<DataSet<Long>> {
   public DataSet<Long> execute(LogicalGraph graph) {
     return Count.count(graph.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return EdgeCount.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/EdgeLabelDistribution.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/EdgeLabelDistribution.java
@@ -34,9 +34,4 @@ public class EdgeLabelDistribution
   public DataSet<WithCount<String>> execute(LogicalGraph graph) {
     return new EdgeValueDistribution<>(new Label<>()).execute(graph);
   }
-
-  @Override
-  public String getName() {
-    return EdgeLabelDistribution.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/EdgeValueDistribution.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/EdgeValueDistribution.java
@@ -41,9 +41,4 @@ public class EdgeValueDistribution<T> extends ValueDistribution<Edge, T> {
   public DataSet<WithCount<T>> execute(LogicalGraph graph) {
     return compute(graph.getEdges());
   }
-
-  @Override
-  public String getName() {
-    return EdgeValueDistribution.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/IncomingVertexDegreeDistribution.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/IncomingVertexDegreeDistribution.java
@@ -37,9 +37,4 @@ public class IncomingVertexDegreeDistribution
         .<Tuple1<Long>>project(1))
       .map(new Tuple2ToWithCount<>());
   }
-
-  @Override
-  public String getName() {
-    return IncomingVertexDegreeDistribution.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/IncomingVertexDegrees.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/IncomingVertexDegrees.java
@@ -37,9 +37,4 @@ public class IncomingVertexDegrees
       .where(0).equalTo("*")
       .with(new SetOrCreateWithCount());
   }
-
-  @Override
-  public String getName() {
-    return IncomingVertexDegrees.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/OutgoingVertexDegreeDistribution.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/OutgoingVertexDegreeDistribution.java
@@ -37,9 +37,4 @@ public class OutgoingVertexDegreeDistribution
         .<Tuple1<Long>>project(1))
       .map(new Tuple2ToWithCount<>());
   }
-
-  @Override
-  public String getName() {
-    return OutgoingVertexDegreeDistribution.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/OutgoingVertexDegrees.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/OutgoingVertexDegrees.java
@@ -37,9 +37,4 @@ public class OutgoingVertexDegrees
       .where(0).equalTo("*")
       .with(new SetOrCreateWithCount());
   }
-
-  @Override
-  public String getName() {
-    return OutgoingVertexDegrees.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/SourceLabelAndEdgeLabelDistribution.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/SourceLabelAndEdgeLabelDistribution.java
@@ -42,9 +42,4 @@ public class SourceLabelAndEdgeLabelDistribution
       .with(new BothLabels()))
       .map(new Tuple2ToWithCount<>());
   }
-
-  @Override
-  public String getName() {
-    return SourceLabelAndEdgeLabelDistribution.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/TargetLabelAndEdgeLabelDistribution.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/TargetLabelAndEdgeLabelDistribution.java
@@ -42,9 +42,4 @@ public class TargetLabelAndEdgeLabelDistribution
       .with(new BothLabels()))
       .map(new Tuple2ToWithCount<>());
   }
-
-  @Override
-  public String getName() {
-    return TargetLabelAndEdgeLabelDistribution.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/VertexCount.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/VertexCount.java
@@ -29,9 +29,4 @@ public class VertexCount implements UnaryGraphToValueOperator<DataSet<Long>> {
   public DataSet<Long> execute(LogicalGraph graph) {
     return Count.count(graph.getVertices());
   }
-
-  @Override
-  public String getName() {
-    return VertexCount.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/VertexDegreeDistribution.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/VertexDegreeDistribution.java
@@ -37,9 +37,4 @@ public class VertexDegreeDistribution
         .<Tuple1<Long>>project(1))
       .map(new Tuple2ToWithCount<>());
   }
-
-  @Override
-  public String getName() {
-    return VertexDegreeDistribution.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/VertexDegrees.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/VertexDegrees.java
@@ -35,9 +35,4 @@ public class VertexDegrees implements UnaryGraphToValueOperator<DataSet<WithCoun
       .where(0).equalTo(0)
       .with(new SumCounts<>());
   }
-
-  @Override
-  public String getName() {
-    return VertexDegrees.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/VertexLabelDistribution.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/VertexLabelDistribution.java
@@ -34,9 +34,4 @@ public class VertexLabelDistribution
   public DataSet<WithCount<String>> execute(LogicalGraph graph) {
     return new VertexValueDistribution<>(new Label<>()).execute(graph);
   }
-
-  @Override
-  public String getName() {
-    return VertexLabelDistribution.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/VertexValueDistribution.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/VertexValueDistribution.java
@@ -41,9 +41,4 @@ public class VertexValueDistribution<T> extends ValueDistribution<Vertex, T> {
   public DataSet<WithCount<T>> execute(LogicalGraph graph) {
     return compute(graph.getVertices());
   }
-
-  @Override
-  public String getName() {
-    return VertexValueDistribution.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/writer/DistinctEdgePropertiesByLabelPreparer.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/writer/DistinctEdgePropertiesByLabelPreparer.java
@@ -44,9 +44,4 @@ Tuple3<String, String, Long>>> {
         .map(value -> Tuple3.of(value.f0.f0, value.f0.f1, value.f1))
         .returns(new TypeHint<Tuple3<String, String, Long>>() { });
   }
-
-  @Override
-  public String getName() {
-    return DistinctEdgePropertiesByLabelPreparer.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/writer/DistinctSourceVertexCountPreparer.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/writer/DistinctSourceVertexCountPreparer.java
@@ -38,9 +38,4 @@ public class DistinctSourceVertexCountPreparer implements UnaryGraphToValueOpera
         .execute(graph)
         .map(new ObjectTo1<>());
   }
-
-  @Override
-  public String getName() {
-    return DistinctSourceVertexCountPreparer.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/writer/DistinctTargetVertexCountPreparer.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/writer/DistinctTargetVertexCountPreparer.java
@@ -38,9 +38,4 @@ public class DistinctTargetVertexCountPreparer implements UnaryGraphToValueOpera
         .execute(graph)
         .map(new ObjectTo1<>());
   }
-
-  @Override
-  public String getName() {
-    return DistinctTargetVertexCountPreparer.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/writer/DistinctVertexPropertiesByLabelPreparer.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/writer/DistinctVertexPropertiesByLabelPreparer.java
@@ -44,9 +44,4 @@ Tuple3<String, String, Long>>> {
         .map(value -> Tuple3.of(value.f0.f0, value.f0.f1, value.f1))
         .returns(new TypeHint<Tuple3<String, String, Long>>() { });
   }
-
-  @Override
-  public String getName() {
-    return DistinctVertexPropertiesByLabelPreparer.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/writer/EdgeCountPreparer.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/writer/EdgeCountPreparer.java
@@ -38,9 +38,4 @@ public class EdgeCountPreparer implements UnaryGraphToValueOperator<MapOperator<
         .execute(graph)
         .map(new ObjectTo1<>());
   }
-
-  @Override
-  public String getName() {
-    return EdgeCountPreparer.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/writer/SourceAndEdgeLabelDistributionPreparer.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/writer/SourceAndEdgeLabelDistributionPreparer.java
@@ -44,9 +44,4 @@ Tuple3<String, String, Long>>> {
         .map(value -> Tuple3.of(value.f0.f0, value.f0.f1, value.f1))
         .returns(new TypeHint<Tuple3<String, String, Long>>() { });
   }
-
-  @Override
-  public String getName() {
-    return SourceAndEdgeLabelDistributionPreparer.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/writer/TargetAndEdgeLabelDistributionPreparer.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/writer/TargetAndEdgeLabelDistributionPreparer.java
@@ -44,9 +44,4 @@ Tuple3<String, String, Long>>> {
         .map(value -> Tuple3.of(value.f0.f0, value.f0.f1, value.f1))
         .returns(new TypeHint<Tuple3<String, String, Long>>() { });
   }
-
-  @Override
-  public String getName() {
-    return TargetAndEdgeLabelDistributionPreparer.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/writer/VertexCountPreparer.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/writer/VertexCountPreparer.java
@@ -38,9 +38,4 @@ public class VertexCountPreparer implements UnaryGraphToValueOperator<MapOperato
         .execute(graph)
         .map(new ObjectTo1<>());
   }
-
-  @Override
-  public String getName() {
-    return VertexCountPreparer.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/ApplySubgraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/ApplySubgraph.java
@@ -347,9 +347,4 @@ public class ApplySubgraph implements ApplicableUnaryGraphToGraphOperator {
     return collection.getConfig().getGraphCollectionFactory()
       .fromDataSets(newGraphHeads, newVertices, newEdges);
   }
-
-  @Override
-  public String getName() {
-    return ApplySubgraph.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/Subgraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/Subgraph.java
@@ -287,9 +287,4 @@ public class Subgraph<
 
     return subgraph.getFactory().fromDataSets(verifiedVertices, verifiedEdges);
   }
-
-  @Override
-  public String getName() {
-    return Subgraph.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/transformation/Transformation.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/transformation/Transformation.java
@@ -117,9 +117,4 @@ public class Transformation<
 
     return factory.fromDataSets(transformedGraphHeads, transformedVertices, transformedEdges);
   }
-
-  @Override
-  public String getName() {
-    return Transformation.class.getName();
-  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/union/Union.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/union/Union.java
@@ -49,9 +49,4 @@ public class Union extends SetOperatorBase {
       .union(secondCollection.getEdges())
       .distinct(new Id<Edge>());
   }
-
-  @Override
-  public String getName() {
-    return Union.class.getName();
-  }
 }


### PR DESCRIPTION
This provides a default implementation of that method and removes all previous implementations of that method. Previous implementations were:
```java
return ThisClass.class.getName();
```
or 
```java
return ThisClass.class.getSimpleName();
```

fixes #1163 