### PR TITLE
[#1438] handle GDL syntax errors as java exceptions

### DIFF
--- a/gradoop-common/src/main/java/org/gradoop/common/util/AsciiGraphLoader.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/util/AsciiGraphLoader.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.antlr.v4.runtime.BailErrorStrategy;
 import org.gradoop.common.model.api.entities.ElementFactoryProvider;
 import org.gradoop.common.model.api.entities.GraphHead;
 import org.gradoop.common.model.api.entities.Edge;
@@ -139,6 +140,7 @@ public class AsciiGraphLoader<G extends GraphHead, V extends Vertex, E extends E
       .setDefaultGraphLabel(GradoopConstants.DEFAULT_GRAPH_LABEL)
       .setDefaultVertexLabel(GradoopConstants.DEFAULT_VERTEX_LABEL)
       .setDefaultEdgeLabel(GradoopConstants.DEFAULT_EDGE_LABEL)
+      .setErrorStrategy(new BailErrorStrategy())
       .buildFromString(asciiGraph),
       elementFactoryProvider);
   }
@@ -164,6 +166,7 @@ public class AsciiGraphLoader<G extends GraphHead, V extends Vertex, E extends E
       .setDefaultGraphLabel(GradoopConstants.DEFAULT_GRAPH_LABEL)
       .setDefaultVertexLabel(GradoopConstants.DEFAULT_VERTEX_LABEL)
       .setDefaultEdgeLabel(GradoopConstants.DEFAULT_EDGE_LABEL)
+      .setErrorStrategy(new BailErrorStrategy())
       .buildFromFile(fileName),
       elementFactoryProvider);
   }
@@ -189,6 +192,7 @@ public class AsciiGraphLoader<G extends GraphHead, V extends Vertex, E extends E
       .setDefaultGraphLabel(GradoopConstants.DEFAULT_GRAPH_LABEL)
       .setDefaultVertexLabel(GradoopConstants.DEFAULT_VERTEX_LABEL)
       .setDefaultEdgeLabel(GradoopConstants.DEFAULT_EDGE_LABEL)
+      .setErrorStrategy(new BailErrorStrategy())
       .buildFromStream(inputStream),
       elementFactoryProvider);
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/query/QueryHandler.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/matching/common/query/QueryHandler.java
@@ -17,6 +17,7 @@ package org.gradoop.flink.model.impl.operators.matching.common.query;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.antlr.v4.runtime.BailErrorStrategy;
 import org.apache.commons.lang3.tuple.Pair;
 import org.gradoop.common.util.GradoopConstants;
 import org.gradoop.flink.model.impl.operators.matching.common.query.predicates.CNF;
@@ -101,6 +102,7 @@ public class QueryHandler {
       .setDefaultGraphLabel(GradoopConstants.DEFAULT_GRAPH_LABEL)
       .setDefaultVertexLabel(GradoopConstants.DEFAULT_VERTEX_LABEL)
       .setDefaultEdgeLabel(GradoopConstants.DEFAULT_EDGE_LABEL)
+      .setErrorStrategy(new BailErrorStrategy())
       .buildFromString(gdlString);
     edgeCache = gdlHandler.getEdgeCache(true, true);
     vertexCache = gdlHandler.getVertexCache(true, true);


### PR DESCRIPTION
* Set the ErrorStrategy of the AsciiGraphLoader to BailErrorStrategy in each of the 3 constructors

* Set the ErrorStrategy of the QueryHandler to BailErrorStrategy in the constructor of the class

* A java exception now gets thrown as soon as the query string or the GDL input graph doesn't match the GDL grammar