### PR TITLE
[#1458] DotDataSink Background Color

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/dot/DOTDataSink.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/dot/DOTDataSink.java
@@ -160,14 +160,14 @@ public class DOTDataSink implements DataSink {
      */
     public AbstractDotFileFormat getDotFileFormat(boolean printGraphHeadInformation) {
 
-      String htmlColorGrey = "AAAAAAA";
+      String x11Black = "#000000";
 
       switch (this) {
       case SIMPLE:
         return new DotFileFormatSimple(printGraphHeadInformation);
       case HTML:
       default:
-        return new DotFileFormatHtml(printGraphHeadInformation, htmlColorGrey);
+        return new DotFileFormatHtml(printGraphHeadInformation, x11Black);
       }
     }
   }


### PR DESCRIPTION
* Changed the default background color of the DOTDataSink class to "#000000", x11 code for black
* Now it should be accepted by GraphViz