### PR TITLE
[#1224, #1227] Fix NullPointerException

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSampling.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSampling.java
@@ -142,7 +142,7 @@ public class PageRankSampling extends SamplingAlgorithm {
       .where(new TargetId<>()).equalTo(new Id<>())
       .with(new LeftSide<>());
 
-    graph = graph.getFactory().fromDataSets(scaledVertices, newEdges);
+    graph = graph.getFactory().fromDataSets(graph.getGraphHead(), scaledVertices, newEdges);
 
     return graph;
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSampling.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSampling.java
@@ -16,14 +16,9 @@
 package org.gradoop.flink.model.impl.operators.sampling;
 
 import org.apache.flink.api.java.DataSet;
-import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.Vertex;
 import org.gradoop.flink.algorithms.gelly.pagerank.PageRank;
 import org.gradoop.flink.model.impl.epgm.LogicalGraph;
-import org.gradoop.flink.model.impl.functions.epgm.Id;
-import org.gradoop.flink.model.impl.functions.epgm.SourceId;
-import org.gradoop.flink.model.impl.functions.epgm.TargetId;
-import org.gradoop.flink.model.impl.functions.utils.LeftSide;
 import org.gradoop.flink.model.impl.operators.aggregation.functions.count.VertexCount;
 import org.gradoop.flink.model.impl.operators.aggregation.functions.max.MaxVertexProperty;
 import org.gradoop.flink.model.impl.operators.aggregation.functions.min.MinVertexProperty;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSampling.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSampling.java
@@ -129,7 +129,6 @@ public class PageRankSampling extends SamplingAlgorithm {
       .filter(new PageRankResultVertexFilter(
         threshold, sampleGreaterThanThreshold, keepVerticesIfSameScore));
 
-    return graph.getFactory()
-      .fromDataSets(graph.getGraphHead(), scaledVertices, graph.getEdges()).verify();
+    return graph.getFactory().fromDataSets(scaledVertices, graph.getEdges()).verify();
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSampling.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSampling.java
@@ -134,16 +134,7 @@ public class PageRankSampling extends SamplingAlgorithm {
       .filter(new PageRankResultVertexFilter(
         threshold, sampleGreaterThanThreshold, keepVerticesIfSameScore));
 
-    DataSet<Edge> newEdges = graph.getEdges()
-      .join(scaledVertices)
-      .where(new SourceId<>()).equalTo(new Id<>())
-      .with(new LeftSide<>())
-      .join(scaledVertices)
-      .where(new TargetId<>()).equalTo(new Id<>())
-      .with(new LeftSide<>());
-
-    graph = graph.getFactory().fromDataSets(graph.getGraphHead(), scaledVertices, newEdges);
-
-    return graph;
+    return graph.getFactory()
+      .fromDataSets(graph.getGraphHead(), scaledVertices, graph.getEdges()).verify();
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSamplingTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSamplingTest.java
@@ -15,21 +15,18 @@
  */
 package org.gradoop.flink.model.impl.operators.sampling;
 
-import com.google.common.collect.Lists;
-import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
 import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
 import org.gradoop.flink.model.impl.epgm.LogicalGraph;
 import org.gradoop.flink.model.impl.operators.sampling.common.SamplingConstants;
+import org.junit.Test;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -66,89 +63,67 @@ public class PageRankSamplingTest extends ParameterizedTestForGraphSampling {
   }
 
   @Override
-  public void validateSpecific(LogicalGraph input, LogicalGraph output) {
+  public void validateSpecific(LogicalGraph input, LogicalGraph output) throws Exception {
 
-    try {
-      // test normal graph
-      GraphHead normalGh = output.getGraphHead().collect().get(0);
-      double minScore = normalGh.getPropertyValue(SamplingConstants.MIN_PAGE_RANK_SCORE_PROPERTY_KEY)
-        .getDouble();
-      double maxScore = normalGh.getPropertyValue(SamplingConstants.MAX_PAGE_RANK_SCORE_PROPERTY_KEY)
-        .getDouble();
-      if (minScore != maxScore) {
-        for (Vertex v : newVertices) {
-          assertTrue("vertex does not have scaled PageRank-score property (should have):" +
-            v.toString(), v.hasProperty(SamplingConstants.SCALED_PAGE_RANK_SCORE_PROPERTY_KEY));
+    // test normal graph
+    GraphHead normalGh = output.getGraphHead().collect().get(0);
+    double minScore = normalGh.getPropertyValue(SamplingConstants.MIN_PAGE_RANK_SCORE_PROPERTY_KEY)
+      .getDouble();
+    double maxScore = normalGh.getPropertyValue(SamplingConstants.MAX_PAGE_RANK_SCORE_PROPERTY_KEY)
+      .getDouble();
+    if (minScore != maxScore) {
+      for (Vertex v : newVertices) {
+        assertTrue("vertex does not have scaled PageRank-score property (should have):" +
+          v.toString(), v.hasProperty(SamplingConstants.SCALED_PAGE_RANK_SCORE_PROPERTY_KEY));
 
-          if (v.hasProperty(SamplingConstants.SCALED_PAGE_RANK_SCORE_PROPERTY_KEY)) {
-            double score = v.getPropertyValue(SamplingConstants.SCALED_PAGE_RANK_SCORE_PROPERTY_KEY)
-              .getDouble();
-            if (sampleGreaterThanThreshold) {
-              assertTrue("sampled vertex has PageRankScore smaller or equal than threshold",
-                score > sampleSize);
-            } else {
-              assertTrue("sampled vertex has PageRankScore greater than threshold",
-                score <= sampleSize);
-            }
+        if (v.hasProperty(SamplingConstants.SCALED_PAGE_RANK_SCORE_PROPERTY_KEY)) {
+          double score = v.getPropertyValue(SamplingConstants.SCALED_PAGE_RANK_SCORE_PROPERTY_KEY)
+            .getDouble();
+          if (sampleGreaterThanThreshold) {
+            assertTrue("sampled vertex has PageRankScore smaller or equal than threshold",
+              score > sampleSize);
+          } else {
+            assertTrue("sampled vertex has PageRankScore greater than threshold",
+              score <= sampleSize);
           }
         }
-      } else {
-        if (keepVerticesIfSameScore) {
-          assertEquals("not all vertices got sampled (should be, all got same score)",
-            dbVertices.size(), newVertices.size());
-        } else {
-          assertTrue("some vertices got sampled (should NOT be, all got same score)",
-            newVertices.isEmpty());
-        }
       }
-      dbEdges.removeAll(newEdges);
-      for (Edge edge : dbEdges) {
-        assertFalse("edge from original graph was not sampled but source and target were",
-          newVertexIDs.contains(edge.getSourceId()) &&
-            newVertexIDs.contains(edge.getTargetId()));
-      }
-
-      // test special graph
-      LogicalGraph specialGraph = getLoaderFromString(
-        "(alice:Person {name : \"Alice\"})\n" +
-          "(eve:Person {name : \"Eve\"})\n" +
-          "g0:Community {interest : \"Friends\", vertexCount : 2} [\n" +
-          "(eve)-[eka:knows {since : 2013}]->(alice)\n" +
-          "(alice)-[ake:knows {since : 2013}]->(eve)]").getLogicalGraphByVariable("g0");
-
-      LogicalGraph sampledGraph = getSamplingOperator().sample(specialGraph);
-
-      List<Vertex> specialVertices = Lists.newArrayList();
-      List<Vertex> specialSampledVertices = Lists.newArrayList();
-
-      specialGraph.getVertices().output(new LocalCollectionOutputFormat<>(specialVertices));
-      sampledGraph.getVertices().output(new LocalCollectionOutputFormat<>(specialSampledVertices));
-
-      getExecutionEnvironment().execute();
-
-      assertNotNull("graph was null", sampledGraph);
-
-      GraphHead specialGh = sampledGraph.getGraphHead().collect().get(0);
-      double minScore1 = specialGh.getPropertyValue(
-        SamplingConstants.MIN_PAGE_RANK_SCORE_PROPERTY_KEY).getDouble();
-      double maxScore1 = specialGh.getPropertyValue(
-        SamplingConstants.MAX_PAGE_RANK_SCORE_PROPERTY_KEY).getDouble();
-
-      assertEquals("min PageRankScore is not equal to max PageRankScore",
-        minScore1, maxScore1, 0.0);
-
+    } else {
       if (keepVerticesIfSameScore) {
-        assertEquals(
-          "special: not all vertices got sampled (should be, all got same score)",
-          specialVertices.size(), specialSampledVertices.size());
+        assertEquals("not all vertices got sampled (should be, all got same score)",
+          dbVertices.size(), newVertices.size());
       } else {
-        assertTrue(
-          "special: some vertices got sampled (should NOT be, all got same score)",
-          specialSampledVertices.isEmpty());
+        assertTrue("some vertices got sampled (should NOT be, all got same score)",
+          newVertices.isEmpty());
       }
-    } catch (Exception e) {
-      e.printStackTrace();
     }
+    dbEdges.removeAll(newEdges);
+    for (Edge edge : dbEdges) {
+      assertFalse("edge from original graph was not sampled but source and target were",
+        newVertexIDs.contains(edge.getSourceId()) &&
+          newVertexIDs.contains(edge.getTargetId()));
+    }
+  }
+
+  /**
+   * Test special graph with the same page rank score for each vertex.
+   *
+   * @throws Exception on failure
+   */
+  @Test
+  public void testGraphWithSameScore() throws Exception {
+    // test special graph
+    LogicalGraph specialGraph = getLoaderFromString(
+      "(alice:Person {name : \"Alice\"})\n" +
+        "(eve:Person {name : \"Eve\"})\n" +
+        "g0:Community {interest : \"Friends\", vertexCount : 2} [\n" +
+        "(eve)-[eka:knows {since : 2013}]->(alice)\n" +
+        "(alice)-[ake:knows {since : 2013}]->(eve)]").getLogicalGraphByVariable("g0");
+
+    LogicalGraph sampledGraph = getSamplingOperator().sample(specialGraph);
+
+    validateGraph(specialGraph, sampledGraph);
+    validateSpecific(specialGraph, sampledGraph);
   }
 
   /**

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSamplingTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSamplingTest.java
@@ -73,7 +73,7 @@ public class PageRankSamplingTest extends ParameterizedTestForGraphSampling {
       .getDouble();
     if (minScore != maxScore) {
       for (Vertex v : newVertices) {
-        assertTrue("vertex does not have scaled PageRank-score property (should have):" +
+        assertTrue("vertex does not have scaled PageRank-score property (should have): " +
           v.toString(), v.hasProperty(SamplingConstants.SCALED_PAGE_RANK_SCORE_PROPERTY_KEY));
 
         if (v.hasProperty(SamplingConstants.SCALED_PAGE_RANK_SCORE_PROPERTY_KEY)) {

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSamplingTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSamplingTest.java
@@ -76,16 +76,14 @@ public class PageRankSamplingTest extends ParameterizedTestForGraphSampling {
         assertTrue("vertex does not have scaled PageRank-score property (should have): " +
           v.toString(), v.hasProperty(SamplingConstants.SCALED_PAGE_RANK_SCORE_PROPERTY_KEY));
 
-        if (v.hasProperty(SamplingConstants.SCALED_PAGE_RANK_SCORE_PROPERTY_KEY)) {
-          double score = v.getPropertyValue(SamplingConstants.SCALED_PAGE_RANK_SCORE_PROPERTY_KEY)
-            .getDouble();
-          if (sampleGreaterThanThreshold) {
-            assertTrue("sampled vertex has PageRankScore smaller or equal than threshold",
-              score > sampleSize);
-          } else {
-            assertTrue("sampled vertex has PageRankScore greater than threshold",
-              score <= sampleSize);
-          }
+        double score = v.getPropertyValue(SamplingConstants.SCALED_PAGE_RANK_SCORE_PROPERTY_KEY)
+          .getDouble();
+        if (sampleGreaterThanThreshold) {
+          assertTrue("sampled vertex has PageRankScore smaller or equal than threshold",
+            score > sampleSize);
+        } else {
+          assertTrue("sampled vertex has PageRankScore greater than threshold",
+            score <= sampleSize);
         }
       }
     } else {

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSamplingTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSamplingTest.java
@@ -79,9 +79,11 @@ public class PageRankSamplingTest extends ParameterizedTestForGraphSampling {
       noneHasScore || allHaveScore);
 
     if (newVertices.isEmpty()) {
+      // Result is empty, if input is empty
+      // OR all have the same score and keepVerticesIfSameScore = false
       assertTrue("some vertices got sampled (should NOT be)",
         dbVertices.isEmpty() || !keepVerticesIfSameScore);
-    } else if (allHaveScore) {
+    } else if (allHaveScore) { // normal case
       for (Vertex v : newVertices) {
         double score = v.getPropertyValue(SamplingConstants.SCALED_PAGE_RANK_SCORE_PROPERTY_KEY)
           .getDouble();
@@ -93,7 +95,7 @@ public class PageRankSamplingTest extends ParameterizedTestForGraphSampling {
             score <= sampleSize);
         }
       }
-    } else if (keepVerticesIfSameScore) {
+    } else if (keepVerticesIfSameScore) { // and noneHasScore
       assertEquals("not all vertices got sampled (should be, all got same score)",
         dbVertices.size(), newVertices.size());
     }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/sampling/ParameterizedTestForGraphSampling.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/sampling/ParameterizedTestForGraphSampling.java
@@ -260,5 +260,5 @@ public abstract class ParameterizedTestForGraphSampling extends GradoopFlinkTest
    * @param input The input graph
    * @param output The sampled graph
    */
-  public abstract void validateSpecific(LogicalGraph input, LogicalGraph output) throws Exception;
+  public abstract void validateSpecific(LogicalGraph input, LogicalGraph output);
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/sampling/ParameterizedTestForGraphSampling.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/sampling/ParameterizedTestForGraphSampling.java
@@ -223,7 +223,7 @@ public abstract class ParameterizedTestForGraphSampling extends GradoopFlinkTest
    * @param input The input graph
    * @param output The sampled graph
    */
-  private void validateGraph(LogicalGraph input, LogicalGraph output) throws Exception {
+  void validateGraph(LogicalGraph input, LogicalGraph output) throws Exception {
     dbVertices = Lists.newArrayList();
     dbEdges = Lists.newArrayList();
     newVertices = Lists.newArrayList();
@@ -260,5 +260,5 @@ public abstract class ParameterizedTestForGraphSampling extends GradoopFlinkTest
    * @param input The input graph
    * @param output The sampled graph
    */
-  public abstract void validateSpecific(LogicalGraph input, LogicalGraph output);
+  public abstract void validateSpecific(LogicalGraph input, LogicalGraph output) throws Exception;
 }


### PR DESCRIPTION
 - Split the two test graphs into two different tests
 - Pass old graph head to output graph (fixes `NullPointerException`, related: #1236 )
 - Remove try/catch
 - Use verify operator to create new edges

Fixes #1224
Fixes #1227 