### PR TITLE
[#1366] Move generified operators to BaseGraphOperators.

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraph.java
@@ -15,10 +15,14 @@
  */
 package org.gradoop.flink.model.api.epgm;
 
+import org.apache.flink.api.java.DataSet;
 import org.gradoop.common.model.api.entities.GraphHead;
 import org.gradoop.common.model.api.entities.Edge;
 import org.gradoop.common.model.api.entities.Vertex;
 import org.gradoop.flink.model.api.layouts.LogicalGraphLayout;
+import org.gradoop.flink.model.impl.functions.bool.Not;
+import org.gradoop.flink.model.impl.functions.bool.Or;
+import org.gradoop.flink.model.impl.functions.bool.True;
 import org.gradoop.flink.util.GradoopFlinkConfig;
 
 /**
@@ -58,4 +62,18 @@ public interface BaseGraph<
    * @return a factory that can be used to create a {@link GC} instance.
    */
   BaseGraphCollectionFactory<G, V, E, LG, GC> getCollectionFactory();
+
+  //----------------------------------------------------------------------------
+  // Utility methods
+  //----------------------------------------------------------------------------
+
+  @Override
+  default DataSet<Boolean> isEmpty() {
+    return getVertices()
+      .map(new True<>())
+      .distinct()
+      .union(getConfig().getExecutionEnvironment().fromElements(false))
+      .reduce(new Or())
+      .map(new Not());
+  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraphCollection.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraphCollection.java
@@ -23,6 +23,9 @@ import org.gradoop.common.model.api.entities.Vertex;
 import org.gradoop.common.model.impl.id.GradoopId;
 import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.flink.model.api.layouts.GraphCollectionLayout;
+import org.gradoop.flink.model.impl.functions.bool.Not;
+import org.gradoop.flink.model.impl.functions.bool.Or;
+import org.gradoop.flink.model.impl.functions.bool.True;
 import org.gradoop.flink.model.impl.functions.epgm.BySameId;
 import org.gradoop.flink.model.impl.functions.graphcontainment.InAnyGraph;
 import org.gradoop.flink.model.impl.functions.graphcontainment.InGraph;
@@ -97,5 +100,19 @@ public interface BaseGraphCollection<
       .filter(new InAnyGraph<>(identifiers));
 
     return getFactory().fromDataSets(newGraphHeads, vertices, edges);
+  }
+
+  //----------------------------------------------------------------------------
+  // Utility methods
+  //----------------------------------------------------------------------------
+
+  @Override
+  default DataSet<Boolean> isEmpty() {
+    return getGraphHeads()
+      .map(new True<>())
+      .distinct()
+      .union(getConfig().getExecutionEnvironment().fromElements(false))
+      .reduce(new Or())
+      .map(new Not());
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraphCollectionOperators.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraphCollectionOperators.java
@@ -300,13 +300,12 @@ public interface BaseGraphCollectionOperators<
   //----------------------------------------------------------------------------
 
   /**
-   * Returns a 1-element dataset containing a {@code boolean} value which
-   * indicates if the collection is empty.
+   * Returns a 1-element dataset containing a {@code boolean} value which indicates if the collection
+   * is empty.
    *
    * A collection is considered empty, if it contains no logical graphs.
    *
-   * @return  1-element dataset containing {@code true}, if the collection is
-   *          empty or {@code false} if not
+   * @return  1-element dataset containing {@code true}, if the collection is empty or {@code false} if not
    */
   DataSet<Boolean> isEmpty();
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraphCollectionOperators.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraphCollectionOperators.java
@@ -300,6 +300,17 @@ public interface BaseGraphCollectionOperators<
   //----------------------------------------------------------------------------
 
   /**
+   * Returns a 1-element dataset containing a {@code boolean} value which
+   * indicates if the collection is empty.
+   *
+   * A collection is considered empty, if it contains no logical graphs.
+   *
+   * @return  1-element dataset containing {@code true}, if the collection is
+   *          empty or {@code false} if not
+   */
+  DataSet<Boolean> isEmpty();
+
+  /**
    * Returns a distinct collection of base graphs. Graph equality is based on graph identifiers.
    *
    * @return distinct graph collection

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraphOperators.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraphOperators.java
@@ -16,6 +16,7 @@
 package org.gradoop.flink.model.api.epgm;
 
 import org.apache.flink.api.common.functions.FilterFunction;
+import org.apache.flink.api.java.DataSet;
 import org.gradoop.common.model.api.entities.Edge;
 import org.gradoop.common.model.api.entities.GraphHead;
 import org.gradoop.common.model.api.entities.Vertex;
@@ -490,6 +491,20 @@ public interface BaseGraphOperators<
   default LG exclude(LG otherGraph) {
     return callForGraph(new Exclusion<>(), otherGraph);
   }
+
+  //----------------------------------------------------------------------------
+  // Utility methods
+  //----------------------------------------------------------------------------
+
+  /**
+   * Returns a 1-element dataset containing a {@code boolean} value which indicates if the graph is empty.
+   *
+   * A graph is considered empty, if it contains no vertices.
+   *
+   * @return  1-element dataset containing {@code true}, if the collection is
+   *          empty or {@code false} if not
+   */
+  DataSet<Boolean> isEmpty();
 
   //----------------------------------------------------------------------------
   // Call for Operators

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/GraphCollectionOperators.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/GraphCollectionOperators.java
@@ -15,7 +15,6 @@
  */
 package org.gradoop.flink.model.api.epgm;
 
-import org.apache.flink.api.java.DataSet;
 import org.gradoop.common.model.impl.pojo.EPGMEdge;
 import org.gradoop.common.model.impl.pojo.EPGMGraphHead;
 import org.gradoop.common.model.impl.pojo.EPGMVertex;
@@ -34,17 +33,6 @@ public interface GraphCollectionOperators
   //----------------------------------------------------------------------------
   // Auxiliary operators
   //----------------------------------------------------------------------------
-
-  /**
-   * Returns a 1-element dataset containing a {@code boolean} value which
-   * indicates if the collection is empty.
-   *
-   * A collection is considered empty, if it contains no logical graphs.
-   *
-   * @return  1-element dataset containing {@code true}, if the collection is
-   *          empty or {@code false} if not
-   */
-  DataSet<Boolean> isEmpty();
 
   /**
      * Writes the graph collection to the given data sink.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/LogicalGraphOperators.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/LogicalGraphOperators.java
@@ -26,8 +26,6 @@ import org.gradoop.flink.model.api.operators.GraphsToGraphOperator;
 import org.gradoop.flink.model.impl.epgm.GraphCollection;
 import org.gradoop.flink.model.impl.epgm.LogicalGraph;
 import org.gradoop.flink.model.impl.operators.cypher.capf.result.CAPFQueryResult;
-import org.gradoop.flink.model.impl.operators.matching.common.MatchStrategy;
-import org.gradoop.flink.model.impl.operators.matching.common.statistics.GraphStatistics;
 import org.gradoop.flink.model.impl.operators.sampling.SamplingAlgorithm;
 
 import java.io.IOException;
@@ -70,106 +68,6 @@ public interface LogicalGraphOperators
    * @throws Exception on failure
    */
   CAPFQueryResult cypher(String query) throws Exception;
-
-  /**
-   * Evaluates the given query using the Cypher query engine. The engine uses default morphism
-   * strategies, which is vertex homomorphism and edge isomorphism. The vertex and edge data of
-   * the data graph elements is attached to the resulting vertices.
-   * <p>
-   * Note, that this method used no statistics about the data graph which may result in bad
-   * runtime performance. Use {@link LogicalGraphOperators#query(String, GraphStatistics)} to
-   * provide statistics for the query planner.
-   *
-   * @param query Cypher query
-   * @return graph collection containing matching subgraphs
-   */
-  GraphCollection query(String query);
-
-  /**
-   * Evaluates the given query using the Cypher query engine. The engine uses default morphism
-   * strategies, which is vertex homomorphism and edge isomorphism. The vertex and edge data of
-   * the data graph elements is attached to the resulting vertices.
-   * <p>
-   * Note, that this method used no statistics about the data graph which may result in bad
-   * runtime performance. Use {@link LogicalGraphOperators#query(String, GraphStatistics)} to
-   * provide statistics for the query planner.
-   * <p>
-   * In addition, the operator can be supplied with a construction pattern allowing the creation
-   * of new graph elements based on variable bindings of the match pattern. Consider the following example:
-   * <p>
-   * {@code graph.query(
-   *  "MATCH (a:Author)-[:WROTE]->(:Paper)<-[:WROTE]-(b:Author) WHERE a <> b",
-   *  "(a)-[:CO_AUTHOR]->(b)")}
-   * <p>
-   * The query pattern is looking for pairs of authors that worked on the same paper.
-   * The construction pattern defines a new edge of type CO_AUTHOR between the two entities.
-   *
-   * @param query               Cypher query string
-   * @param constructionPattern Construction pattern
-   * @return graph collection containing the output of the construct pattern
-   */
-  GraphCollection query(String query, String constructionPattern);
-
-  /**
-   * Evaluates the given query using the Cypher query engine. The engine uses default morphism
-   * strategies, which is vertex homomorphism and edge isomorphism. The vertex and edge data of
-   * the data graph elements is attached to the resulting vertices.
-   *
-   * @param query           Cypher query
-   * @param graphStatistics statistics about the data graph
-   * @return graph collection containing matching subgraphs
-   */
-  GraphCollection query(String query, GraphStatistics graphStatistics);
-
-  /**
-   * Evaluates the given query using the Cypher query engine. The engine uses default morphism
-   * strategies, which is vertex homomorphism and edge isomorphism. The vertex and edge data of
-   * the data graph elements is attached to the resulting vertices.
-   * <p>
-   * In addition, the operator can be supplied with a construction pattern allowing the creation
-   * of new graph elements based on variable bindings of the match pattern. Consider the following example:
-   * <p>
-   * {@code graph.query(
-   *  "MATCH (a:Author)-[:WROTE]->(:Paper)<-[:WROTE]-(b:Author) WHERE a <> b",
-   *  "(a)-[:CO_AUTHOR]->(b)")}
-   * <p>
-   * The query pattern is looking for pairs of authors that worked on the same paper.
-   * The construction pattern defines a new edge of type CO_AUTHOR between the two entities.
-   *
-   * @param query               Cypher query
-   * @param constructionPattern Construction pattern
-   * @param graphStatistics     statistics about the data graph
-   * @return graph collection containing the output of the construct pattern
-   */
-  GraphCollection query(String query, String constructionPattern, GraphStatistics graphStatistics);
-
-  /**
-   * Evaluates the given query using the Cypher query engine.
-   *
-   * @param query           Cypher query
-   * @param attachData      attach original vertex and edge data to the result
-   * @param vertexStrategy  morphism setting for vertex mapping
-   * @param edgeStrategy    morphism setting for edge mapping
-   * @param graphStatistics statistics about the data graph
-   * @return graph collection containing matching subgraphs
-   */
-  GraphCollection query(String query, boolean attachData, MatchStrategy vertexStrategy,
-    MatchStrategy edgeStrategy, GraphStatistics graphStatistics);
-
-  /**
-   * Evaluates the given query using the Cypher query engine.
-   *
-   * @param query               Cypher query
-   * @param constructionPattern Construction pattern
-   * @param attachData          attach original vertex and edge data to the result
-   * @param vertexStrategy      morphism setting for vertex mapping
-   * @param edgeStrategy        morphism setting for edge mapping
-   * @param graphStatistics     statistics about the data graph
-   * @return graph collection containing matching subgraphs
-   */
-  GraphCollection query(String query, String constructionPattern, boolean attachData,
-    MatchStrategy vertexStrategy, MatchStrategy edgeStrategy,
-    GraphStatistics graphStatistics);
 
   /**
    * Creates a new graph from a randomly chosen subset of nodes and their associated edges.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/LogicalGraphOperators.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/LogicalGraphOperators.java
@@ -159,16 +159,6 @@ public interface LogicalGraphOperators
   LogicalGraph callForGraph(GraphsToGraphOperator operator, LogicalGraph... otherGraphs);
 
   /**
-   * Returns a 1-element dataset containing a {@code boolean} value which indicates if the graph is empty.
-   *
-   * A graph is considered empty, if it contains no vertices.
-   *
-   * @return  1-element dataset containing {@code true}, if the collection is
-   *          empty or {@code false} if not
-   */
-  DataSet<Boolean> isEmpty();
-
-  /**
      * Writes the graph to given data sink.
      *
      * @param dataSink The data sink to which the graph should be written.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/epgm/GraphCollection.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/epgm/GraphCollection.java
@@ -28,9 +28,6 @@ import org.gradoop.flink.model.api.epgm.GraphCollectionOperators;
 import org.gradoop.flink.model.api.layouts.GraphCollectionLayout;
 import org.gradoop.flink.model.api.operators.BinaryBaseGraphCollectionToValueOperator;
 import org.gradoop.flink.model.api.operators.UnaryBaseGraphCollectionToValueOperator;
-import org.gradoop.flink.model.impl.functions.bool.Not;
-import org.gradoop.flink.model.impl.functions.bool.Or;
-import org.gradoop.flink.model.impl.functions.bool.True;
 import org.gradoop.flink.model.impl.layouts.transactional.tuples.GraphTransaction;
 import org.gradoop.flink.util.GradoopFlinkConfig;
 
@@ -165,16 +162,6 @@ public class GraphCollection implements
   public BaseGraphFactory<EPGMGraphHead, EPGMVertex, EPGMEdge, LogicalGraph, GraphCollection>
   getGraphFactory() {
     return config.getLogicalGraphFactory();
-  }
-
-  @Override
-  public DataSet<Boolean> isEmpty() {
-    return getGraphHeads()
-      .map(new True<>())
-      .distinct()
-      .union(getConfig().getExecutionEnvironment().fromElements(false))
-      .reduce(new Or())
-      .map(new Not());
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/epgm/LogicalGraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/epgm/LogicalGraph.java
@@ -39,9 +39,6 @@ import org.gradoop.flink.model.impl.functions.epgm.PropertyGetter;
 import org.gradoop.flink.model.impl.operators.cypher.capf.query.CAPFQuery;
 import org.gradoop.flink.model.impl.operators.cypher.capf.result.CAPFQueryResult;
 import org.gradoop.flink.model.impl.operators.equality.GraphEquality;
-import org.gradoop.flink.model.impl.operators.matching.common.MatchStrategy;
-import org.gradoop.flink.model.impl.operators.matching.common.statistics.GraphStatistics;
-import org.gradoop.flink.model.impl.operators.matching.single.cypher.CypherPatternMatching;
 import org.gradoop.flink.model.impl.operators.rollup.EdgeRollUp;
 import org.gradoop.flink.model.impl.operators.rollup.VertexRollUp;
 import org.gradoop.flink.model.impl.operators.sampling.SamplingAlgorithm;
@@ -171,43 +168,6 @@ public class LogicalGraph implements
     CAPFQuery capfQuery = new CAPFQuery(
       query, metaData, this.config.getExecutionEnvironment());
     return capfQuery.execute(this);
-  }
-
-  @Override
-  public GraphCollection query(String query) {
-    return query(query, new GraphStatistics(1, 1, 1, 1));
-  }
-
-  @Override
-  public GraphCollection query(String query, String constructionPattern) {
-    return query(query, constructionPattern, new GraphStatistics(1, 1, 1, 1));
-  }
-
-  @Override
-  public GraphCollection query(String query, GraphStatistics graphStatistics) {
-    return query(query, true,
-      MatchStrategy.HOMOMORPHISM, MatchStrategy.ISOMORPHISM, graphStatistics);
-  }
-
-  @Override
-  public GraphCollection query(String query, String constructionPattern,
-    GraphStatistics graphStatistics) {
-    return query(query, constructionPattern, true,
-      MatchStrategy.HOMOMORPHISM, MatchStrategy.ISOMORPHISM, graphStatistics);
-  }
-
-  @Override
-  public GraphCollection query(String query, boolean attachData, MatchStrategy vertexStrategy,
-    MatchStrategy edgeStrategy, GraphStatistics graphStatistics) {
-    return query(query, null, attachData, vertexStrategy, edgeStrategy, graphStatistics);
-  }
-
-  @Override
-  public GraphCollection query(String query, String constructionPattern, boolean attachData,
-    MatchStrategy vertexStrategy, MatchStrategy edgeStrategy,
-    GraphStatistics graphStatistics) {
-    return callForCollection(new CypherPatternMatching<>(query, constructionPattern, attachData,
-      vertexStrategy, edgeStrategy, graphStatistics));
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/epgm/LogicalGraph.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/epgm/LogicalGraph.java
@@ -32,9 +32,6 @@ import org.gradoop.flink.model.api.layouts.LogicalGraphLayout;
 import org.gradoop.flink.model.api.operators.BinaryBaseGraphToValueOperator;
 import org.gradoop.flink.model.api.operators.GraphsToGraphOperator;
 import org.gradoop.flink.model.api.operators.UnaryBaseGraphToValueOperator;
-import org.gradoop.flink.model.impl.functions.bool.Not;
-import org.gradoop.flink.model.impl.functions.bool.Or;
-import org.gradoop.flink.model.impl.functions.bool.True;
 import org.gradoop.flink.model.impl.functions.epgm.PropertyGetter;
 import org.gradoop.flink.model.impl.operators.cypher.capf.query.CAPFQuery;
 import org.gradoop.flink.model.impl.operators.cypher.capf.result.CAPFQueryResult;
@@ -256,16 +253,6 @@ public class LogicalGraph implements
   //----------------------------------------------------------------------------
   // Utility methods
   //----------------------------------------------------------------------------
-
-  @Override
-  public DataSet<Boolean> isEmpty() {
-    return getVertices()
-      .map(new True<>())
-      .distinct()
-      .union(getConfig().getExecutionEnvironment().fromElements(false))
-      .reduce(new Or())
-      .map(new Not());
-  }
 
   @Override
   public void writeTo(DataSink dataSink) throws IOException {

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/api/TemporalGraphOperators.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/api/TemporalGraphOperators.java
@@ -17,7 +17,6 @@ package org.gradoop.temporal.model.api;
 
 import org.gradoop.flink.model.api.epgm.BaseGraphOperators;
 import org.gradoop.flink.model.impl.epgm.LogicalGraph;
-import org.gradoop.flink.model.impl.operators.matching.common.statistics.GraphStatistics;
 import org.gradoop.temporal.model.api.functions.TemporalPredicate;
 import org.gradoop.temporal.model.impl.TemporalGraph;
 import org.gradoop.temporal.model.impl.TemporalGraphCollection;
@@ -228,86 +227,6 @@ public interface TemporalGraphOperators extends BaseGraphOperators<TemporalGraph
     TimeDimension dimension) {
     return callForGraph(new Diff(firstSnapshot, secondSnapshot, dimension));
   }
-
-  /**
-   * Evaluates the given query using the Cypher query engine. The engine uses default morphism
-   * strategies, which is vertex homomorphism and edge isomorphism. The vertex and edge data of
-   * the data graph elements is attached to the resulting vertices.
-   *
-   * Note, that this method used no statistics about the data graph which may result in bad
-   * runtime performance. Use {@link TemporalGraphOperators#query(String, GraphStatistics)} to
-   * provide statistics for the query planner.
-   *
-   * @param query Cypher query
-   * @return graph collection containing matching subgraphs
-   */
-  default TemporalGraphCollection query(String query) {
-    return query(query, new GraphStatistics(1, 1, 1, 1));
-  }
-
-  /**
-   * Evaluates the given query using the Cypher query engine. The engine uses default morphism
-   * strategies, which is vertex homomorphism and edge isomorphism. The vertex and edge data of
-   * the data graph elements is attached to the resulting vertices.
-   * <p>
-   * Note, that this method used no statistics about the data graph which may result in bad
-   * runtime performance. Use {@link TemporalGraphOperators#query(String, GraphStatistics)} to
-   * provide statistics for the query planner.
-   * <p>
-   * In addition, the operator can be supplied with a construction pattern allowing the creation
-   * of new graph elements based on variable bindings of the match pattern. Consider the following example:
-   * <br>
-   * {@code graph.query(
-   * "MATCH (a:Author)-[:WROTE]->(:Paper)<-[:WROTE]-(b:Author) WHERE a <> b",
-   * "(a)-[:CO_AUTHOR]->(b)")
-   * }
-   * <p>
-   * The query pattern is looking for pairs of authors that worked on the same paper. The
-   * construction pattern defines a new edge of type CO_AUTHOR between the two entities.
-   *
-   * @param query Cypher query string
-   * @param constructionPattern Construction pattern
-   * @return graph collection containing the output of the construct pattern
-   */
-  default TemporalGraphCollection query(String query, String constructionPattern) {
-    return query(query, constructionPattern, new GraphStatistics(1, 1, 1, 1));
-  }
-
-  /**
-   * Evaluates the given query using the Cypher query engine. The engine uses default morphism
-   * strategies, which is vertex homomorphism and edge isomorphism. The vertex and edge data of
-   * the data graph elements is attached to the resulting vertices.
-   *
-   * @param query Cypher query
-   * @param graphStatistics statistics about the data graph
-   * @return graph collection containing matching subgraphs
-   */
-  default TemporalGraphCollection query(String query, GraphStatistics graphStatistics) {
-    return query(query, null, graphStatistics);
-  }
-
-  /**
-   * Evaluates the given query using the Cypher query engine. The engine uses default morphism
-   * strategies, which is vertex homomorphism and edge isomorphism. The vertex and edge data of
-   * the data graph elements is attached to the resulting vertices.
-   * <p>
-   * In addition, the operator can be supplied with a construction pattern allowing the creation
-   * of new graph elements based on variable bindings of the match pattern. Consider the following example:
-   * <br>
-   * {@code graph.query(
-   * "MATCH (a:Author)-[:WROTE]->(:Paper)<-[:WROTE]-(b:Author) WHERE a <> b",
-   * "(a)-[:CO_AUTHOR]->(b)")
-   * }
-   * <p>
-   * The query pattern is looking for pairs of authors that worked on the same paper. The
-   * construction pattern defines a new edge of type {@code CO_AUTHOR} between the two entities.
-   *
-   * @param query Cypher query
-   * @param constructionPattern Construction pattern
-   * @param graphStatistics statistics about the data graph
-   * @return graph collection containing the output of the construct pattern
-   */
-  TemporalGraphCollection query(String query, String constructionPattern, GraphStatistics graphStatistics);
 
   //----------------------------------------------------------------------------
   // Utilities

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/TemporalGraph.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/TemporalGraph.java
@@ -27,9 +27,6 @@ import org.gradoop.flink.model.api.operators.BinaryBaseGraphToValueOperator;
 import org.gradoop.flink.model.api.operators.UnaryBaseGraphToValueOperator;
 import org.gradoop.flink.model.impl.epgm.LogicalGraph;
 import org.gradoop.flink.model.impl.epgm.LogicalGraphFactory;
-import org.gradoop.flink.model.impl.functions.bool.Not;
-import org.gradoop.flink.model.impl.functions.bool.Or;
-import org.gradoop.flink.model.impl.functions.bool.True;
 import org.gradoop.temporal.io.api.TemporalDataSink;
 import org.gradoop.temporal.model.api.TemporalGraphOperators;
 import org.gradoop.temporal.model.impl.functions.tpgm.TemporalEdgeToEdge;
@@ -104,20 +101,6 @@ public class TemporalGraph implements BaseGraph<TemporalGraphHead, TemporalVerte
   public BaseGraphCollectionFactory<TemporalGraphHead, TemporalVertex, TemporalEdge, TemporalGraph,
       TemporalGraphCollection> getCollectionFactory() {
     return this.config.getTemporalGraphCollectionFactory();
-  }
-
-  /**
-   * Returns a 1-element dataset containing a {@link Boolean} value which indicates if the graph is empty.
-   *
-   * A graph is considered empty, if it contains no vertices.
-   *
-   * @return  1-element dataset containing {@link Boolean#TRUE}, if the collection is
-   *          empty or {@link Boolean#FALSE} if not
-   */
-  public DataSet<Boolean> isEmpty() {
-    return getVertices().map(new True<>()).distinct()
-      .union(getConfig().getExecutionEnvironment().fromElements(false)).reduce(new Or())
-      .map(new Not());
   }
 
   /**

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/TemporalGraph.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/TemporalGraph.java
@@ -30,9 +30,6 @@ import org.gradoop.flink.model.impl.epgm.LogicalGraphFactory;
 import org.gradoop.flink.model.impl.functions.bool.Not;
 import org.gradoop.flink.model.impl.functions.bool.Or;
 import org.gradoop.flink.model.impl.functions.bool.True;
-import org.gradoop.flink.model.impl.operators.matching.common.MatchStrategy;
-import org.gradoop.flink.model.impl.operators.matching.common.statistics.GraphStatistics;
-import org.gradoop.flink.model.impl.operators.matching.single.cypher.CypherPatternMatching;
 import org.gradoop.temporal.io.api.TemporalDataSink;
 import org.gradoop.temporal.model.api.TemporalGraphOperators;
 import org.gradoop.temporal.model.impl.functions.tpgm.TemporalEdgeToEdge;
@@ -177,17 +174,6 @@ public class TemporalGraph implements BaseGraph<TemporalGraphHead, TemporalVerte
   @Override
   public DataSet<TemporalEdge> getEdgesByLabel(String label) {
     return this.layout.getEdgesByLabel(label);
-  }
-
-  //----------------------------------------------------------------------------
-  // Unary Operators
-  //----------------------------------------------------------------------------
-
-  @Override
-  public TemporalGraphCollection query(String query, String constructionPattern,
-    GraphStatistics graphStatistics) {
-    return callForCollection(new CypherPatternMatching<>(query, constructionPattern,
-      true, MatchStrategy.HOMOMORPHISM, MatchStrategy.ISOMORPHISM, graphStatistics));
   }
 
   //----------------------------------------------------------------------------

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/TemporalGraphCollection.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/TemporalGraphCollection.java
@@ -26,9 +26,6 @@ import org.gradoop.flink.model.api.operators.BinaryBaseGraphCollectionToValueOpe
 import org.gradoop.flink.model.api.operators.UnaryBaseGraphCollectionToValueOperator;
 import org.gradoop.flink.model.impl.epgm.GraphCollection;
 import org.gradoop.flink.model.impl.epgm.GraphCollectionFactory;
-import org.gradoop.flink.model.impl.functions.bool.Not;
-import org.gradoop.flink.model.impl.functions.bool.Or;
-import org.gradoop.flink.model.impl.functions.bool.True;
 import org.gradoop.flink.model.impl.layouts.transactional.tuples.GraphTransaction;
 import org.gradoop.flink.util.GradoopFlinkConfig;
 import org.gradoop.temporal.io.api.TemporalDataSink;
@@ -107,21 +104,6 @@ public class TemporalGraphCollection implements BaseGraphCollection<
   public BaseGraphFactory<TemporalGraphHead, TemporalVertex, TemporalEdge, TemporalGraph,
     TemporalGraphCollection> getGraphFactory() {
     return this.config.getTemporalGraphFactory();
-  }
-
-  /**
-   * Returns a 1-element dataset containing a {@link Boolean} value which indicates if the graph collection
-   * is empty.
-   *
-   * The graph is considered empty if it contains no graphs.
-   *
-   * @return 1-element dataset containing {@link Boolean#TRUE} if the collection is empty and
-   * {@link Boolean#FALSE} otherwise.
-   */
-  public DataSet<Boolean> isEmpty() {
-    return getGraphHeads().map(new True<>()).distinct()
-      .union(getConfig().getExecutionEnvironment().fromElements(false)).reduce(new Or())
-      .map(new Not());
   }
 
   /**


### PR DESCRIPTION
Move `query` and `isEmpty` from `LogicalGraph/GraphCollection` and `TemporalGraph(Collection)` to `BaseGraph(Collection)`.

Fixes #1366 