### PR TITLE
[#1386] Replace hbase-server dependency.

### DIFF
--- a/gradoop-common/pom.xml
+++ b/gradoop-common/pom.xml
@@ -123,7 +123,7 @@
         <!-- HBase -->
         <dependency>
             <groupId>org.apache.hbase</groupId>
-            <artifactId>hbase-server</artifactId>
+            <artifactId>hbase-common</artifactId>
         </dependency>
 
         <!-- Flink -->

--- a/gradoop-store/gradoop-hbase/pom.xml
+++ b/gradoop-store/gradoop-hbase/pom.xml
@@ -132,7 +132,11 @@
         <!-- HBase -->
         <dependency>
             <groupId>org.apache.hbase</groupId>
-            <artifactId>hbase-server</artifactId>
+            <artifactId>hbase-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-common</artifactId>
         </dependency>
 
         <dependency>

--- a/gradoop-store/gradoop-hbase/pom.xml
+++ b/gradoop-store/gradoop-hbase/pom.xml
@@ -132,7 +132,7 @@
         <!-- HBase -->
         <dependency>
             <groupId>org.apache.hbase</groupId>
-            <artifactId>hbase-client</artifactId>
+            <artifactId>hbase-server</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -702,7 +702,7 @@
             <!-- HBase -->
             <dependency>
                 <groupId>org.apache.hbase</groupId>
-                <artifactId>hbase-client</artifactId>
+                <artifactId>hbase-server</artifactId>
                 <version>${dep.hbase.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -702,7 +702,12 @@
             <!-- HBase -->
             <dependency>
                 <groupId>org.apache.hbase</groupId>
-                <artifactId>hbase-server</artifactId>
+                <artifactId>hbase-client</artifactId>
+                <version>${dep.hbase.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hbase</groupId>
+                <artifactId>hbase-common</artifactId>
                 <version>${dep.hbase.version}</version>
             </dependency>
 


### PR DESCRIPTION
Replaces this `hbase-server` runtime-dependency with `hbase-common` and `hbase-client` (for `gradoop-hbase`)
This removes many transitive dependencies.

fixes #1386 