### PR TITLE
[#1298][#1299]  Added GC Type to BaseGraph and generified GDL print method   

### DIFF
--- a/gradoop-data-integration/src/main/java/org/gradoop/dataintegration/transformation/impl/PropertyTransformation.java
+++ b/gradoop-data-integration/src/main/java/org/gradoop/dataintegration/transformation/impl/PropertyTransformation.java
@@ -20,6 +20,7 @@ import org.gradoop.common.model.api.entities.EPGMGraphHead;
 import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.flink.model.api.epgm.BaseGraph;
 import org.gradoop.dataintegration.transformation.api.PropertyTransformationFunction;
+import org.gradoop.flink.model.api.epgm.BaseGraphCollection;
 import org.gradoop.flink.model.api.operators.UnaryBaseGraphToBaseGraphOperator;
 import org.gradoop.flink.model.impl.operators.transformation.Transformation;
 
@@ -33,12 +34,14 @@ import org.gradoop.flink.model.impl.operators.transformation.Transformation;
  * @param <V> the vertex type
  * @param <E> the edge type
  * @param <LG> type of the logical graph instance
+ * @param <GC> type of the graph collection instance
  */
 public class PropertyTransformation<
   G extends EPGMGraphHead,
   V extends EPGMVertex,
   E extends EPGMEdge,
-  LG extends BaseGraph<G, V, E, LG>> implements UnaryBaseGraphToBaseGraphOperator<LG> {
+  LG extends BaseGraph<G, V, E, LG, GC>,
+  GC extends BaseGraphCollection<G, V, E, GC>> implements UnaryBaseGraphToBaseGraphOperator<LG> {
 
   /**
    * Label of the element whose property shall be transformed.
@@ -130,7 +133,7 @@ public class PropertyTransformation<
    */
   @Override
   public LG execute(LG graph) {
-    return new Transformation<G, V, E, LG>(
+    return new Transformation<G, V, E, LG, GC>(
         graphHeadTransformationFunction == null ? null : new BasePropertyTransformationFunction<>(
             propertyKey, graphHeadTransformationFunction, label, newPropertyKey, keepHistory),
         vertexTransformationFunction == null ? null : new BasePropertyTransformationFunction<>(

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVDataSink.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVDataSink.java
@@ -77,7 +77,7 @@ public class CSVDataSink extends CSVBase implements DataSink {
 
   @Override
   public void write(LogicalGraph logicalGraph, boolean overwrite) throws IOException {
-    write(logicalGraph.getConfig().getGraphCollectionFactory().fromGraph(logicalGraph), overwrite);
+    write(logicalGraph.getCollectionFactory().fromGraph(logicalGraph), overwrite);
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVDataSink.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVDataSink.java
@@ -77,7 +77,7 @@ public class CSVDataSink extends CSVBase implements DataSink {
 
   @Override
   public void write(LogicalGraph logicalGraph, boolean overwrite) throws IOException {
-    write(logicalGraph.getCollectionFactory().fromGraph(logicalGraph), overwrite);
+    write(logicalGraph.getConfig().getGraphCollectionFactory().fromGraph(logicalGraph), overwrite);
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/gdl/GDLConsoleOutput.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/gdl/GDLConsoleOutput.java
@@ -37,7 +37,7 @@ public class GDLConsoleOutput {
    * @param <G>   the graph head type
    * @param <V>   the vertex type
    * @param <E>   the edge type
-   * @param <LG>  the type of the logical graph that will be created with this factory
+   * @param <LG>  the type of the logical graph instance
    * @param <GC>  the type of the according graph collection
    * @throws Exception Forwarded from flink execute.
    */
@@ -59,7 +59,7 @@ public class GDLConsoleOutput {
    * @param <G>        the graph head type
    * @param <V>        the vertex type
    * @param <E>        the edge type
-   * @param <GC>       the type of the according graph collection
+   * @param <GC>       the type of the graph collection
    * @throws Exception Forwarded from flink execute.
    */
   public static <

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/gdl/GDLConsoleOutput.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/gdl/GDLConsoleOutput.java
@@ -16,12 +16,11 @@
 package org.gradoop.flink.io.impl.gdl;
 
 import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
-import org.gradoop.common.model.impl.pojo.Edge;
-import org.gradoop.common.model.impl.pojo.GraphHead;
-import org.gradoop.common.model.impl.pojo.Vertex;
-import org.gradoop.flink.model.impl.epgm.GraphCollection;
-import org.gradoop.flink.model.impl.epgm.GraphCollectionFactory;
-import org.gradoop.flink.model.impl.epgm.LogicalGraph;
+import org.gradoop.common.model.api.entities.EPGMEdge;
+import org.gradoop.common.model.api.entities.EPGMGraphHead;
+import org.gradoop.common.model.api.entities.EPGMVertex;
+import org.gradoop.flink.model.api.epgm.BaseGraph;
+import org.gradoop.flink.model.api.epgm.BaseGraphCollection;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,35 +33,54 @@ public class GDLConsoleOutput {
   /**
    * Prints the logical graph to the standard output.
    *
-   * @param logicalGraph The logical graph that is supposed to be printed.
+   * @param graph The logical graph that is supposed to be printed.
+   * @param <G>   the graph head type
+   * @param <V>   the vertex type
+   * @param <E>   the edge type
+   * @param <LG>  the type of the logical graph that will be created with this factory
+   * @param <GC>  the type of the according graph collection
    * @throws Exception Forwarded from flink execute.
    */
-  public static void print(LogicalGraph logicalGraph) throws Exception {
-    GraphCollectionFactory collectionFactory = logicalGraph.getConfig().getGraphCollectionFactory();
-    GraphCollection graphCollection = collectionFactory.fromGraph(logicalGraph);
+  public static <
+    G extends EPGMGraphHead,
+    V extends EPGMVertex,
+    E extends EPGMEdge,
+    LG extends BaseGraph<G, V, E, LG, GC>,
+    GC extends BaseGraphCollection<G, V, E, GC>> void print(BaseGraph<G, V, E, LG, GC> graph)
+    throws Exception {
 
-    print(graphCollection);
+    print(graph.getCollectionFactory().fromGraph(graph));
   }
 
   /**
    * Prints the graph collection to the standard output.
    *
-   * @param graphCollection The graph collection that is supposed to be printed.
+   * @param collection The graph collection that is supposed to be printed.
+   * @param <G>        the graph head type
+   * @param <V>        the vertex type
+   * @param <E>        the edge type
+   * @param <GC>       the type of the according graph collection
    * @throws Exception Forwarded from flink execute.
    */
-  public static void print(GraphCollection graphCollection) throws Exception {
-    List<GraphHead> graphHeads = new ArrayList<>();
-    graphCollection.getGraphHeads().output(new LocalCollectionOutputFormat<>(graphHeads));
+  public static <
+    G extends EPGMGraphHead,
+    V extends EPGMVertex,
+    E extends EPGMEdge,
+    GC extends BaseGraphCollection<G, V, E, GC>> void print(
+      BaseGraphCollection<G, V, E, GC> collection) throws Exception {
 
-    List<Vertex> vertices = new ArrayList<>();
-    graphCollection.getVertices().output(new LocalCollectionOutputFormat<>(vertices));
+    List<G> graphHeads = new ArrayList<>();
+    collection.getGraphHeads().output(new LocalCollectionOutputFormat<>(graphHeads));
 
-    List<Edge> edges = new ArrayList<>();
-    graphCollection.getEdges().output(new LocalCollectionOutputFormat<>(edges));
+    List<V> vertices = new ArrayList<>();
+    collection.getVertices().output(new LocalCollectionOutputFormat<>(vertices));
 
-    graphCollection.getConfig().getExecutionEnvironment().execute();
+    List<E> edges = new ArrayList<>();
+    collection.getEdges().output(new LocalCollectionOutputFormat<>(edges));
 
-    GDLEncoder encoder = new GDLEncoder(graphHeads, vertices, edges);
+    collection.getConfig().getExecutionEnvironment().execute();
+
+    GDLEncoder encoder = new GDLEncoder<>(graphHeads, vertices, edges);
     String graphString = encoder.getGDLString();
 
     System.out.println(graphString);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/gdl/GDLEncoder.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/gdl/GDLEncoder.java
@@ -37,10 +37,7 @@ import java.util.stream.Collectors;
  * @param <V> vertex type
  * @param <E> edge type
  */
-public class GDLEncoder<
-  G extends EPGMGraphHead,
-  V extends EPGMVertex,
-  E extends EPGMEdge> {
+public class GDLEncoder<G extends EPGMGraphHead, V extends EPGMVertex, E extends EPGMEdge> {
 
   /**
    * Marks the beginning of the definition of vertices and edges.
@@ -252,8 +249,8 @@ public class GDLEncoder<
    * @param firstOccurrence Is it the first occurrence of the vertex in all graphs?
    * @return A GDL formatted vertex string.
    */
-  private String vertexToGDLString(
-    V vertex, Map<GradoopId, String> idToVertexName, boolean firstOccurrence) {
+  private String vertexToGDLString(V vertex, Map<GradoopId, String> idToVertexName,
+    boolean firstOccurrence) {
     if (firstOccurrence) {
       return String.format("(%s:%s %s)",
         idToVertexName.get(vertex.getId()),

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/gdl/GDLEncoder.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/gdl/GDLEncoder.java
@@ -15,10 +15,10 @@
  */
 package org.gradoop.flink.io.impl.gdl;
 
+import org.gradoop.common.model.api.entities.EPGMEdge;
+import org.gradoop.common.model.api.entities.EPGMGraphHead;
+import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.pojo.Edge;
-import org.gradoop.common.model.impl.pojo.GraphHead;
-import org.gradoop.common.model.impl.pojo.Vertex;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.common.model.impl.properties.Property;
 import org.gradoop.common.model.impl.properties.PropertyValue;
@@ -32,8 +32,16 @@ import java.util.stream.Collectors;
 
 /**
  * Encodes data structures using the GDL format.
+ *
+ * @param <G> graph head type
+ * @param <V> vertex type
+ * @param <E> edge type
  */
-public class GDLEncoder {
+public class GDLEncoder<
+  G extends EPGMGraphHead,
+  V extends EPGMVertex,
+  E extends EPGMEdge> {
+
   /**
    * Marks the beginning of the definition of vertices and edges.
    */
@@ -98,15 +106,15 @@ public class GDLEncoder {
   /**
    * Graph head to encode.
    */
-  private List<GraphHead> graphHeads;
+  private List<G> graphHeads;
   /**
    * Vertices to encode.
    */
-  private List<Vertex> vertices;
+  private List<V> vertices;
   /**
    * Edges to encode.
    */
-  private List<Edge> edges;
+  private List<E> edges;
 
   /**
    * Creates a GDLEncoder using the passed parameters.
@@ -115,7 +123,7 @@ public class GDLEncoder {
    * @param vertices vertices that should be encoded
    * @param edges edges that should be encoded
    */
-  public GDLEncoder(List<GraphHead> graphHeads, List<Vertex> vertices, List<Edge> edges) {
+  public GDLEncoder(List<G> graphHeads, List<V> vertices, List<E> edges) {
     this.graphHeads = graphHeads;
     this.vertices = vertices;
     this.edges = edges;
@@ -136,32 +144,32 @@ public class GDLEncoder {
 
     StringBuilder result = new StringBuilder();
 
-    for (GraphHead gh : graphHeads) {
+    for (G graphHead : graphHeads) {
       StringBuilder verticesString = new StringBuilder();
       StringBuilder edgesString = new StringBuilder();
 
-      for (Vertex v : vertices) {
-        boolean containedInGraph = v.getGraphIds().contains(gh.getId());
-        boolean firstOccurrence = !usedVertexIds.contains(v.getId());
+      for (V vertex : vertices) {
+        boolean containedInGraph = vertex.getGraphIds().contains(graphHead.getId());
+        boolean firstOccurrence = !usedVertexIds.contains(vertex.getId());
 
         if (containedInGraph) {
-          String vertexString = vertexToGDLString(v, idToVertexName, firstOccurrence);
-          usedVertexIds.add(v.getId());
+          String vertexString = vertexToGDLString(vertex, idToVertexName, firstOccurrence);
+          usedVertexIds.add(vertex.getId());
           verticesString.append(vertexString).append(System.lineSeparator());
         }
       }
 
-      for (Edge e : edges) {
-        if (e.getGraphIds().contains(gh.getId())) {
-          boolean firstOccurrence = !usedEdgeIds.contains(e.getId());
-          String edgeString = edgeToGDLString(e, idToVertexName, idToEdgeName, firstOccurrence);
-          usedEdgeIds.add(e.getId());
+      for (E edge : edges) {
+        if (edge.getGraphIds().contains(graphHead.getId())) {
+          boolean firstOccurrence = !usedEdgeIds.contains(edge.getId());
+          String edgeString = edgeToGDLString(edge, idToVertexName, idToEdgeName, firstOccurrence);
+          usedEdgeIds.add(edge.getId());
           edgesString.append(edgeString).append(System.lineSeparator());
         }
       }
 
       result
-        .append(graphHeadToGDLString(gh, idToGraphHeadName))
+        .append(graphHeadToGDLString(graphHead, idToGraphHeadName))
         .append(GRAPH_ELEMENTS_DEFINITION_START).append(System.lineSeparator())
         .append(verticesString)
         .append(edgesString.length() > 0 ? System.lineSeparator() : "")
@@ -178,12 +186,12 @@ public class GDLEncoder {
    * @param graphHeads The graph heads.
    * @return Mapping between graph head and GDL variable name.
    */
-  private Map<GradoopId, String> getGraphHeadNameMapping(List<GraphHead> graphHeads) {
+  private Map<GradoopId, String> getGraphHeadNameMapping(List<G> graphHeads) {
     Map<GradoopId, String> idToGraphHeadName = new HashMap<>(graphHeads.size());
     for (int i = 0; i < graphHeads.size(); i++) {
-      GraphHead g = graphHeads.get(i);
+      G graphHead = graphHeads.get(i);
       String gName = String.format("%s%s", GRAPH_VARIABLE_PREFIX, i);
-      idToGraphHeadName.put(g.getId(), gName);
+      idToGraphHeadName.put(graphHead.getId(), gName);
     }
     return idToGraphHeadName;
   }
@@ -194,12 +202,12 @@ public class GDLEncoder {
    * @param vertices The graph vertices.
    * @return Mapping between vertex and GDL variable name.
    */
-  private Map<GradoopId, String> getVertexNameMapping(List<Vertex> vertices) {
+  private Map<GradoopId, String> getVertexNameMapping(List<V> vertices) {
     Map<GradoopId, String> idToVertexName = new HashMap<>(vertices.size());
     for (int i = 0; i < vertices.size(); i++) {
-      Vertex v = vertices.get(i);
-      String vName = String.format("%s_%s_%s", VERTEX_VARIABLE_PREFIX, v.getLabel(), i);
-      idToVertexName.put(v.getId(), vName);
+      V vertex = vertices.get(i);
+      String vName = String.format("%s_%s_%s", VERTEX_VARIABLE_PREFIX, vertex.getLabel(), i);
+      idToVertexName.put(vertex.getId(), vName);
     }
     return idToVertexName;
   }
@@ -210,12 +218,12 @@ public class GDLEncoder {
    * @param edges The graph edges.
    * @return Mapping between edge and GDL variable name.
    */
-  private Map<GradoopId, String> getEdgeNameMapping(List<Edge> edges) {
+  private Map<GradoopId, String> getEdgeNameMapping(List<E> edges) {
     Map<GradoopId, String> idToEdgeName = new HashMap<>(edges.size());
     for (int i = 0; i < edges.size(); i++) {
-      Edge e = edges.get(i);
-      String eName = String.format("%s_%s_%s", EDGE_VARIABLE_PREFIX, e.getLabel(), i);
-      idToEdgeName.put(e.getId(), eName);
+      E edge = edges.get(i);
+      String eName = String.format("%s_%s_%s", EDGE_VARIABLE_PREFIX, edge.getLabel(), i);
+      idToEdgeName.put(edge.getId(), eName);
     }
     return idToEdgeName;
   }
@@ -223,15 +231,15 @@ public class GDLEncoder {
   /**
    * Returns a GDL formatted graph head string.
    *
-   * @param g graph head
+   * @param graphhead graph head
    * @param idToGraphHeadName mapping from graph head id to its GDL variable name
    * @return GDL formatted string
    */
-  private String graphHeadToGDLString(GraphHead g, Map<GradoopId, String> idToGraphHeadName) {
+  private String graphHeadToGDLString(G graphhead, Map<GradoopId, String> idToGraphHeadName) {
     return String.format("%s:%s %s",
-      idToGraphHeadName.get(g.getId()),
-      g.getLabel(),
-      propertiesToGDLString(g.getProperties()));
+      idToGraphHeadName.get(graphhead.getId()),
+      graphhead.getLabel(),
+      propertiesToGDLString(graphhead.getProperties()));
   }
 
   /**
@@ -245,9 +253,7 @@ public class GDLEncoder {
    * @return A GDL formatted vertex string.
    */
   private String vertexToGDLString(
-    Vertex vertex,
-    Map<GradoopId, String> idToVertexName,
-    boolean firstOccurrence) {
+    V vertex, Map<GradoopId, String> idToVertexName, boolean firstOccurrence) {
     if (firstOccurrence) {
       return String.format("(%s:%s %s)",
         idToVertexName.get(vertex.getId()),
@@ -270,11 +276,8 @@ public class GDLEncoder {
    * @param firstOccurrence Is it the first occurrence of the edge in all graphs?
    * @return A GDL formatted edge string.
    */
-  private String edgeToGDLString(
-    Edge edge,
-    Map<GradoopId, String> idToVertexName,
-    Map<GradoopId, String> idToEdgeName,
-    boolean firstOccurrence) {
+  private String edgeToGDLString(E edge, Map<GradoopId, String> idToVertexName,
+    Map<GradoopId, String> idToEdgeName, boolean firstOccurrence) {
     String result;
     if (firstOccurrence) {
       result =  String.format("(%s)-[%s:%s%s]->(%s)",

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraph.java
@@ -28,12 +28,14 @@ import org.gradoop.flink.util.GradoopFlinkConfig;
  * @param <V> the vertex type
  * @param <E> the edge type
  * @param <LG> the type of the logical graph that will be created with a provided factory
+ * @param <GC> the type of the graph collection that will be created with a provided factory
  */
 public interface BaseGraph<
   G extends EPGMGraphHead,
   V extends EPGMVertex,
   E extends EPGMEdge,
-  LG extends BaseGraph<G, V, E, LG>> extends LogicalGraphLayout<G, V, E> {
+  LG extends BaseGraph<G, V, E, LG, GC>,
+  GC extends BaseGraphCollection<G, V, E, GC>> extends LogicalGraphLayout<G, V, E> {
   /**
    * Returns the Gradoop Flink configuration.
    *
@@ -46,5 +48,14 @@ public interface BaseGraph<
    *
    * @return a factory that can be used to create a {@link LG} instance
    */
-  BaseGraphFactory<G, V, E, LG> getFactory();
+  BaseGraphFactory<G, V, E, LG, GC> getFactory();
+
+  /**
+   * Get the factory that is responsible for creating an instance of a graph collection of type
+   * {@link GC}.
+   *
+   * @return a factory that can be used to create {@link GC} instance.
+   */
+  BaseGraphCollectionFactory<G, V, E, GC> getCollectionFactory();
+
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraph.java
@@ -54,7 +54,7 @@ public interface BaseGraph<
    * Get the factory that is responsible for creating an instance of a graph collection of type
    * {@link GC}.
    *
-   * @return a factory that can be used to create {@link GC} instance.
+   * @return a factory that can be used to create a {@link GC} instance.
    */
   BaseGraphCollectionFactory<G, V, E, GC> getCollectionFactory();
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraphCollectionFactory.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraphCollectionFactory.java
@@ -22,6 +22,7 @@ import org.gradoop.common.model.api.entities.EPGMGraphHead;
 import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.common.model.api.entities.ElementFactoryProvider;
 import org.gradoop.flink.model.api.layouts.GraphCollectionLayoutFactory;
+import org.gradoop.flink.model.api.layouts.LogicalGraphLayout;
 import org.gradoop.flink.model.impl.epgm.LogicalGraph;
 import org.gradoop.flink.model.impl.layouts.transactional.tuples.GraphTransaction;
 
@@ -97,7 +98,7 @@ public interface BaseGraphCollectionFactory<
    * @param logicalGraphLayout  input graph
    * @return 1-element graph collection
    */
-  GC fromGraph(LogicalGraph logicalGraphLayout);
+  GC fromGraph(LogicalGraphLayout<G, V, E> logicalGraphLayout);
 
   /**
    * Creates a graph collection from multiple given logical graphs.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraphFactory.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraphFactory.java
@@ -33,12 +33,14 @@ import java.util.Map;
  * @param <V> the vertex type
  * @param <E> the edge type
  * @param <LG> the type of the logical graph that will be created with this factory
+ * @param <GC> the type of the according graph collection
  */
 public interface BaseGraphFactory<
   G extends EPGMGraphHead,
   V extends EPGMVertex,
   E extends EPGMEdge,
-  LG extends BaseGraph<G, V, E, LG>> extends ElementFactoryProvider<G, V, E> {
+  LG extends BaseGraph<G, V, E, LG, GC>,
+  GC extends BaseGraphCollection<G, V, E, GC>> extends ElementFactoryProvider<G, V, E> {
 
   /**
    * Sets the layout factory that is responsible for creating a graph layout.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/epgm/GraphCollectionFactory.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/epgm/GraphCollectionFactory.java
@@ -26,6 +26,7 @@ import org.gradoop.common.model.impl.pojo.Vertex;
 import org.gradoop.flink.model.api.epgm.BaseGraphCollectionFactory;
 import org.gradoop.flink.model.api.layouts.GraphCollectionLayout;
 import org.gradoop.flink.model.api.layouts.GraphCollectionLayoutFactory;
+import org.gradoop.flink.model.api.layouts.LogicalGraphLayout;
 import org.gradoop.flink.model.impl.functions.epgm.Id;
 import org.gradoop.flink.model.impl.layouts.transactional.tuples.GraphTransaction;
 import org.gradoop.flink.util.GradoopFlinkConfig;
@@ -123,7 +124,7 @@ public class GraphCollectionFactory
   }
 
   @Override
-  public GraphCollection fromGraph(LogicalGraph logicalGraphLayout) {
+  public GraphCollection fromGraph(LogicalGraphLayout<GraphHead, Vertex, Edge> logicalGraphLayout) {
     return new GraphCollection(layoutFactory.fromGraphLayout(logicalGraphLayout), config);
   }
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/epgm/LogicalGraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/epgm/LogicalGraph.java
@@ -25,6 +25,7 @@ import org.gradoop.common.model.impl.pojo.Vertex;
 import org.gradoop.flink.io.api.DataSink;
 import org.gradoop.flink.io.impl.gdl.GDLConsoleOutput;
 import org.gradoop.flink.model.api.epgm.BaseGraph;
+import org.gradoop.flink.model.api.epgm.BaseGraphCollectionFactory;
 import org.gradoop.flink.model.api.epgm.BaseGraphFactory;
 import org.gradoop.flink.model.api.epgm.LogicalGraphOperators;
 import org.gradoop.flink.model.api.functions.AggregateFunction;
@@ -90,8 +91,8 @@ import java.util.Objects;
  * represented in Apache Flink. Note that the LogicalGraph also implements that interface and
  * just forward the calls to the layout. This is just for convenience and API synchronicity.
  */
-public class LogicalGraph implements BaseGraph<GraphHead, Vertex, Edge, LogicalGraph>,
-  LogicalGraphOperators {
+public class LogicalGraph implements
+  BaseGraph<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>, LogicalGraphOperators {
   /**
    * Layout for that logical graph.
    */
@@ -124,8 +125,14 @@ public class LogicalGraph implements BaseGraph<GraphHead, Vertex, Edge, LogicalG
   }
 
   @Override
-  public BaseGraphFactory<GraphHead, Vertex, Edge, LogicalGraph> getFactory() {
+  public BaseGraphFactory<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection> getFactory() {
     return config.getLogicalGraphFactory();
+  }
+
+  @Override
+  public BaseGraphCollectionFactory<GraphHead, Vertex, Edge, GraphCollection>
+  getCollectionFactory() {
+    return config.getGraphCollectionFactory();
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/epgm/LogicalGraphFactory.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/epgm/LogicalGraphFactory.java
@@ -35,7 +35,7 @@ import java.util.Objects;
  * {@link org.gradoop.flink.model.api.layouts.LogicalGraphLayout}.
  */
 public class LogicalGraphFactory
-  implements BaseGraphFactory<GraphHead, Vertex, Edge, LogicalGraph> {
+  implements BaseGraphFactory<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection> {
   /**
    * Creates the layout from given data.
    */

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/Aggregation.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/Aggregation.java
@@ -21,6 +21,7 @@ import org.gradoop.common.model.api.entities.EPGMGraphHead;
 import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.common.model.impl.properties.PropertyValue;
 import org.gradoop.flink.model.api.epgm.BaseGraph;
+import org.gradoop.flink.model.api.epgm.BaseGraphCollection;
 import org.gradoop.flink.model.api.functions.AggregateFunction;
 import org.gradoop.flink.model.api.operators.UnaryBaseGraphToBaseGraphOperator;
 import org.gradoop.flink.model.impl.operators.aggregation.functions.AggregateElements;
@@ -44,12 +45,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @param <V>  The vertex type.
  * @param <E>  The edge type.
  * @param <LG> The type of the graph.
+ * @param <GC> The type of the graph collection.
  */
 public class Aggregation<
   G extends EPGMGraphHead,
   V extends EPGMVertex,
   E extends EPGMEdge,
-  LG extends BaseGraph<G, V, E, LG>> implements UnaryBaseGraphToBaseGraphOperator<LG> {
+  LG extends BaseGraph<G, V, E, LG, GC>,
+  GC extends BaseGraphCollection<G, V, E, GC>> implements UnaryBaseGraphToBaseGraphOperator<LG> {
 
   /**
    * User-defined aggregate functions which are applied on a single logical graph.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/Grouping.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/Grouping.java
@@ -22,6 +22,7 @@ import org.gradoop.common.model.api.entities.EPGMGraphHead;
 import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.common.util.GradoopConstants;
 import org.gradoop.flink.model.api.epgm.BaseGraph;
+import org.gradoop.flink.model.api.epgm.BaseGraphCollection;
 import org.gradoop.flink.model.api.functions.AggregateFunction;
 import org.gradoop.flink.model.api.operators.UnaryBaseGraphToBaseGraphOperator;
 import org.gradoop.flink.model.impl.epgm.LogicalGraph;
@@ -80,12 +81,14 @@ import java.util.Objects;
  * @param <V>  The vertex type.
  * @param <E>  The edge type.
  * @param <LG> The type of the graph.
+ * @param <GC> The type of the graph collection.
  */
 public abstract class Grouping<
   G extends EPGMGraphHead,
   V extends EPGMVertex,
   E extends EPGMEdge,
-  LG extends BaseGraph<G, V, E, LG>>  implements UnaryBaseGraphToBaseGraphOperator<LG> {
+  LG extends BaseGraph<G, V, E, LG, GC>,
+  GC extends BaseGraphCollection<G, V, E, GC>>  implements UnaryBaseGraphToBaseGraphOperator<LG> {
   /**
    * Used as property key to declare a label based grouping.
    *
@@ -647,13 +650,15 @@ public abstract class Grouping<
      * @param <V> The vertex type.
      * @param <E> The edge type.
      * @param <LG> The type of the graph.
+     * @param <GC> The type of the graph collection.
      * @return grouping operator instance
      */
     public <
       G extends EPGMGraphHead,
       V extends EPGMVertex,
       E extends EPGMEdge,
-      LG extends BaseGraph<G, V, E, LG>> Grouping<G, V, E, LG> build() {
+      LG extends BaseGraph<G, V, E, LG, GC>,
+      GC extends BaseGraphCollection<G, V, E, GC>> Grouping<G, V, E, LG, GC> build() {
       if (vertexLabelGroups.isEmpty() && !useVertexLabel) {
         throw new IllegalArgumentException(
           "Provide vertex key(s) and/or use vertex labels for grouping.");
@@ -672,7 +677,7 @@ public abstract class Grouping<
         }
       }
 
-      Grouping<G, V, E, LG> groupingOperator;
+      Grouping<G, V, E, LG, GC> groupingOperator;
 
       switch (strategy) {
       case GROUP_REDUCE:

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/GroupingGroupCombine.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/GroupingGroupCombine.java
@@ -21,6 +21,7 @@ import org.gradoop.common.model.api.entities.EPGMEdge;
 import org.gradoop.common.model.api.entities.EPGMGraphHead;
 import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.flink.model.api.epgm.BaseGraph;
+import org.gradoop.flink.model.api.epgm.BaseGraphCollection;
 import org.gradoop.flink.model.impl.functions.tuple.Value0Of2;
 import org.gradoop.flink.model.impl.functions.tuple.Value1Of2;
 import org.gradoop.flink.model.impl.operators.grouping.functions.BuildSuperVertex;
@@ -68,12 +69,14 @@ import java.util.List;
  * @param <V>  The vertex type.
  * @param <E>  The edge type.
  * @param <LG> The type of the graph.
+ * @param <GC> The type of the graph collection.
  */
 public class GroupingGroupCombine<
   G extends EPGMGraphHead,
   V extends EPGMVertex,
   E extends EPGMEdge,
-  LG extends BaseGraph<G, V, E, LG>> extends Grouping<G, V, E, LG> {
+  LG extends BaseGraph<G, V, E, LG, GC>,
+  GC extends BaseGraphCollection<G, V, E, GC>> extends Grouping<G, V, E, LG, GC> {
 
   /**
    * Creates grouping operator instance.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/GroupingGroupReduce.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/GroupingGroupReduce.java
@@ -20,6 +20,7 @@ import org.gradoop.common.model.api.entities.EPGMEdge;
 import org.gradoop.common.model.api.entities.EPGMGraphHead;
 import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.flink.model.api.epgm.BaseGraph;
+import org.gradoop.flink.model.api.epgm.BaseGraphCollection;
 import org.gradoop.flink.model.impl.operators.grouping.functions.BuildSuperVertex;
 import org.gradoop.flink.model.impl.operators.grouping.functions.BuildVertexGroupItem;
 import org.gradoop.flink.model.impl.operators.grouping.functions.BuildVertexWithSuperVertex;
@@ -59,12 +60,14 @@ import java.util.List;
  * @param <V>  The vertex type.
  * @param <E>  The edge type.
  * @param <LG> The type of the graph.
+ * @param <GC> The type of the graph collection.
  */
 public class GroupingGroupReduce<
   G extends EPGMGraphHead,
   V extends EPGMVertex,
   E extends EPGMEdge,
-  LG extends BaseGraph<G, V, E, LG>> extends Grouping<G, V, E, LG> {
+  LG extends BaseGraph<G, V, E, LG, GC>,
+  GC extends BaseGraphCollection<G, V, E, GC>> extends Grouping<G, V, E, LG, GC> {
   /**
    * Creates grouping operator instance.
    *

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/Subgraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/subgraph/Subgraph.java
@@ -24,6 +24,7 @@ import org.gradoop.common.model.api.entities.EPGMGraphHead;
 import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.common.model.impl.id.GradoopId;
 import org.gradoop.flink.model.api.epgm.BaseGraph;
+import org.gradoop.flink.model.api.epgm.BaseGraphCollection;
 import org.gradoop.flink.model.api.operators.UnaryBaseGraphToBaseGraphOperator;
 import org.gradoop.flink.model.impl.functions.epgm.Id;
 import org.gradoop.flink.model.impl.functions.epgm.SourceId;
@@ -55,12 +56,14 @@ import static org.gradoop.flink.model.impl.operators.subgraph.Subgraph.Strategy.
  * @param <V> the vertex type
  * @param <E> the edge type
  * @param <LG> type of the logical graph instance
+ * @param <GC> type of the graph collection
  */
 public class Subgraph<
   G extends EPGMGraphHead,
   V extends EPGMVertex,
   E extends EPGMEdge,
-  LG extends BaseGraph<G, V, E, LG>> implements UnaryBaseGraphToBaseGraphOperator<LG> {
+  LG extends BaseGraph<G, V, E, LG, GC>,
+  GC extends BaseGraphCollection<G, V, E, GC>> implements UnaryBaseGraphToBaseGraphOperator<LG> {
 
   /**
    * Used to filter vertices from the logical graph.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/transformation/ApplyTransformation.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/transformation/ApplyTransformation.java
@@ -31,7 +31,8 @@ import org.gradoop.flink.util.GradoopFlinkConfig;
  * Applies the transformation operator on on all logical graphs in a graph
  * collection.
  */
-public class ApplyTransformation extends Transformation<GraphHead, Vertex, Edge, LogicalGraph>
+public class ApplyTransformation
+  extends Transformation<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>
   implements ApplicableUnaryGraphToGraphOperator {
 
   /**

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/transformation/Transformation.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/transformation/Transformation.java
@@ -21,6 +21,7 @@ import org.gradoop.common.model.api.entities.EPGMEdge;
 import org.gradoop.common.model.api.entities.EPGMGraphHead;
 import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.flink.model.api.epgm.BaseGraph;
+import org.gradoop.flink.model.api.epgm.BaseGraphCollection;
 import org.gradoop.flink.model.api.epgm.BaseGraphFactory;
 import org.gradoop.flink.model.api.functions.TransformationFunction;
 import org.gradoop.flink.model.api.operators.UnaryBaseGraphToBaseGraphOperator;
@@ -39,12 +40,14 @@ import org.gradoop.flink.model.impl.operators.transformation.functions.Transform
  * @param <V> the EPGM vertex type
  * @param <E> the EPGM edge type
  * @param <LG> the logical graph type
+ * @param <GC> the graph collection type
  */
 public class Transformation<
   G extends EPGMGraphHead,
   V extends EPGMVertex,
   E extends EPGMEdge,
-  LG extends BaseGraph<G, V, E, LG>> implements UnaryBaseGraphToBaseGraphOperator<LG> {
+  LG extends BaseGraph<G, V, E, LG, GC>,
+  GC extends BaseGraphCollection<G, V, E, GC>> implements UnaryBaseGraphToBaseGraphOperator<LG> {
 
   /**
    * Modification function for graph heads
@@ -101,7 +104,7 @@ public class Transformation<
    */
   @SuppressWarnings("unchecked")
   protected LG executeInternal(DataSet<G> graphHeads, DataSet<V> vertices, DataSet<E> edges,
-    BaseGraphFactory<G, V, E, LG> factory) {
+    BaseGraphFactory<G, V, E, LG, GC> factory) {
 
     DataSet<G> transformedGraphHeads = graphHeadTransFunc != null ? graphHeads
       .map(new TransformGraphHead(graphHeadTransFunc, factory.getGraphHeadFactory()))

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/transformation/Transformation.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/transformation/Transformation.java
@@ -102,20 +102,19 @@ public class Transformation<
    * @param factory the factory that is responsible for creating an instance of the logical graph
    * @return transformed logical graph
    */
-  @SuppressWarnings("unchecked")
   protected LG executeInternal(DataSet<G> graphHeads, DataSet<V> vertices, DataSet<E> edges,
     BaseGraphFactory<G, V, E, LG, GC> factory) {
 
     DataSet<G> transformedGraphHeads = graphHeadTransFunc != null ? graphHeads
-      .map(new TransformGraphHead(graphHeadTransFunc, factory.getGraphHeadFactory()))
+      .map(new TransformGraphHead<>(graphHeadTransFunc, factory.getGraphHeadFactory()))
       .returns(TypeExtractor.createTypeInfo(factory.getGraphHeadFactory().getType())) : graphHeads;
 
     DataSet<V> transformedVertices = vertexTransFunc != null ? vertices
-      .map(new TransformVertex(vertexTransFunc, factory.getVertexFactory()))
+      .map(new TransformVertex<>(vertexTransFunc, factory.getVertexFactory()))
       .returns(TypeExtractor.createTypeInfo(factory.getVertexFactory().getType())) : vertices;
 
     DataSet<E> transformedEdges = edgeTransFunc != null ? edges
-      .map(new TransformEdge(edgeTransFunc, factory.getEdgeFactory()))
+      .map(new TransformEdge<>(edgeTransFunc, factory.getEdgeFactory()))
       .returns(TypeExtractor.createTypeInfo(factory.getEdgeFactory().getType())) : edges;
 
     return factory.fromDataSets(transformedGraphHeads, transformedVertices, transformedEdges);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/verify/Verify.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/verify/Verify.java
@@ -20,6 +20,7 @@ import org.gradoop.common.model.api.entities.EPGMEdge;
 import org.gradoop.common.model.api.entities.EPGMGraphHead;
 import org.gradoop.common.model.api.entities.EPGMVertex;
 import org.gradoop.flink.model.api.epgm.BaseGraph;
+import org.gradoop.flink.model.api.epgm.BaseGraphCollection;
 import org.gradoop.flink.model.api.operators.UnaryBaseGraphToBaseGraphOperator;
 import org.gradoop.flink.model.impl.functions.epgm.Id;
 import org.gradoop.flink.model.impl.functions.epgm.SourceId;
@@ -34,12 +35,14 @@ import org.gradoop.flink.model.impl.functions.utils.LeftSide;
  * @param <V>  The vertex type.
  * @param <E>  The edge type.
  * @param <LG> The graph type.
+ * @param <GC> The graph collection type.
  */
 public class Verify<
   G extends EPGMGraphHead,
   V extends EPGMVertex,
   E extends EPGMEdge,
-  LG extends BaseGraph<G, V, E, LG>> implements UnaryBaseGraphToBaseGraphOperator<LG> {
+  LG extends BaseGraph<G, V, E, LG, GC>,
+  GC extends BaseGraphCollection<G, V, E, GC>> implements UnaryBaseGraphToBaseGraphOperator<LG> {
 
   @Override
   public LG execute(LG graph) {

--- a/gradoop-flink/src/main/java/org/gradoop/flink/util/GradoopFlinkConfig.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/util/GradoopFlinkConfig.java
@@ -46,7 +46,7 @@ public class GradoopFlinkConfig extends GradoopConfig<GraphHead, Vertex, Edge> {
   /**
    * Creates instances of {@link LogicalGraph}
    */
-  private final BaseGraphFactory<GraphHead, Vertex, Edge, LogicalGraph> logicalGraphFactory;
+  private final BaseGraphFactory<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection> graphFac;
 
   /**
    * Creates instances of {@link GraphCollection}
@@ -74,8 +74,8 @@ public class GradoopFlinkConfig extends GradoopConfig<GraphHead, Vertex, Edge> {
     this.executionEnvironment = executionEnvironment;
 
     // init with default layout factories
-    this.logicalGraphFactory = new LogicalGraphFactory(this);
-    this.logicalGraphFactory.setLayoutFactory(logicalGraphLayoutFactory);
+    this.graphFac = new LogicalGraphFactory(this);
+    this.graphFac.setLayoutFactory(logicalGraphLayoutFactory);
 
     this.graphCollectionFactory = new GraphCollectionFactory(this);
     this.graphCollectionFactory.setLayoutFactory(graphCollectionLayoutFactory);
@@ -122,7 +122,7 @@ public class GradoopFlinkConfig extends GradoopConfig<GraphHead, Vertex, Edge> {
    * @return factory for logical graph layouts
    */
   public LogicalGraphFactory getLogicalGraphFactory() {
-    return (LogicalGraphFactory) logicalGraphFactory;
+    return (LogicalGraphFactory) graphFac;
   }
 
   /**
@@ -144,7 +144,7 @@ public class GradoopFlinkConfig extends GradoopConfig<GraphHead, Vertex, Edge> {
     LogicalGraphLayoutFactory<GraphHead, Vertex, Edge> factory) {
     Objects.requireNonNull(factory);
     factory.setGradoopFlinkConfig(this);
-    logicalGraphFactory.setLayoutFactory(factory);
+    graphFac.setLayoutFactory(factory);
   }
 
   /**

--- a/gradoop-flink/src/main/java/org/gradoop/flink/util/GradoopFlinkConfig.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/util/GradoopFlinkConfig.java
@@ -46,7 +46,8 @@ public class GradoopFlinkConfig extends GradoopConfig<GraphHead, Vertex, Edge> {
   /**
    * Creates instances of {@link LogicalGraph}
    */
-  private final BaseGraphFactory<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection> graphFac;
+  private final BaseGraphFactory<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>
+    graphFactory;
 
   /**
    * Creates instances of {@link GraphCollection}
@@ -74,8 +75,8 @@ public class GradoopFlinkConfig extends GradoopConfig<GraphHead, Vertex, Edge> {
     this.executionEnvironment = executionEnvironment;
 
     // init with default layout factories
-    this.graphFac = new LogicalGraphFactory(this);
-    this.graphFac.setLayoutFactory(logicalGraphLayoutFactory);
+    this.graphFactory = new LogicalGraphFactory(this);
+    this.graphFactory.setLayoutFactory(logicalGraphLayoutFactory);
 
     this.graphCollectionFactory = new GraphCollectionFactory(this);
     this.graphCollectionFactory.setLayoutFactory(graphCollectionLayoutFactory);
@@ -122,7 +123,7 @@ public class GradoopFlinkConfig extends GradoopConfig<GraphHead, Vertex, Edge> {
    * @return factory for logical graph layouts
    */
   public LogicalGraphFactory getLogicalGraphFactory() {
-    return (LogicalGraphFactory) graphFac;
+    return (LogicalGraphFactory) graphFactory;
   }
 
   /**
@@ -144,7 +145,7 @@ public class GradoopFlinkConfig extends GradoopConfig<GraphHead, Vertex, Edge> {
     LogicalGraphLayoutFactory<GraphHead, Vertex, Edge> factory) {
     Objects.requireNonNull(factory);
     factory.setGradoopFlinkConfig(this);
-    graphFac.setLayoutFactory(factory);
+    graphFactory.setLayoutFactory(factory);
   }
 
   /**

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/grouping/GroupingTestBase.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/grouping/GroupingTestBase.java
@@ -20,6 +20,7 @@ import org.gradoop.common.model.impl.pojo.Edge;
 import org.gradoop.common.model.impl.pojo.GraphHead;
 import org.gradoop.common.model.impl.pojo.Vertex;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
+import org.gradoop.flink.model.impl.epgm.GraphCollection;
 import org.gradoop.flink.model.impl.epgm.LogicalGraph;
 import org.gradoop.flink.model.impl.operators.aggregation.functions.SumPlusOne;
 import org.gradoop.flink.model.impl.operators.aggregation.functions.count.Count;
@@ -93,7 +94,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -125,7 +126,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -164,7 +165,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -189,7 +190,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -217,7 +218,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -251,7 +252,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -303,7 +304,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(loader.getLogicalGraphByVariable("input"));
 
     collectAndAssertTrue(
@@ -358,7 +359,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(loader.getLogicalGraphByVariable("input"));
 
     collectAndAssertTrue(
@@ -386,7 +387,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addVertexAggregateFunction(new Count("count"))
         .addEdgeAggregateFunction(new Count("count"))
         .setStrategy(getStrategy())
-        .<GraphHead, Vertex, Edge, LogicalGraph>build()
+        .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
         .execute(input);
 
     collectAndAssertTrue(
@@ -414,7 +415,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -447,7 +448,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -485,7 +486,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -514,7 +515,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -546,7 +547,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -581,7 +582,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -611,7 +612,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .setStrategy(getStrategy())
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -645,7 +646,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -686,7 +687,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -716,7 +717,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -751,7 +752,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -787,7 +788,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexAggregateFunction(new Count("count"))
       .addEdgeAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -832,7 +833,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addVertexAggregateFunction(new Count("count"))
         .addEdgeAggregateFunction(new Count("count"))
         .setStrategy(getStrategy())
-        .<GraphHead, Vertex, Edge, LogicalGraph>build()
+        .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
         .execute(input);
 
     collectAndAssertTrue(
@@ -876,7 +877,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       new GroupingBuilder()
         .useVertexLabel(true)
         .setStrategy(getStrategy())
-        .<GraphHead, Vertex, Edge, LogicalGraph>build()
+        .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
         .execute(input);
 
     collectAndAssertTrue(
@@ -918,7 +919,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addVertexAggregateFunction(new Count("count"))
         .addEdgeAggregateFunction(new Count("count"))
         .setStrategy(getStrategy())
-        .<GraphHead, Vertex, Edge, LogicalGraph>build()
+        .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
         .execute(input);
 
     collectAndAssertTrue(
@@ -960,7 +961,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addVertexAggregateFunction(new SumProperty("a", "sumA"))
         .addEdgeAggregateFunction(new SumProperty("b", "sumB"))
         .setStrategy(getStrategy())
-        .<GraphHead, Vertex, Edge, LogicalGraph>build()
+        .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
         .execute(input);
 
     collectAndAssertTrue(
@@ -1002,7 +1003,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addVertexAggregateFunction(new SumProperty("a", "sumA"))
         .addEdgeAggregateFunction(new SumProperty("b", "sumB"))
         .setStrategy(getStrategy())
-        .<GraphHead, Vertex, Edge, LogicalGraph>build()
+        .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
         .execute(input);
 
     collectAndAssertTrue(
@@ -1044,7 +1045,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addVertexAggregateFunction(new SumProperty("a", "sumA"))
         .addEdgeAggregateFunction(new SumProperty("b", "sumB"))
         .setStrategy(getStrategy())
-        .<GraphHead, Vertex, Edge, LogicalGraph>build()
+        .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
         .execute(input);
 
     collectAndAssertTrue(
@@ -1086,7 +1087,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addVertexAggregateFunction(new MinProperty("a", "minA"))
         .addEdgeAggregateFunction(new MinProperty("b", "minB"))
         .setStrategy(getStrategy())
-        .<GraphHead, Vertex, Edge, LogicalGraph>build()
+        .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
         .execute(input);
 
     collectAndAssertTrue(
@@ -1128,7 +1129,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addVertexAggregateFunction(new MinProperty("a", "minA"))
         .addEdgeAggregateFunction(new MinProperty("b", "minB"))
         .setStrategy(getStrategy())
-        .<GraphHead, Vertex, Edge, LogicalGraph>build()
+        .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
         .execute(input);
 
     collectAndAssertTrue(
@@ -1170,7 +1171,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addVertexAggregateFunction(new MinProperty("a", "minA"))
         .addEdgeAggregateFunction(new MinProperty("b", "minB"))
         .setStrategy(getStrategy())
-        .<GraphHead, Vertex, Edge, LogicalGraph>build()
+        .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
         .execute(input);
 
     collectAndAssertTrue(
@@ -1212,7 +1213,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addVertexAggregateFunction(new MaxProperty("a", "maxA"))
         .addEdgeAggregateFunction(new MaxProperty("b", "maxB"))
         .setStrategy(getStrategy())
-        .<GraphHead, Vertex, Edge, LogicalGraph>build()
+        .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
         .execute(input);
 
     collectAndAssertTrue(
@@ -1254,7 +1255,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addVertexAggregateFunction(new MaxProperty("a", "maxA"))
         .addEdgeAggregateFunction(new MaxProperty("b", "maxB"))
         .setStrategy(getStrategy())
-        .<GraphHead, Vertex, Edge, LogicalGraph>build()
+        .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
         .execute(input);
 
     collectAndAssertTrue(
@@ -1296,7 +1297,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addVertexAggregateFunction(new MaxProperty("a", "maxA"))
         .addEdgeAggregateFunction(new MaxProperty("b", "maxB"))
         .setStrategy(getStrategy())
-        .<GraphHead, Vertex, Edge, LogicalGraph>build()
+        .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
         .execute(input);
 
     collectAndAssertTrue(
@@ -1344,7 +1345,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         .addEdgeAggregateFunction(new SumProperty("b", "sumB"))
         .addEdgeAggregateFunction(new Count("count"))
         .setStrategy(getStrategy())
-        .<GraphHead, Vertex, Edge, LogicalGraph>build()
+        .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
         .execute(input);
 
     collectAndAssertTrue(
@@ -1379,7 +1380,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexGroupingKey("topic")
       .addVertexLabelGroup("User", Lists.newArrayList("gender"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -1410,7 +1411,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexGroupingKey("topic")
       .addVertexLabelGroup("User", "UserGender", Lists.newArrayList("gender"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -1440,7 +1441,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexGroupingKey("gender")
       .addVertexLabelGroup("Forum", Lists.newArrayList("topic"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -1473,7 +1474,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexLabelGroup("User", Lists.newArrayList("gender"),
         Lists.newArrayList(new SumProperty("age", "sum")))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -1506,7 +1507,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexGroupingKey("topic")
       .addVertexLabelGroup("User", Lists.newArrayList("gender"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -1550,7 +1551,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addVertexLabelGroup("User", Lists.newArrayList("gender"))
       .addVertexLabelGroup("User", Lists.newArrayList("age"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -1597,7 +1598,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
         Lists.newArrayList(new Count("count"), new SumProperty("age", "sum")))
       .addVertexAggregateFunction(new Count("count"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -1625,7 +1626,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addEdgeGroupingKey("until")
       .addEdgeLabelGroup("knows", Lists.newArrayList("since"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -1653,7 +1654,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addEdgeGroupingKey("until")
       .addEdgeLabelGroup("knows", "knowsSince", Lists.newArrayList("since"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -1680,7 +1681,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addEdgeGroupingKey("until")
       .addEdgeLabelGroup("knows", Lists.newArrayList("since"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -1710,7 +1711,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addEdgeLabelGroup("knows", Lists.newArrayList("since"),
         Lists.newArrayList(new SumProperty("since", "sum")))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -1741,7 +1742,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addEdgeLabelGroup("knows", Lists.newArrayList("since"),
         Lists.newArrayList(new SumProperty("since", "sum")))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -1770,7 +1771,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addEdgeLabelGroup("knows", Lists.newArrayList())
       .addEdgeLabelGroup("member", Lists.newArrayList("until"))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(
@@ -1802,7 +1803,7 @@ public abstract class GroupingTestBase extends GradoopFlinkTestBase {
       .addEdgeLabelGroup("member", Lists.newArrayList("until"),
         Lists.newArrayList(new MinProperty("until", "min")))
       .setStrategy(getStrategy())
-      .<GraphHead, Vertex, Edge, LogicalGraph>build()
+      .<GraphHead, Vertex, Edge, LogicalGraph, GraphCollection>build()
       .execute(input);
 
     collectAndAssertTrue(


### PR DESCRIPTION
#1298 
- GDL output is now working on BaseGraph and BaseGraphCollection
- fixes #1298 

#1299
- Added GC Type to BaseGraph
- Added `getCollectionFactory` to BaseGraph
- fixes #1299 
