### PR TITLE
[#1468] Fix CopyableValue implementation in GradoopId

### DIFF
--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/id/GradoopId.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/id/GradoopId.java
@@ -28,6 +28,7 @@ import java.net.SocketException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -441,12 +442,12 @@ public class GradoopId implements NormalizableKey<GradoopId>, CopyableValue<Grad
 
   @Override
   public void copyTo(GradoopId target) {
-    target.bytes = this.bytes;
+    System.arraycopy(bytes, 0, target.bytes, 0, ID_SIZE);
   }
 
   @Override
   public GradoopId copy() {
-    return new GradoopId(this.bytes);
+    return new GradoopId(Arrays.copyOf(bytes, ID_SIZE));
   }
 
   @Override

--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/id/GradoopIdTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/id/GradoopIdTest.java
@@ -125,6 +125,33 @@ public class GradoopIdTest {
   }
 
   /**
+   * Test the {@link GradoopId#copy()}.
+   */
+  @Test
+  public void testCopy() {
+    GradoopId someId = GradoopId.get();
+    GradoopId copy = someId.copy();
+    assertEquals(someId, copy);
+    assertSame("toByteArray() seems to return copies of the id, not the raw byte[] data,",
+      someId.toByteArray(), someId.toByteArray());
+    assertNotSame("copy", someId, copy);
+    assertNotSame("raw data of copy", someId.toByteArray(), copy.toByteArray());
+  }
+
+  /**
+   * Test the {@link GradoopId#copyTo(GradoopId)} method.
+   */
+  @Test
+  public void testCopyTo() {
+    GradoopId someId = GradoopId.get();
+    GradoopId copy = GradoopId.get();
+    assertNotEquals(someId, copy);
+    someId.copyTo(copy);
+    assertEquals(someId, copy);
+    assertNotSame("raw data of copy target", someId.toByteArray(), copy.toByteArray());
+  }
+
+  /**
    * Test if {@link GradoopId#isValid(String)} returns false for invalid input strings
    *
    * @param input an invalid input string


### PR DESCRIPTION
Fixes the implementation of methods from `CopyableValue` in `GradoopId` and adds tests.

## Description
Fixes the broken `copy` and `copyTo` methods and adds tests verifying that the copy is equal but the references are not the same.

## Related Issue
#1468 

## Motivation and Context
This leads to some weird issues when Flink decides to reuse `GradoopId` objects, even with object reuse disabled.

## How Has This Been Tested?
This adds new tests, this has not been tested before (see coverage reports).

## Types of Changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly (if necessary).
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I ran a spell checker.

