### PR TITLE
[#1256] Exclude mockito-all dependency from CAPF.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -639,6 +639,10 @@
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-nop</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-all</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 


### PR DESCRIPTION
fixes #1256 