### PR TITLE
[#974] avoid multiple graph heads to be created using csv source

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/api/DataSource.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/api/DataSource.java
@@ -28,7 +28,7 @@ public interface DataSource {
   /**
    * Reads the input as logical graph.
    *
-   * @return logial graph
+   * @return logical graph
    * @throws IOException on failure
    */
   LogicalGraph getLogicalGraph() throws IOException;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVDataSource.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVDataSource.java
@@ -56,6 +56,8 @@ public class CSVDataSource extends CSVBase implements DataSource {
   /**
    * Will use a single graph head of the collection as final graph head for the graph.
    * Issue #1217 (https://github.com/dbs-leipzig/gradoop/issues/1217) will optimize further.
+   *
+   * {@inheritDoc}
    */
   @Override
   public LogicalGraph getLogicalGraph() {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVDataSource.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVDataSource.java
@@ -27,7 +27,6 @@ import org.gradoop.flink.io.impl.csv.functions.CSVLineToVertex;
 import org.gradoop.flink.io.impl.csv.metadata.CSVMetaDataSource;
 import org.gradoop.flink.model.impl.epgm.GraphCollection;
 import org.gradoop.flink.model.impl.epgm.LogicalGraph;
-import org.gradoop.flink.model.impl.operators.combination.ReduceCombination;
 import org.gradoop.flink.util.GradoopFlinkConfig;
 
 /**
@@ -55,14 +54,15 @@ public class CSVDataSource extends CSVBase implements DataSource {
   }
 
   /**
-   * {@inheritDoc}
-   * <p>
-   * Graph heads will be disposed at the moment. The following issue attempts to provide
-   * alternatives to keep graph heads: https://github.com/dbs-leipzig/gradoop/issues/974
+   * Will use a single graph head of the collection as final graph head for the graph.
+   * Issue #1217 (https://github.com/dbs-leipzig/gradoop/issues/1217) will optimize further.
    */
   @Override
   public LogicalGraph getLogicalGraph() {
-    return getGraphCollection().reduce(new ReduceCombination());
+    GraphCollection collection = getGraphCollection();
+    return getConfig().getLogicalGraphFactory()
+      .fromDataSets(
+        collection.getGraphHeads().first(1), collection.getVertices(), collection.getEdges());
   }
 
   @Override


### PR DESCRIPTION
Switched to factory methods to avoid multiple graph heads to be created and stored on each element.
Further optimizations will be discussed in #1217 

fixes #974 