### PR TITLE
[#1323] Use getFactory instead of getConfig in operators, when possible.

### DIFF
--- a/gradoop-data-integration/src/main/java/org/gradoop/dataintegration/importer/impl/csv/MinimalCSVImporter.java
+++ b/gradoop-data-integration/src/main/java/org/gradoop/dataintegration/importer/impl/csv/MinimalCSVImporter.java
@@ -147,7 +147,8 @@ public class MinimalCSVImporter implements DataSource {
 
   @Override
   public GraphCollection getGraphCollection() throws IOException {
-    return config.getGraphCollectionFactory().fromGraph(getLogicalGraph());
+    LogicalGraph logicalGraph = getLogicalGraph();
+    return logicalGraph.getCollectionFactory().fromGraph(logicalGraph);
   }
 
   /**

--- a/gradoop-data-integration/src/main/java/org/gradoop/dataintegration/importer/impl/json/MinimalJSONImporter.java
+++ b/gradoop-data-integration/src/main/java/org/gradoop/dataintegration/importer/impl/json/MinimalJSONImporter.java
@@ -65,6 +65,7 @@ public class MinimalJSONImporter implements DataSource {
 
   @Override
   public GraphCollection getGraphCollection() {
-    return config.getGraphCollectionFactory().fromGraph(getLogicalGraph());
+    LogicalGraph logicalGraph = getLogicalGraph();
+    return logicalGraph.getCollectionFactory().fromGraph(logicalGraph);
   }
 }

--- a/gradoop-data-integration/src/main/java/org/gradoop/dataintegration/transformation/impl/ExtractPropertyFromVertex.java
+++ b/gradoop-data-integration/src/main/java/org/gradoop/dataintegration/transformation/impl/ExtractPropertyFromVertex.java
@@ -165,8 +165,7 @@ public class ExtractPropertyFromVertex implements UnaryGraphToGraphOperator {
         .union(edges);
     }
 
-    return logicalGraph.getConfig()
-      .getLogicalGraphFactory()
+    return logicalGraph.getFactory()
       .fromDataSets(logicalGraph.getGraphHead(), vertices, edges);
   }
 }

--- a/gradoop-data-integration/src/test/java/org/gradoop/dataintegration/importer/impl/json/MinimalJSONImporterTest.java
+++ b/gradoop-data-integration/src/test/java/org/gradoop/dataintegration/importer/impl/json/MinimalJSONImporterTest.java
@@ -61,7 +61,7 @@ public class MinimalJSONImporterTest extends GradoopFlinkTestBase {
     LogicalGraph read = dataImport.getLogicalGraph();
     LogicalGraph expected = loader.getLogicalGraph();
     GraphCollection expectedCollection =
-      getConfig().getGraphCollectionFactory().fromGraph(expected);
+      expected.getCollectionFactory().fromGraph(expected);
 
     collectAndAssertTrue(expected.equalsByElementData(read));
     collectAndAssertTrue(dataImport.getGraphCollection()
@@ -79,7 +79,7 @@ public class MinimalJSONImporterTest extends GradoopFlinkTestBase {
     LogicalGraph read = dataImport.getLogicalGraph();
     LogicalGraph expected = loader.getLogicalGraphByVariable("expected2");
     GraphCollection expectedCollection =
-      getConfig().getGraphCollectionFactory().fromGraph(expected);
+      expected.getCollectionFactory().fromGraph(expected);
 
     collectAndAssertTrue(expected.equalsByElementData(read));
     collectAndAssertTrue(dataImport.getGraphCollection()

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/BusinessTransactionGraphs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/btgs/BusinessTransactionGraphs.java
@@ -144,7 +144,7 @@ public class BusinessTransactionGraphs implements
       .where(new Id<>()).equalTo(0)
       .with(new SetBtgIds<>());
 
-    return iig.getConfig().getGraphCollectionFactory()
+    return iig.getCollectionFactory()
       .fromDataSets(graphHeads, transVertices.union(masterVertices), btgEdges);
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/fsm/TransactionalFSM.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/fsm/TransactionalFSM.java
@@ -66,7 +66,7 @@ public class TransactionalFSM implements UnaryCollectionToCollectionOperator {
     DataSet<GraphTransaction> output = dimSpan.execute(input);
 
     // convert to Gradoop graph collection
-    return collection.getConfig().getGraphCollectionFactory().fromTransactions(output);
+    return collection.getFactory().fromTransactions(output);
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/fsm/transactional/tle/TransactionalFSMBase.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/fsm/transactional/tle/TransactionalFSMBase.java
@@ -77,7 +77,7 @@ public abstract class TransactionalFSMBase implements UnaryCollectionToCollectio
 
     DataSet<GraphTransaction> output = execute(input);
 
-    return config.getGraphCollectionFactory()
+    return collection.getFactory()
       .fromTransactions(output);
   }
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/clusteringcoefficient/GellyGlobalClusteringCoefficientDirected.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/clusteringcoefficient/GellyGlobalClusteringCoefficientDirected.java
@@ -61,7 +61,7 @@ public class GellyGlobalClusteringCoefficientDirected extends ClusteringCoeffici
       .map(new WritePropertyToGraphHeadMap(ClusteringCoefficientBase.PROPERTY_KEY_GLOBAL,
         PropertyValue.create(globalValue)));
 
-    return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(
+    return currentGraph.getFactory().fromDataSets(
       resultHead, currentGraph.getVertices(), currentGraph.getEdges());
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/clusteringcoefficient/GellyGlobalClusteringCoefficientUndirected.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/clusteringcoefficient/GellyGlobalClusteringCoefficientUndirected.java
@@ -62,7 +62,7 @@ public class GellyGlobalClusteringCoefficientUndirected extends ClusteringCoeffi
       .map(new WritePropertyToGraphHeadMap(ClusteringCoefficientBase.PROPERTY_KEY_GLOBAL,
         PropertyValue.create(globalValue)));
 
-    return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(
+    return currentGraph.getFactory().fromDataSets(
       resultHead, currentGraph.getVertices(), currentGraph.getEdges());
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/clusteringcoefficient/GellyLocalClusteringCoefficientDirected.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/clusteringcoefficient/GellyLocalClusteringCoefficientDirected.java
@@ -57,7 +57,7 @@ public class GellyLocalClusteringCoefficientDirected extends ClusteringCoefficie
       .where(0).equalTo(new Id<>())
       .with(new LocalCCResultTupleToVertexJoin());
 
-    return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(
+    return currentGraph.getFactory().fromDataSets(
       currentGraph.getGraphHead(), resultVertices, currentGraph.getEdges());
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/clusteringcoefficient/GellyLocalClusteringCoefficientUndirected.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/clusteringcoefficient/GellyLocalClusteringCoefficientUndirected.java
@@ -58,7 +58,7 @@ public class GellyLocalClusteringCoefficientUndirected extends ClusteringCoeffic
       .where(0).equalTo(new Id<>())
       .with(new LocalCCResultTupleToVertexJoin());
 
-    return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(
+    return currentGraph.getFactory().fromDataSets(
       currentGraph.getGraphHead(), resultVertices, currentGraph.getEdges());
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/connectedcomponents/AnnotateWeaklyConnectedComponents.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/connectedcomponents/AnnotateWeaklyConnectedComponents.java
@@ -104,7 +104,7 @@ public class AnnotateWeaklyConnectedComponents extends GradoopGellyAlgorithm<Gra
         .with(new VertexPropertyToEdgePropertyJoin(propertyKey));
     }
 
-    return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(
+    return currentGraph.getFactory().fromDataSets(
       currentGraph.getGraphHead(), annotatedVertices, edges);
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/hits/HITS.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/hits/HITS.java
@@ -110,7 +110,7 @@ public class HITS extends GradoopGellyAlgorithm<NullValue, NullValue> {
       .where(new HitsResultKeySelector()).equalTo(new Id<>())
       .with(new HITSToAttributes(authorityPropertyKey, hubPropertyKey));
 
-    return currentGraph.getConfig().getLogicalGraphFactory()
+    return currentGraph.getFactory()
       .fromDataSets(currentGraph.getGraphHead(), newVertices, currentGraph.getEdges());
   }
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/labelpropagation/LabelPropagation.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/labelpropagation/LabelPropagation.java
@@ -76,7 +76,7 @@ public abstract class LabelPropagation extends GradoopGellyAlgorithm<PropertyVal
       .with(new LPVertexJoin(propertyKey));
 
     // return labeled graph
-    return currentGraph.getConfig().getLogicalGraphFactory()
+    return currentGraph.getFactory()
       .fromDataSets(currentGraph.getGraphHead(), labeledVertices, currentGraph.getEdges());
   }
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/pagerank/PageRank.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/pagerank/PageRank.java
@@ -96,7 +96,7 @@ public class PageRank extends GradoopGellyAlgorithm<NullValue, NullValue> {
       .join(currentGraph.getVertices())
       .where(new PageRankResultKey()).equalTo(new Id<>())
       .with(new PageRankToAttribute(propertyKey));
-    return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(
+    return currentGraph.getFactory().fromDataSets(
       currentGraph.getGraphHead(), newVertices, currentGraph.getEdges());
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/randomjump/KRandomJumpGellyVCI.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/randomjump/KRandomJumpGellyVCI.java
@@ -220,7 +220,7 @@ public class KRandomJumpGellyVCI
       .with(new VertexWithVisitedSourceTargetIdJoin(SamplingConstants.PROPERTY_KEY_SAMPLED));
 
     // return graph
-    return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(
+    return currentGraph.getFactory().fromDataSets(
       currentGraph.getGraphHead(), visitedVertices, visitedEdges);
   }
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/trianglecounting/GellyTriangleCounting.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/algorithms/gelly/trianglecounting/GellyTriangleCounting.java
@@ -62,7 +62,7 @@ public class GellyTriangleCounting extends GradoopGellyAlgorithm<NullValue, Null
       .map(new WritePropertyToGraphHeadMap(
         PROPERTY_KEY_TRIANGLES, PropertyValue.create(triangles.count())));
 
-    return currentGraph.getConfig().getLogicalGraphFactory().fromDataSets(
+    return currentGraph.getFactory().fromDataSets(
       resultHead, currentGraph.getVertices(), currentGraph.getEdges());
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVDataSink.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVDataSink.java
@@ -77,7 +77,7 @@ public class CSVDataSink extends CSVBase implements DataSink {
 
   @Override
   public void write(LogicalGraph logicalGraph, boolean overwrite) throws IOException {
-    write(logicalGraph.getConfig().getGraphCollectionFactory().fromGraph(logicalGraph), overwrite);
+    write(logicalGraph.getCollectionFactory().fromGraph(logicalGraph), overwrite);
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVDataSource.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVDataSource.java
@@ -62,7 +62,7 @@ public class CSVDataSource extends CSVBase implements DataSource {
   @Override
   public LogicalGraph getLogicalGraph() {
     GraphCollection collection = getGraphCollection();
-    return getConfig().getLogicalGraphFactory()
+    return collection.getGraphFactory()
       .fromDataSets(
         collection.getGraphHeads().first(1), collection.getVertices(), collection.getEdges());
   }
@@ -86,7 +86,6 @@ public class CSVDataSource extends CSVBase implements DataSource {
       .readTextFile(getEdgeCSVPath())
       .map(new CSVLineToEdge(getConfig().getEdgeFactory()))
       .withBroadcastSet(metaData, BC_METADATA);
-
 
     return getConfig().getGraphCollectionFactory().fromDataSets(graphHeads, vertices, edges);
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/indexed/IndexedCSVDataSink.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/indexed/IndexedCSVDataSink.java
@@ -80,7 +80,7 @@ public class IndexedCSVDataSink extends CSVBase implements DataSink {
 
   @Override
   public void write(LogicalGraph logicalGraph, boolean overwrite) throws IOException {
-    write(logicalGraph.getConfig().getGraphCollectionFactory().fromGraph(logicalGraph), overwrite);
+    write(logicalGraph.getCollectionFactory().fromGraph(logicalGraph), overwrite);
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/deprecated/json/JSONDataSink.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/deprecated/json/JSONDataSink.java
@@ -76,7 +76,7 @@ public class JSONDataSink extends JSONBase implements DataSink {
 
   @Override
   public void write(LogicalGraph logicalGraph, boolean overwrite) throws IOException {
-    write(logicalGraph.getConfig().getGraphCollectionFactory().fromGraph(logicalGraph), overwrite);
+    write(logicalGraph.getCollectionFactory().fromGraph(logicalGraph), overwrite);
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/deprecated/logicalgraphcsv/LogicalGraphCSVDataSource.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/deprecated/logicalgraphcsv/LogicalGraphCSVDataSource.java
@@ -69,7 +69,8 @@ public class LogicalGraphCSVDataSource extends LogicalGraphCSVBase implements Da
 
   @Override
   public GraphCollection getGraphCollection() {
-    return getConfig().getGraphCollectionFactory().fromGraph(getLogicalGraph());
+    LogicalGraph logicalGraph = getLogicalGraph();
+    return logicalGraph.getCollectionFactory().fromGraph(logicalGraph);
   }
 }
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/deprecated/logicalgraphcsv/LogicalGraphIndexedCSVDataSource.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/deprecated/logicalgraphcsv/LogicalGraphIndexedCSVDataSource.java
@@ -26,6 +26,7 @@ import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.io.api.DataSource;
 import org.gradoop.flink.model.impl.epgm.GraphCollection;
 import org.gradoop.flink.model.impl.epgm.LogicalGraph;
+import org.gradoop.flink.model.impl.epgm.LogicalGraphFactory;
 import org.gradoop.flink.util.GradoopFlinkConfig;
 
 import java.io.IOException;
@@ -81,8 +82,9 @@ public class LogicalGraphIndexedCSVDataSource extends LogicalGraphCSVBase implem
     MetaData metaData = MetaData.fromFile(getMetaDataPath(), hdfsConfig);
 
     ExecutionEnvironment env = getConfig().getExecutionEnvironment();
-    VertexFactory<EPGMVertex> vertexFactory = getConfig().getLogicalGraphFactory().getVertexFactory();
-    EdgeFactory<EPGMEdge> edgeFactory = getConfig().getLogicalGraphFactory().getEdgeFactory();
+    LogicalGraphFactory factory = getConfig().getLogicalGraphFactory();
+    VertexFactory<EPGMVertex> vertexFactory = factory.getVertexFactory();
+    EdgeFactory<EPGMEdge> edgeFactory = factory.getEdgeFactory();
 
     Map<String, DataSet<EPGMVertex>> vertices = metaData.getVertexLabels().stream()
       .map(l -> Tuple2.of(l, env.readTextFile(getVertexCSVPath(l))
@@ -96,7 +98,7 @@ public class LogicalGraphIndexedCSVDataSource extends LogicalGraphCSVBase implem
         .withBroadcastSet(MetaData.fromFile(getMetaDataPath(), getConfig()), BC_METADATA)))
       .collect(Collectors.toMap(t -> t.f0, t -> t.f1));
 
-    return getConfig().getLogicalGraphFactory().fromIndexedDataSets(vertices, edges);
+    return factory.fromIndexedDataSets(vertices, edges);
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/deprecated/logicalgraphcsv/LogicalGraphIndexedCSVDataSource.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/deprecated/logicalgraphcsv/LogicalGraphIndexedCSVDataSource.java
@@ -101,6 +101,7 @@ public class LogicalGraphIndexedCSVDataSource extends LogicalGraphCSVBase implem
 
   @Override
   public GraphCollection getGraphCollection() throws IOException {
-    return getConfig().getGraphCollectionFactory().fromGraph(getLogicalGraph());
+    LogicalGraph logicalGraph = getLogicalGraph();
+    return logicalGraph.getCollectionFactory().fromGraph(logicalGraph);
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/dot/DOTDataSink.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/dot/DOTDataSink.java
@@ -87,7 +87,7 @@ public class DOTDataSink implements DataSink {
 
   @Override
   public void write(LogicalGraph graph, boolean overwrite) throws IOException {
-    write(graph.getConfig().getGraphCollectionFactory().fromGraph(graph), overwrite);
+    write(graph.getCollectionFactory().fromGraph(graph), overwrite);
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/gdl/GDLDataSink.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/gdl/GDLDataSink.java
@@ -57,7 +57,7 @@ public class GDLDataSink implements DataSink {
 
   @Override
   public void write(LogicalGraph logicalGraph, boolean overwrite) throws IOException {
-    write(logicalGraph.getConfig().getGraphCollectionFactory().fromGraph(logicalGraph), overwrite);
+    write(logicalGraph.getCollectionFactory().fromGraph(logicalGraph), overwrite);
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/graph/GraphDataSource.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/graph/GraphDataSource.java
@@ -139,6 +139,7 @@ public class GraphDataSource<K extends Comparable<K>> implements DataSource {
 
   @Override
   public GraphCollection getGraphCollection() throws IOException {
-    return config.getGraphCollectionFactory().fromGraph(getLogicalGraph());
+    LogicalGraph logicalGraph = getLogicalGraph();
+    return logicalGraph.getCollectionFactory().fromGraph(logicalGraph);
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/graph/GraphDataSource.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/graph/GraphDataSource.java
@@ -31,6 +31,7 @@ import org.gradoop.flink.io.impl.graph.tuples.ImportEdge;
 import org.gradoop.flink.io.impl.graph.tuples.ImportVertex;
 import org.gradoop.flink.model.impl.epgm.GraphCollection;
 import org.gradoop.flink.model.impl.epgm.LogicalGraph;
+import org.gradoop.flink.model.impl.epgm.LogicalGraphFactory;
 import org.gradoop.flink.model.impl.functions.tuple.Project3To0And1;
 import org.gradoop.flink.model.impl.functions.tuple.Value2Of3;
 import org.gradoop.flink.util.GradoopFlinkConfig;
@@ -115,9 +116,11 @@ public class GraphDataSource<K extends Comparable<K>> implements DataSource {
     TypeInformation<K> externalIdType = ((TupleTypeInfo<?>) importVertices
       .getType()).getTypeAt(0);
 
+    LogicalGraphFactory factory = config.getLogicalGraphFactory();
+
     DataSet<Tuple3<K, GradoopId, EPGMVertex>> vertexTriples = importVertices
       .map(new InitVertex<K>(
-        config.getLogicalGraphFactory().getVertexFactory(), lineagePropertyKey, externalIdType));
+        factory.getVertexFactory(), lineagePropertyKey, externalIdType));
 
     DataSet<EPGMVertex> epgmVertices = vertexTriples
       .map(new Value2Of3<K, GradoopId, EPGMVertex>());
@@ -129,12 +132,12 @@ public class GraphDataSource<K extends Comparable<K>> implements DataSource {
       .join(vertexIdPair)
       .where(1).equalTo(0)
       .with(new InitEdge<K>(
-        config.getLogicalGraphFactory().getEdgeFactory(), lineagePropertyKey, externalIdType))
+        factory.getEdgeFactory(), lineagePropertyKey, externalIdType))
       .join(vertexIdPair)
       .where(0).equalTo(0)
       .with(new UpdateEdge<EPGMEdge, K>());
 
-    return config.getLogicalGraphFactory().fromDataSets(epgmVertices, epgmEdges);
+    return factory.fromDataSets(epgmVertices, epgmEdges);
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/tlf/TLFDataSink.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/tlf/TLFDataSink.java
@@ -74,7 +74,7 @@ public class TLFDataSink extends TLFBase implements DataSink {
 
   @Override
   public void write(LogicalGraph logicalGraph, boolean overwrite) throws IOException {
-    write(logicalGraph.getConfig().getGraphCollectionFactory().fromGraph(logicalGraph), overwrite);
+    write(logicalGraph.getCollectionFactory().fromGraph(logicalGraph), overwrite);
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/ApplyAggregation.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/ApplyAggregation.java
@@ -82,7 +82,7 @@ public class ApplyAggregation
       .where(new Id<>()).equalTo(0)
       .with(new SetAggregateProperties(aggregateFunctions));
 
-    return collection.getConfig().getGraphCollectionFactory()
+    return collection.getFactory()
       .fromDataSets(graphHeads, collection.getVertices(), collection.getEdges());
   }
 
@@ -91,7 +91,7 @@ public class ApplyAggregation
     DataSet<GraphTransaction> updatedTransactions = collection.getGraphTransactions()
       .map(new AggregateTransactions(aggregateFunctions));
 
-    return collection.getConfig().getGraphCollectionFactory().fromTransactions(updatedTransactions);
+    return collection.getFactory().fromTransactions(updatedTransactions);
   }
 
   /**

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/base/BinaryCollectionToCollectionOperatorBase.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/base/BinaryCollectionToCollectionOperatorBase.java
@@ -51,7 +51,7 @@ public abstract class BinaryCollectionToCollectionOperatorBase
     final DataSet<EPGMVertex> newVertices = computeNewVertices(newGraphHeads);
     final DataSet<EPGMEdge> newEdges = computeNewEdges(newVertices);
 
-    return firstCollection.getConfig().getGraphCollectionFactory()
+    return firstCollection.getFactory()
       .fromDataSets(newGraphHeads, newVertices, newEdges);
   }
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/combination/ReduceCombination.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/combination/ReduceCombination.java
@@ -28,7 +28,7 @@ public class ReduceCombination implements ReducibleBinaryGraphToGraphOperator {
 
   @Override
   public LogicalGraph execute(GraphCollection collection) {
-    return collection.getConfig().getLogicalGraphFactory().fromDataSets(
+    return collection.getGraphFactory().fromDataSets(
       collection.getVertices(), collection.getEdges());
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/distinction/DistinctById.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/distinction/DistinctById.java
@@ -27,7 +27,7 @@ public class DistinctById implements UnaryCollectionToCollectionOperator {
 
   @Override
   public GraphCollection execute(GraphCollection collection) {
-    return collection.getConfig().getGraphCollectionFactory().fromDataSets(
+    return collection.getFactory().fromDataSets(
       collection.getGraphHeads().distinct(new Id<>()),
       collection.getVertices(),
       collection.getEdges());

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/equality/GraphEquality.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/equality/GraphEquality.java
@@ -19,8 +19,9 @@ import org.apache.flink.api.java.DataSet;
 import org.gradoop.common.model.impl.pojo.EPGMEdge;
 import org.gradoop.common.model.impl.pojo.EPGMGraphHead;
 import org.gradoop.common.model.impl.pojo.EPGMVertex;
+import org.gradoop.flink.model.api.epgm.BaseGraphCollectionFactory;
 import org.gradoop.flink.model.api.operators.BinaryBaseGraphToValueOperator;
-import org.gradoop.flink.model.impl.epgm.GraphCollectionFactory;
+import org.gradoop.flink.model.impl.epgm.GraphCollection;
 import org.gradoop.flink.model.impl.epgm.LogicalGraph;
 import org.gradoop.flink.model.impl.operators.tostring.api.EdgeToString;
 import org.gradoop.flink.model.impl.operators.tostring.api.GraphHeadToString;
@@ -61,8 +62,8 @@ public class GraphEquality
 
   @Override
   public DataSet<Boolean> execute(LogicalGraph firstGraph, LogicalGraph secondGraph) {
-    GraphCollectionFactory collectionFactory = firstGraph.getConfig()
-      .getGraphCollectionFactory();
+    BaseGraphCollectionFactory<EPGMGraphHead, EPGMVertex, EPGMEdge, LogicalGraph, GraphCollection>
+      collectionFactory = firstGraph.getCollectionFactory();
     return collectionEquality
       .execute(collectionFactory.fromGraph(firstGraph), collectionFactory.fromGraph(secondGraph));
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/exclusion/ReduceExclusion.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/exclusion/ReduceExclusion.java
@@ -68,7 +68,7 @@ public class ReduceExclusion implements ReducibleBinaryGraphToGraphOperator {
       .filter(new NotInGraphsBroadcast<>())
       .withBroadcastSet(excludedGraphIds, NotInGraphsBroadcast.GRAPH_IDS);
 
-    return collection.getConfig().getLogicalGraphFactory()
+    return collection.getGraphFactory()
       .fromDataSets(collection.getGraphHeads().filter(new BySameId<>(startId)), vertices, edges);
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/fusion/VertexFusion.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/fusion/VertexFusion.java
@@ -63,7 +63,7 @@ public class VertexFusion implements BinaryBaseGraphToBaseGraphOperator<LogicalG
   @Override
   public LogicalGraph execute(LogicalGraph searchGraph, LogicalGraph graphPatterns) {
     return execute(searchGraph,
-        graphPatterns.getConfig().getGraphCollectionFactory()
+        graphPatterns.getCollectionFactory()
         .fromDataSets(
             graphPatterns.getGraphHead(),
             graphPatterns.getVertices(),
@@ -139,6 +139,6 @@ public class VertexFusion implements BinaryBaseGraphToBaseGraphOperator<LogicalG
       .reduceGroup(new AddNewIdToDuplicatedEdge())
       .map(new MapFunctionAddGraphElementToGraph2<>(newGraphid));
 
-    return searchGraph.getConfig().getLogicalGraphFactory().fromDataSets(gh, vToRet, edges);
+    return searchGraph.getFactory().fromDataSets(gh, vToRet, edges);
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/limit/Limit.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/limit/Limit.java
@@ -63,7 +63,7 @@ public class Limit implements UnaryCollectionToCollectionOperator {
       .filter(new InAnyGraphBroadcast<>())
       .withBroadcastSet(firstIds, GraphsContainmentFilterBroadcast.GRAPH_IDS);
 
-    return collection.getConfig().getGraphCollectionFactory()
+    return collection.getFactory()
       .fromDataSets(graphHeads, filteredVertices, filteredEdges);
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/PostProcessor.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/PostProcessor.java
@@ -108,7 +108,7 @@ public class PostProcessor {
       .with(new MergedGraphIds<>())
       .withForwardedFieldsFirst("id;label;properties");
 
-    return config.getGraphCollectionFactory().fromDataSets(
+    return inputGraph.getCollectionFactory().fromDataSets(
       collection.getGraphHeads(), newVertices, newEdges);
   }
   /**

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/CypherPatternMatching.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/CypherPatternMatching.java
@@ -124,9 +124,9 @@ public class CypherPatternMatching extends PatternMatching {
       constructFinalElements(graph, embeddings, embeddingMetaData) :
       embeddings.flatMap(
         new ElementsFromEmbedding(
-          graph.getConfig().getGraphHeadFactory(),
-          graph.getConfig().getVertexFactory(),
-          graph.getConfig().getEdgeFactory(),
+          graph.getFactory().getGraphHeadFactory(),
+          graph.getFactory().getVertexFactory(),
+          graph.getFactory().getEdgeFactory(),
           embeddingMetaData,
           queryHandler.getSourceTargetVariables()));
 
@@ -166,9 +166,9 @@ public class CypherPatternMatching extends PatternMatching {
 
     return addEmbeddingsElements.evaluate().flatMap(
       new ElementsFromEmbedding(
-        graph.getConfig().getGraphHeadFactory(),
-        graph.getConfig().getVertexFactory(),
-        graph.getConfig().getEdgeFactory(),
+        graph.getFactory().getGraphHeadFactory(),
+        graph.getFactory().getVertexFactory(),
+        graph.getFactory().getEdgeFactory(),
         newMetaData,
         constructionPatternHandler.getSourceTargetVariables(),
         constructionPatternHandler.getLabelsForVariables(newVars)));

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativePatternMatching.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativePatternMatching.java
@@ -25,12 +25,12 @@ import org.apache.log4j.Logger;
 import org.gradoop.common.model.api.entities.GraphHeadFactory;
 import org.gradoop.common.model.api.entities.VertexFactory;
 import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.common.model.impl.pojo.EPGMElement;
 import org.gradoop.common.model.impl.pojo.EPGMGraphHead;
 import org.gradoop.common.model.impl.pojo.EPGMVertex;
-import org.gradoop.common.model.impl.pojo.EPGMElement;
+import org.gradoop.flink.model.api.operators.UnaryGraphToCollectionOperator;
 import org.gradoop.flink.model.impl.epgm.GraphCollection;
 import org.gradoop.flink.model.impl.epgm.LogicalGraph;
-import org.gradoop.flink.model.api.operators.UnaryGraphToCollectionOperator;
 import org.gradoop.flink.model.impl.functions.epgm.Id;
 import org.gradoop.flink.model.impl.functions.epgm.VertexFromId;
 import org.gradoop.flink.model.impl.functions.tuple.ObjectTo1;
@@ -55,7 +55,6 @@ import org.gradoop.flink.model.impl.operators.matching.single.preserving.explora
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser.TraverserStrategy;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser.TripleForLoopTraverser;
 import org.gradoop.flink.model.impl.operators.matching.single.preserving.explorative.traverser.TripleTraverser;
-import org.gradoop.flink.util.GradoopFlinkConfig;
 
 import java.util.Objects;
 
@@ -126,7 +125,6 @@ public class ExplorativePatternMatching
 
   @Override
   protected GraphCollection executeForVertex(LogicalGraph graph) {
-    GradoopFlinkConfig config = graph.getConfig();
     GraphHeadFactory<EPGMGraphHead> graphHeadFactory = graph.getFactory().getGraphHeadFactory();
     VertexFactory<EPGMVertex> vertexFactory = graph.getFactory().getVertexFactory();
     String variable = getQueryHandler().getVertices().iterator().next().getVariable();

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativePatternMatching.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/preserving/explorative/ExplorativePatternMatching.java
@@ -147,7 +147,7 @@ public class ExplorativePatternMatching
         TypeExtractor.getForClass(vertexFactory.getType()),
         TypeExtractor.getForClass(graphHeadFactory.getType())));
 
-    return config.getGraphCollectionFactory().fromDataSets(
+    return graph.getCollectionFactory().fromDataSets(
       pairs.map(new Value1Of2<>()),
       pairs.map(new Value0Of2<>()));
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/simulation/dual/DualSimulation.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/simulation/dual/DualSimulation.java
@@ -50,7 +50,6 @@ import org.gradoop.flink.model.impl.operators.matching.single.simulation.dual.fu
 import org.gradoop.flink.model.impl.operators.matching.single.simulation.dual.tuples.Deletion;
 import org.gradoop.flink.model.impl.operators.matching.single.simulation.dual.tuples.FatVertex;
 import org.gradoop.flink.model.impl.operators.matching.single.simulation.dual.tuples.Message;
-import org.gradoop.flink.util.GradoopFlinkConfig;
 
 import static org.gradoop.flink.model.impl.operators.matching.common.debug.Printer.log;
 
@@ -282,7 +281,6 @@ public class DualSimulation extends PatternMatching {
    */
   private GraphCollection postProcess(LogicalGraph graph,
     DataSet<FatVertex> vertices) {
-    GradoopFlinkConfig config = graph.getConfig();
 
     DataSet<EPGMVertex> matchVertices = doAttachData() ?
       PostProcessor.extractVerticesWithData(vertices, graph.getVertices()) :

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/simulation/dual/DualSimulation.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/single/simulation/dual/DualSimulation.java
@@ -21,12 +21,13 @@ import org.apache.flink.api.java.operators.IterativeDataSet;
 import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.log4j.Logger;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.common.model.impl.pojo.EPGMEdge;
+import org.gradoop.common.model.impl.pojo.EPGMGraphHead;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
+import org.gradoop.flink.model.api.epgm.BaseGraphCollectionFactory;
+import org.gradoop.flink.model.api.epgm.BaseGraphFactory;
 import org.gradoop.flink.model.impl.epgm.GraphCollection;
-import org.gradoop.flink.model.impl.epgm.GraphCollectionFactory;
 import org.gradoop.flink.model.impl.epgm.LogicalGraph;
-import org.gradoop.flink.model.impl.epgm.LogicalGraphFactory;
 import org.gradoop.flink.model.impl.functions.epgm.Id;
 import org.gradoop.flink.model.impl.functions.epgm.VertexFromId;
 import org.gradoop.flink.model.impl.functions.utils.RightSide;
@@ -88,10 +89,10 @@ public class DualSimulation extends PatternMatching {
       .filterVertices(graph, getQuery())
       .project(0);
 
-    LogicalGraphFactory graphFactory = graph.getConfig()
-      .getLogicalGraphFactory();
-    GraphCollectionFactory collectionFactory = graph.getConfig()
-      .getGraphCollectionFactory();
+    BaseGraphFactory<EPGMGraphHead, EPGMVertex, EPGMEdge, LogicalGraph, GraphCollection>
+      graphFactory = graph.getFactory();
+    BaseGraphCollectionFactory<EPGMGraphHead, EPGMVertex, EPGMEdge, LogicalGraph, GraphCollection>
+      collectionFactory = graph.getCollectionFactory();
 
     if (doAttachData()) {
       return collectionFactory.fromGraph(
@@ -291,7 +292,7 @@ public class DualSimulation extends PatternMatching {
       PostProcessor.extractEdgesWithData(vertices, graph.getEdges()) :
       PostProcessor.extractEdges(vertices, config.getEdgeFactory());
 
-    return config.getGraphCollectionFactory().fromGraph(
-      config.getLogicalGraphFactory().fromDataSets(matchVertices, matchEdges));
+    return graph.getCollectionFactory().fromGraph(
+      graph.getFactory().fromDataSets(matchVertices, matchEdges));
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/TransactionalPatternMatching.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/transactional/TransactionalPatternMatching.java
@@ -159,7 +159,7 @@ public class TransactionalPatternMatching implements UnaryCollectionToCollection
     //--------------------------------------------------------------------------
     // return updated graph collection
     //--------------------------------------------------------------------------
-    return collection.getConfig().getGraphCollectionFactory().fromDataSets(
+    return collection.getFactory().fromDataSets(
       newHeads, collection.getVertices(), collection.getEdges());
   }
 
@@ -216,7 +216,7 @@ public class TransactionalPatternMatching implements UnaryCollectionToCollection
     //--------------------------------------------------------------------------
     // return the embeddings
     //--------------------------------------------------------------------------
-    return collection.getConfig().getGraphCollectionFactory()
+    return collection.getFactory()
       .fromDataSets(newHeads, newVertices, newEdges);
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/overlap/ReduceOverlap.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/overlap/ReduceOverlap.java
@@ -38,7 +38,7 @@ public class ReduceOverlap extends OverlapBase implements
 
     DataSet<GradoopId> graphIDs = graphHeads.map(new Id<EPGMGraphHead>());
 
-    return collection.getConfig().getLogicalGraphFactory().fromDataSets(
+    return collection.getGraphFactory().fromDataSets(
       getVertices(collection.getVertices(), graphIDs),
       getEdges(collection.getEdges(), graphIDs)
     );

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/rollup/RollUp.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/rollup/RollUp.java
@@ -15,20 +15,20 @@
  */
 package org.gradoop.flink.model.impl.operators.rollup;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.flink.api.java.DataSet;
 import org.gradoop.common.model.impl.pojo.EPGMEdge;
-import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.common.model.impl.pojo.EPGMGraphHead;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.common.model.impl.properties.PropertyValue;
 import org.gradoop.flink.model.api.functions.AggregateFunction;
+import org.gradoop.flink.model.api.operators.UnaryGraphToCollectionOperator;
 import org.gradoop.flink.model.impl.epgm.GraphCollection;
 import org.gradoop.flink.model.impl.epgm.LogicalGraph;
-import org.gradoop.flink.model.api.operators.UnaryGraphToCollectionOperator;
 import org.gradoop.flink.model.impl.functions.epgm.SetProperty;
 import org.gradoop.flink.model.impl.operators.grouping.GroupingStrategy;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The rollUp operator generates all combinations of the supplied vertex or edge grouping keys
@@ -128,10 +128,10 @@ public abstract class RollUp implements UnaryGraphToCollectionOperator {
     // DataSets is null.
     GraphCollection collection;
     if (graphHeads != null && vertices != null && edges != null) {
-      collection = graph.getConfig().getGraphCollectionFactory()
+      collection = graph.getCollectionFactory()
         .fromDataSets(graphHeads, vertices, edges);
     } else {
-      collection = graph.getConfig().getGraphCollectionFactory().createEmptyCollection();
+      collection = graph.getCollectionFactory().createEmptyCollection();
     }
 
     return collection;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSampling.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/PageRankSampling.java
@@ -101,7 +101,7 @@ public class PageRankSampling extends SamplingAlgorithm {
       maxIteration,
       true).execute(graph);
 
-    graph = graph.getConfig().getLogicalGraphFactory().fromDataSets(
+    graph = graph.getFactory().fromDataSets(
       graph.getGraphHead(), pageRankGraph.getVertices(), pageRankGraph.getEdges());
 
     graph = graph

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/RandomNonUniformVertexSampling.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/RandomNonUniformVertexSampling.java
@@ -84,7 +84,7 @@ public class RandomNonUniformVertexSampling extends SamplingAlgorithm {
       .cross(graph.getVertices())
       .with(new AddMaxDegreeCrossFunction(SamplingConstants.PROPERTY_KEY_MAX_DEGREE));
 
-    graph = graph.getConfig().getLogicalGraphFactory()
+    graph = graph.getFactory()
       .fromDataSets(graph.getGraphHead(), newVertices, graph.getEdges());
 
     newVertices = graph.getVertices().filter(new NonUniformVertexRandomFilter<>(

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/functions/FilterVerticesWithDegreeOtherThanGiven.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/sampling/functions/FilterVerticesWithDegreeOtherThanGiven.java
@@ -57,7 +57,7 @@ public class FilterVerticesWithDegreeOtherThanGiven implements UnaryGraphToGraph
       .map(new PropertyRemover<>(SamplingConstants.IN_DEGREE_PROPERTY_KEY))
       .map(new PropertyRemover<>(SamplingConstants.OUT_DEGREE_PROPERTY_KEY));
 
-    return graph.getConfig().getLogicalGraphFactory().fromDataSets(
+    return graph.getFactory().fromDataSets(
       graph.getGraphHead(), newVertices, graph.getEdges());
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/selection/Selection.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/selection/Selection.java
@@ -75,7 +75,7 @@ public class Selection extends SelectionBase {
     DataSet<GraphTransaction> filteredTransactions = collection.getGraphTransactions()
       .filter(new FilterTransactions(predicate));
 
-    return collection.getConfig().getGraphCollectionFactory()
+    return collection.getFactory()
       .fromTransactions(filteredTransactions);
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/selection/SelectionBase.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/selection/SelectionBase.java
@@ -59,7 +59,7 @@ public abstract class SelectionBase implements UnaryCollectionToCollectionOperat
       .filter(new InAnyGraphBroadcast<>())
       .withBroadcastSet(graphIds, GraphsContainmentFilterBroadcast.GRAPH_IDS);
 
-    return collection.getConfig().getGraphCollectionFactory()
+    return collection.getFactory()
       .fromDataSets(graphHeads, vertices, edges);
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/Split.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/split/Split.java
@@ -140,7 +140,7 @@ public class Split implements UnaryGraphToCollectionOperator, Serializable {
     // return new graph collection
     //--------------------------------------------------------------------------
 
-    return graph.getConfig().getGraphCollectionFactory()
+    return graph.getCollectionFactory()
       .fromDataSets(newGraphs, vertices, edges);
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/AverageDegree.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/AverageDegree.java
@@ -41,7 +41,7 @@ public class AverageDegree implements UnaryGraphToGraphOperator {
       .map(new CalculateAverageDegree(
         SamplingEvaluationConstants.PROPERTY_KEY_AVERAGE_DEGREE));
 
-    return graph.getConfig().getLogicalGraphFactory()
+    return graph.getFactory()
       .fromDataSets(newGraphHead, graph.getVertices(), graph.getEdges());
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/AverageIncomingDegree.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/AverageIncomingDegree.java
@@ -41,7 +41,7 @@ public class AverageIncomingDegree implements UnaryGraphToGraphOperator {
       .map(new CalculateAverageDegree(
         SamplingEvaluationConstants.PROPERTY_KEY_AVERAGE_INCOMING_DEGREE));
 
-    return graph.getConfig().getLogicalGraphFactory()
+    return graph.getFactory()
       .fromDataSets(newGraphHead, graph.getVertices(), graph.getEdges());
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/AverageOutgoingDegree.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/AverageOutgoingDegree.java
@@ -41,7 +41,7 @@ public class AverageOutgoingDegree implements UnaryGraphToGraphOperator {
       .map(new CalculateAverageDegree(
         SamplingEvaluationConstants.PROPERTY_KEY_AVERAGE_OUTGOING_DEGREE));
 
-    return graph.getConfig().getLogicalGraphFactory()
+    return graph.getFactory()
       .fromDataSets(newGraphHead, graph.getVertices(), graph.getEdges());
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/GraphDensity.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/statistics/GraphDensity.java
@@ -37,7 +37,7 @@ public class GraphDensity implements UnaryGraphToGraphOperator {
       .getGraphHead()
       .map(new CalculateDensity(SamplingEvaluationConstants.PROPERTY_KEY_DENSITY));
 
-    return graph.getConfig().getLogicalGraphFactory()
+    return graph.getFactory()
       .fromDataSets(newGraphHead, graph.getVertices(), graph.getEdges());
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/transformation/ApplyTransformation.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/transformation/ApplyTransformation.java
@@ -17,15 +17,14 @@ package org.gradoop.flink.model.impl.operators.transformation;
 
 import org.apache.flink.api.java.DataSet;
 import org.gradoop.common.model.impl.pojo.EPGMEdge;
-import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.common.model.impl.pojo.EPGMGraphHead;
-import org.gradoop.flink.model.impl.epgm.GraphCollection;
-import org.gradoop.flink.model.impl.epgm.LogicalGraph;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.model.api.functions.TransformationFunction;
 import org.gradoop.flink.model.api.operators.ApplicableUnaryGraphToGraphOperator;
+import org.gradoop.flink.model.impl.epgm.GraphCollection;
+import org.gradoop.flink.model.impl.epgm.LogicalGraph;
 import org.gradoop.flink.model.impl.layouts.transactional.tuples.GraphTransaction;
 import org.gradoop.flink.model.impl.operators.transformation.functions.TransformGraphTransaction;
-import org.gradoop.flink.util.GradoopFlinkConfig;
 
 /**
  * Applies the transformation operator on on all logical graphs in a graph
@@ -56,7 +55,7 @@ public class ApplyTransformation
       collection.getGraphHeads(),
       collection.getVertices(),
       collection.getEdges(),
-      collection.getConfig().getLogicalGraphFactory());
+      collection.getGraphFactory());
 
     return collection.getFactory().fromDataSets(
       modifiedGraph.getGraphHead(),
@@ -68,8 +67,6 @@ public class ApplyTransformation
   public GraphCollection executeForTxLayout(GraphCollection collection) {
     DataSet<GraphTransaction> graphTransactions = collection.getGraphTransactions();
 
-    GradoopFlinkConfig config = collection.getConfig();
-
     DataSet<GraphTransaction> transformedGraphTransactions = graphTransactions
       .map(new TransformGraphTransaction(
         collection.getFactory().getGraphHeadFactory(),
@@ -80,6 +77,6 @@ public class ApplyTransformation
         edgeTransFunc
       ));
 
-    return config.getGraphCollectionFactory().fromTransactions(transformedGraphTransactions);
+    return collection.getFactory().fromTransactions(transformedGraphTransactions);
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSinkTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/CSVDataSinkTest.java
@@ -294,7 +294,7 @@ public class CSVDataSinkTest extends CSVTestBase {
    * @throws Exception if the execution or IO fails.
    */
   private void checkCSVWrite(String tmpPath, LogicalGraph input) throws Exception {
-    checkCSVWrite(tmpPath, input.getConfig().getGraphCollectionFactory().fromGraph(input));
+    checkCSVWrite(tmpPath, input.getCollectionFactory().fromGraph(input));
   }
 
   /**

--- a/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/indexed/IndexedCSVDataSinkTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/csv/indexed/IndexedCSVDataSinkTest.java
@@ -296,7 +296,7 @@ public class IndexedCSVDataSinkTest extends GradoopFlinkTestBase {
    * @throws Exception if the execution or IO fails.
    */
   private void checkIndexedCSVWrite(String tmpPath, LogicalGraph input) throws Exception {
-    checkIndexedCSVWrite(tmpPath, input.getConfig().getGraphCollectionFactory().fromGraph(input));
+    checkIndexedCSVWrite(tmpPath, input.getCollectionFactory().fromGraph(input));
   }
 
   /**

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/GradoopFlinkTestUtils.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/GradoopFlinkTestUtils.java
@@ -129,7 +129,7 @@ public class GradoopFlinkTestUtils {
   public static void printDirectedCanonicalAdjacencyMatrix(LogicalGraph graph)
     throws Exception {
 
-    printDirectedCanonicalAdjacencyMatrix(graph.getConfig().getGraphCollectionFactory()
+    printDirectedCanonicalAdjacencyMatrix(graph.getCollectionFactory()
       .fromGraph(graph));
   }
 
@@ -145,7 +145,7 @@ public class GradoopFlinkTestUtils {
   public static void printUndirectedCanonicalAdjacencyMatrix(LogicalGraph graph)
     throws Exception {
 
-    printUndirectedCanonicalAdjacencyMatrix(graph.getConfig().getGraphCollectionFactory()
+    printUndirectedCanonicalAdjacencyMatrix(graph.getCollectionFactory()
       .fromGraph(graph));
   }
 

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/GraphTransactionTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/GraphTransactionTest.java
@@ -33,7 +33,7 @@ public class GraphTransactionTest extends GradoopFlinkTestBase {
 
     DataSet<GraphTransaction> transactions = originalCollection.getGraphTransactions();
 
-    GraphCollection restoredCollection = getConfig().getGraphCollectionFactory()
+    GraphCollection restoredCollection = originalCollection.getFactory()
       .fromTransactions(transactions);
 
     collectAndAssertTrue(
@@ -54,7 +54,7 @@ public class GraphTransactionTest extends GradoopFlinkTestBase {
 
     DataSet<GraphTransaction> transactions = originalCollection.getGraphTransactions();
 
-    GraphCollection restoredCollection = getConfig().getGraphCollectionFactory()
+    GraphCollection restoredCollection = originalCollection.getFactory()
       .fromTransactions(transactions, new First<>(), new First<>());
 
     collectAndAssertTrue(
@@ -77,7 +77,7 @@ public class GraphTransactionTest extends GradoopFlinkTestBase {
 
     DataSet<GraphTransaction> transactions = originalCollection.getGraphTransactions();
 
-    GraphCollection restoredCollection = getConfig().getGraphCollectionFactory()
+    GraphCollection restoredCollection = originalCollection.getFactory()
       .fromTransactions(transactions, new First<>(), new First<>());
 
     collectAndAssertTrue(

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/difference/DifferenceTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/difference/DifferenceTest.java
@@ -61,7 +61,7 @@ public class DifferenceTest extends BinaryCollectionOperatorsTestBase {
 
     GraphCollection col01 = loader.getGraphCollectionByVariables("g0", "g1");
 
-    GraphCollection expectation = getConfig().getGraphCollectionFactory().createEmptyCollection();
+    GraphCollection expectation = col01.getFactory().createEmptyCollection();
 
     GraphCollection result = col01.difference(col01);
     checkAssertions(expectation, result, "total");

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/fusion/VertexFusionUtils.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/fusion/VertexFusionUtils.java
@@ -82,7 +82,7 @@ public class VertexFusionUtils {
       .union(tobeUnitedWith)
       .distinct(new Id<>());
 
-    return superGraph.getConfig().getLogicalGraphFactory()
+    return superGraph.getFactory()
       .fromDataSets(newVertices, filteredEdges);
   }
 }

--- a/gradoop-store/gradoop-accumulo/src/main/java/org/gradoop/storage/impl/accumulo/io/AccumuloDataSink.java
+++ b/gradoop-store/gradoop-accumulo/src/main/java/org/gradoop/storage/impl/accumulo/io/AccumuloDataSink.java
@@ -58,7 +58,7 @@ public class AccumuloDataSink extends AccumuloBase implements DataSink {
 
   @Override
   public void write(LogicalGraph logicalGraph, boolean overwrite) throws IOException {
-    write(getFlinkConfig().getGraphCollectionFactory().fromGraph(logicalGraph), overwrite);
+    write(logicalGraph.getCollectionFactory().fromGraph(logicalGraph), overwrite);
   }
 
   @Override

--- a/gradoop-store/gradoop-hbase/src/main/java/org/gradoop/storage/impl/hbase/io/HBaseDataSink.java
+++ b/gradoop-store/gradoop-hbase/src/main/java/org/gradoop/storage/impl/hbase/io/HBaseDataSink.java
@@ -61,7 +61,7 @@ public class HBaseDataSink extends HBaseBase implements DataSink {
 
   @Override
   public void write(LogicalGraph logicalGraph, boolean overwrite) throws IOException {
-    write(getFlinkConfig().getGraphCollectionFactory().fromGraph(logicalGraph), overwrite);
+    write(logicalGraph.getCollectionFactory().fromGraph(logicalGraph), overwrite);
   }
 
   @Override


### PR DESCRIPTION
Implements #1323.