### PR TITLE
[#1433] Add vertex retention to KeyedGrouping.

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/gdl/GDLConsoleOutput.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/gdl/GDLConsoleOutput.java
@@ -16,8 +16,8 @@
 package org.gradoop.flink.io.impl.gdl;
 
 import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
-import org.gradoop.common.model.api.entities.GraphHead;
 import org.gradoop.common.model.api.entities.Edge;
+import org.gradoop.common.model.api.entities.GraphHead;
 import org.gradoop.common.model.api.entities.Vertex;
 import org.gradoop.flink.model.api.epgm.BaseGraph;
 import org.gradoop.flink.model.api.epgm.BaseGraphCollection;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/functions/DefaultKeyCheckable.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/functions/DefaultKeyCheckable.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.api.functions;
+
+/**
+ * Indicates that a key-function can check if a key is considered a default value for that function.<p>
+ * This interface needs to be implemented on {@link KeyFunction key functions} where the default key
+ * is not unique, but depending on some other conditions, like the label of an element.
+ */
+public interface DefaultKeyCheckable {
+
+  /**
+   * Check if a key is considered a default key for this function.
+   *
+   * @param key The key to check.
+   * @return {@code true}, if the key is effectively a default key.
+   */
+  boolean isDefaultKey(Object key);
+}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/functions/DefaultKeyCheckable.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/functions/DefaultKeyCheckable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/functions/KeyFunctionWithDefaultValue.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/functions/KeyFunctionWithDefaultValue.java
@@ -15,6 +15,8 @@
  */
 package org.gradoop.flink.model.api.functions;
 
+import java.util.Objects;
+
 /**
  * A (grouping) key function with a default value. The value will be used in some cases where the key can
  * not be determined or when this key function is not applicable for an element.<p>
@@ -23,7 +25,7 @@ package org.gradoop.flink.model.api.functions;
  * @param <E> The type of the object from which the grouping key is extracted.
  * @param <K> The type of the extracted key.
  */
-public interface KeyFunctionWithDefaultValue<E, K> extends KeyFunction<E, K> {
+public interface KeyFunctionWithDefaultValue<E, K> extends KeyFunction<E, K>, DefaultKeyCheckable {
 
   /**
    * Get the default key value for all elements.
@@ -31,4 +33,18 @@ public interface KeyFunctionWithDefaultValue<E, K> extends KeyFunction<E, K> {
    * @return The default key.
    */
   K getDefaultKey();
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * The default implementation of this method compares the key to the default key provided by this class
+   * using {@link Objects#deepEquals(Object, Object)}.
+   *
+   * @param key The key to check.
+   * @return {@code true}, if the key is a default key for this key-function.
+   */
+  @Override
+  default boolean isDefaultKey(Object key) {
+    return Objects.deepEquals(getDefaultKey(), key);
+  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/Grouping.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/grouping/Grouping.java
@@ -779,13 +779,10 @@ public abstract class Grouping<
           retainVerticesWithoutGroup);
         break;
       case GROUP_WITH_KEYFUNCTIONS:
-        if (retainVerticesWithoutGroup) {
-          throw new UnsupportedOperationException("Retaining vertices without group is not yet supported" +
-            " with this strategy.");
-        }
-        groupingOperator = KeyedGroupingUtils.createInstance(
+        groupingOperator = KeyedGroupingUtils.<G, V, E, LG, GC>createInstance(
           useVertexLabel, useEdgeLabel, vertexLabelGroups, edgeLabelGroups,
-          globalVertexAggregateFunctions, globalEdgeAggregateFunctions);
+          globalVertexAggregateFunctions, globalEdgeAggregateFunctions)
+          .setRetainUngroupedVertices(retainVerticesWithoutGroup);
         break;
       default:
         throw new IllegalArgumentException("Unsupported strategy: " + strategy);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/KeyedGrouping.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/KeyedGrouping.java
@@ -189,9 +189,9 @@ public class KeyedGrouping<
     /* Group the edge-tuples by the key fields and vertex IDs and reduce them to single elements.
        When retention of ungrouped vertices is enabled, we have to filter out edges marked for retention
        before the grouping step and then project to remove the additional ID field. */
-    DataSet<Tuple> superEdgeTuples = retainUngroupedVertices ? edgesWithUpdatedIds
+    DataSet<Tuple> superEdgeTuples = (retainUngroupedVertices ? edgesWithUpdatedIds
       .filter(new FilterEdgesToGroup<>())
-      .project(getInternalEdgeProjectionIndices()) : edgesWithUpdatedIds
+      .project(getInternalEdgeProjectionIndices()) : edgesWithUpdatedIds)
       .groupBy(getInternalEdgeGroupingKeys())
       .reduceGroup(new ReduceEdgeTuples<>(
         GroupingConstants.EDGE_TUPLE_RESERVED + edgeGroupingKeys.size(), edgeAggregateFunctions))

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/BuildTuplesFromEdges.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/BuildTuplesFromEdges.java
@@ -31,20 +31,42 @@ import java.util.List;
 public class BuildTuplesFromEdges<E extends Edge> extends BuildTuplesFromElements<E> {
 
   /**
+   * An additional edge offset. All tuple accesses will be shifted by this value.
+   */
+  private final int offset;
+
+  /**
+   * Initialize this function, setting the grouping keys and aggregate functions.<p>
+   * This constructor will consider additional reserved fields in the edge tuple.
+   *
+   * @param keys               The grouping keys.
+   * @param aggregateFunctions The aggregate functions used to determine the aggregate property
+   * @param additionalOffset   An additional number of fields to be reserved in edge tuples.
+   */
+  protected BuildTuplesFromEdges(List<KeyFunction<E, ?>> keys, List<AggregateFunction> aggregateFunctions,
+    int additionalOffset) {
+    super(GroupingConstants.EDGE_TUPLE_RESERVED + additionalOffset, keys, aggregateFunctions);
+    if (additionalOffset < 0) {
+      throw new IllegalArgumentException("Additional offset can not be negative: " + additionalOffset);
+    }
+    this.offset = additionalOffset;
+  }
+
+  /**
    * Initialize this function, setting the grouping keys and aggregate functions.
    *
    * @param keys               The grouping keys.
    * @param aggregateFunctions The aggregate functions used to determine the aggregate property
    */
   public BuildTuplesFromEdges(List<KeyFunction<E, ?>> keys, List<AggregateFunction> aggregateFunctions) {
-    super(GroupingConstants.EDGE_TUPLE_RESERVED, keys, aggregateFunctions);
+    this(keys, aggregateFunctions, 0);
   }
 
   @Override
   public Tuple map(E element) throws Exception {
     final Tuple result = super.map(element);
-    result.setField(element.getSourceId(), GroupingConstants.EDGE_TUPLE_SOURCEID);
-    result.setField(element.getTargetId(), GroupingConstants.EDGE_TUPLE_TARGETID);
+    result.setField(element.getSourceId(), GroupingConstants.EDGE_TUPLE_SOURCEID + offset);
+    result.setField(element.getTargetId(), GroupingConstants.EDGE_TUPLE_TARGETID + offset);
     return result;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/BuildTuplesFromEdgesWithId.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/BuildTuplesFromEdgesWithId.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.impl.operators.keyedgrouping.functions;
+
+import org.apache.flink.api.java.tuple.Tuple;
+import org.gradoop.common.model.api.entities.Edge;
+import org.gradoop.flink.model.api.functions.AggregateFunction;
+import org.gradoop.flink.model.api.functions.KeyFunction;
+
+import java.util.List;
+
+/**
+ * Build a tuple-based representation of edges for grouping with an additional source ID field at position
+ * {@value GroupingConstants#EDGE_TUPLE_ID}. All other fields will be shifted by
+ * {@value GroupingConstants#EDGE_RETENTION_OFFSET}.
+ *
+ * @param <E> The edge type.
+ */
+public class BuildTuplesFromEdgesWithId<E extends Edge> extends BuildTuplesFromEdges<E> {
+
+  /**
+   * Initialize this function, setting the grouping keys and aggregate functions.
+   *
+   * @param keys               The edge grouping keys.
+   * @param aggregateFunctions The edge aggregate functions.
+   */
+  public BuildTuplesFromEdgesWithId(List<KeyFunction<E, ?>> keys,
+    List<AggregateFunction> aggregateFunctions) {
+    super(keys, aggregateFunctions, GroupingConstants.EDGE_RETENTION_OFFSET);
+  }
+
+  @Override
+  public Tuple map(E element) throws Exception {
+    final Tuple tuple = super.map(element);
+    tuple.setField(element.getId(), GroupingConstants.EDGE_TUPLE_ID);
+    return tuple;
+  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/BuildTuplesFromEdgesWithId.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/BuildTuplesFromEdgesWithId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/BuildTuplesFromElements.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/BuildTuplesFromElements.java
@@ -105,7 +105,7 @@ public class BuildTuplesFromElements<E extends Element>
     reuseTuple = Tuple.newInstance(tupleSize);
     // Fill first fields with default ID values.
     for (int i = 0; i < tupleDataOffset; i++) {
-      reuseTuple.setField(GradoopId.NULL_VALUE, i);
+      reuseTuple.setField(GradoopId.NULL_VALUE.copy(), i);
     }
   }
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/CreateElementMappingToSelf.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/CreateElementMappingToSelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/CreateElementMappingToSelf.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/CreateElementMappingToSelf.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.impl.operators.keyedgrouping.functions;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.gradoop.common.model.api.entities.Identifiable;
+import org.gradoop.common.model.impl.id.GradoopId;
+
+/**
+ * Create a mapping (in the form of a {@link Tuple2}) from the ID of an element to itself.
+ *
+ * @param <E> The element type.
+ */
+public class CreateElementMappingToSelf<E extends Identifiable>
+  implements MapFunction<E, Tuple2<GradoopId, GradoopId>> {
+
+  /**
+   * Reduce object instantiations.
+   */
+  private final Tuple2<GradoopId, GradoopId> reuse = new Tuple2<>();
+
+  @Override
+  public Tuple2<GradoopId, GradoopId> map(E element) {
+    reuse.f0 = element.getId();
+    reuse.f1 = element.getId();
+    return reuse;
+  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/FilterEdgesToGroup.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/FilterEdgesToGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/FilterEdgesToGroup.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/FilterEdgesToGroup.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.impl.operators.keyedgrouping.functions;
+
+import org.apache.flink.api.common.functions.FilterFunction;
+import org.apache.flink.api.java.tuple.Tuple;
+import org.gradoop.common.model.impl.id.GradoopId;
+
+/**
+ * A filter function accepting all edges that were not marked for retention.
+ *
+ * @param <T> The edge tuple type.
+ */
+public class FilterEdgesToGroup<T extends Tuple> implements FilterFunction<T> {
+
+  @Override
+  public boolean filter(T tuple) {
+    return tuple.getField(GroupingConstants.EDGE_TUPLE_ID).equals(GradoopId.NULL_VALUE);
+  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/FilterSuperVertices.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/FilterSuperVertices.java
@@ -16,7 +16,6 @@
 package org.gradoop.flink.model.impl.operators.keyedgrouping.functions;
 
 import org.apache.flink.api.common.functions.FilterFunction;
-import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.gradoop.common.model.impl.id.GradoopId;
 
@@ -26,7 +25,6 @@ import org.gradoop.common.model.impl.id.GradoopId;
  *
  * @param <T> The type of the vertex-tuples.
  */
-@FunctionAnnotation.ReadFields({"f0", "f1"})
 public class FilterSuperVertices<T extends Tuple> implements FilterFunction<T> {
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/GroupingConstants.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/GroupingConstants.java
@@ -43,4 +43,18 @@ public abstract class GroupingConstants {
    * The number of reserved fields in the tuple-representation of an edge.
    */
   public static final int EDGE_TUPLE_RESERVED = 2;
+  /**
+   * The number of additionally reserved fields in the tuple-representation of an edge.
+   */
+  public static final int EDGE_DEFAULT_OFFSET = 0;
+  /**
+   * The number of additionally reserved fields in the tuple-representation of an edge, when retention of
+   * ungrouped vertices is enabled.
+   */
+  public static final int EDGE_RETENTION_OFFSET = 1;
+  /**
+   * The index of the ID in the tuple-representation of an edge. This will <b>only</b> be available
+   * if retention of ungrouped vertices is enabled.
+   */
+  public static final int EDGE_TUPLE_ID = 0;
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/PickRetainedEdgeIDs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/PickRetainedEdgeIDs.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.impl.operators.keyedgrouping.functions;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.util.Collector;
+import org.gradoop.common.model.impl.id.GradoopId;
+
+/**
+ * Picks the ID from a tuple if that ID is not {@link GradoopId#NULL_VALUE}.
+ *
+ * @param <T> The input tuple type.
+ */
+public class PickRetainedEdgeIDs<T extends Tuple> implements FlatMapFunction<T, GradoopId> {
+
+  @Override
+  public void flatMap(T tuple, Collector<GradoopId> collector) {
+    final GradoopId id = tuple.getField(GroupingConstants.EDGE_TUPLE_ID);
+    if (!id.equals(GradoopId.NULL_VALUE)) {
+      collector.collect(id);
+    }
+  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/PickRetainedEdgeIDs.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/PickRetainedEdgeIDs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/UpdateIdField.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/UpdateIdField.java
@@ -45,7 +45,9 @@ public class UpdateIdField<T extends Tuple> implements JoinFunction<T, Tuple2<Gr
 
   @Override
   public T join(T inputTuple, Tuple2<GradoopId, GradoopId> updateValue) throws Exception {
-    inputTuple.setField(updateValue.f1, index);
+    if (updateValue != null) {
+      inputTuple.setField(updateValue.f1, index);
+    }
     return inputTuple;
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/UpdateIdFieldAndMarkTuple.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/UpdateIdFieldAndMarkTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class UpdateIdFieldAndMarkTuple<T extends Tuple>
   public T join(T edgeTuple, Tuple2<GradoopId, GradoopId> mapping) {
     if (!mapping.f0.equals(mapping.f1)) {
       // Mark the tuple and update the field, if the mapping would actually change it.
-      edgeTuple.setField(GradoopId.NULL_VALUE, GroupingConstants.EDGE_TUPLE_ID);
+      GradoopId.NULL_VALUE.copyTo(edgeTuple.getField(GroupingConstants.EDGE_TUPLE_ID));
       edgeTuple.setField(mapping.f1, index);
     }
     return edgeTuple;

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/UpdateIdFieldAndMarkTuple.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/UpdateIdFieldAndMarkTuple.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.impl.operators.keyedgrouping.functions;
+
+import org.apache.flink.api.common.functions.JoinFunction;
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.gradoop.common.model.impl.id.GradoopId;
+
+/**
+ * Updates the an ID field of an edge tuple to the ID of the corresponding super vertex.<p>
+ * This function is used when retention of ungrouped vertices is enabled. In this case edge tuples have an
+ * additional ID field. This field will initially be equal to the ID of the edge. When the ID field is
+ * updated by this function, that field will be set to {@link GradoopId#NULL_VALUE} instead.
+ *
+ * @param <T> The edge tuple type.
+ */
+public class UpdateIdFieldAndMarkTuple<T extends Tuple>
+  implements JoinFunction<T, Tuple2<GradoopId, GradoopId>, T> {
+
+  /**
+   * The index of the field to update.
+   */
+  private final int index;
+
+  /**
+   * Create a new instance of this update function.
+   *
+   * @param index The index of the field to update (without offset).
+   */
+  public UpdateIdFieldAndMarkTuple(int index) {
+    if (index < 0) {
+      throw new IllegalArgumentException("Index can not be negative.");
+    }
+    this.index = index + GroupingConstants.EDGE_RETENTION_OFFSET;
+  }
+
+  @Override
+  public T join(T edgeTuple, Tuple2<GradoopId, GradoopId> mapping) {
+    if (!mapping.f0.equals(mapping.f1)) {
+      // Mark the tuple and update the field, if the mapping would actually change it.
+      edgeTuple.setField(GradoopId.NULL_VALUE, GroupingConstants.EDGE_TUPLE_ID);
+      edgeTuple.setField(mapping.f1, index);
+    }
+    return edgeTuple;
+  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/CompositeKeyFunction.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/CompositeKeyFunction.java
@@ -34,7 +34,7 @@ public class CompositeKeyFunction<T> implements KeyFunction<T, Tuple> {
   /**
    * A list of grouping key functions combined in this key function.
    */
-  private final List<? extends KeyFunction<T, ?>> componentFunctions;
+  protected final List<? extends KeyFunction<T, ?>> componentFunctions;
 
   /**
    * Reduce object instantiations.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/CompositeKeyFunctionWithDefaultValues.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/CompositeKeyFunctionWithDefaultValues.java
@@ -52,4 +52,22 @@ public class CompositeKeyFunctionWithDefaultValues<T> extends CompositeKeyFuncti
   public Tuple getDefaultKey() {
     return defaultValue;
   }
+
+  @Override
+  public boolean isDefaultKey(Object key) {
+    if (!(key instanceof Tuple)) {
+      return false;
+    }
+    final Tuple tupleKey = (Tuple) key;
+    if (tupleKey.getArity() != defaultValue.getArity()) {
+      return false;
+    }
+    for (int index = 0; index < tupleKey.getArity(); index++) {
+      if (!((KeyFunctionWithDefaultValue) componentFunctions.get(index)).isDefaultKey(
+        tupleKey.getField(index))) {
+        return false;
+      }
+    }
+    return true;
+  }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/labelspecific/WithAllKeysSetToDefault.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/labelspecific/WithAllKeysSetToDefault.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.impl.operators.keyedgrouping.labelspecific;
+
+import org.gradoop.flink.model.api.functions.DefaultKeyCheckable;
+import org.gradoop.flink.model.api.functions.KeyFunction;
+import org.gradoop.flink.model.impl.functions.filters.CombinableFilter;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A filter function selecting elements with all values set to a default value.
+ *
+ * @param <E> The type of the elements to filter.
+ */
+public class WithAllKeysSetToDefault<E> implements CombinableFilter<E> {
+
+  /**
+   * The keys to check on each element.
+   */
+  private final List<KeyFunction<E, ?>> keys;
+
+  /**
+   * Create a new instance of this filter function.
+   *
+   * @param keys The list of key functions to check.
+   */
+  public WithAllKeysSetToDefault(List<KeyFunction<E, ?>> keys) {
+    checkKeySupport(keys);
+    this.keys = Objects.requireNonNull(keys);
+  }
+
+  @Override
+  public boolean filter(E value) {
+    for (KeyFunction<E, ?> key : keys) {
+      final Object extractedKey = key.getKey(value);
+      if (!((DefaultKeyCheckable) key).isDefaultKey(extractedKey)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Check if keys functions are supported with this filter function.
+   *
+   * @param keys The key functions to check.
+   * @param <E> The type of the key functions.
+   * @throws IllegalArgumentException When any key function is not supported by this filter.
+   */
+  public static <E> void checkKeySupport(List<KeyFunction<E, ?>> keys) {
+    for (KeyFunction<E, ?> key : keys) {
+      if (!(key instanceof DefaultKeyCheckable)) {
+        throw new IllegalArgumentException("Key function " + key + " does not implement " +
+          DefaultKeyCheckable.class.getName());
+      }
+    }
+  }
+}

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/labelspecific/WithAllKeysSetToDefault.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/labelspecific/WithAllKeysSetToDefault.java
@@ -65,8 +65,8 @@ public class WithAllKeysSetToDefault<E> implements CombinableFilter<E> {
   public static <E> void checkKeySupport(List<KeyFunction<E, ?>> keys) {
     for (KeyFunction<E, ?> key : keys) {
       if (!(key instanceof DefaultKeyCheckable)) {
-        throw new IllegalArgumentException("Key function " + key + " does not implement " +
-          DefaultKeyCheckable.class.getName());
+        throw new IllegalArgumentException("Key function " + key.getClass().getName() +
+          " does not implement " + DefaultKeyCheckable.class.getName());
       }
     }
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/labelspecific/WithAllKeysSetToDefault.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/keyedgrouping/labelspecific/WithAllKeysSetToDefault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/KeyedGroupingVertexRetentionTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/KeyedGroupingVertexRetentionTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.impl.operators.keyedgrouping;
+
+import org.gradoop.common.model.impl.pojo.EPGMEdge;
+import org.gradoop.common.model.impl.pojo.EPGMGraphHead;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
+import org.gradoop.flink.model.impl.epgm.GraphCollection;
+import org.gradoop.flink.model.impl.epgm.LogicalGraph;
+import org.gradoop.flink.model.impl.operators.aggregation.functions.count.Count;
+import org.gradoop.flink.model.impl.operators.grouping.Grouping;
+import org.gradoop.flink.model.impl.operators.grouping.GroupingStrategy;
+import org.gradoop.flink.model.impl.operators.grouping.VertexRetentionTestBase;
+import org.gradoop.flink.util.FlinkAsciiGraphLoader;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.gradoop.flink.model.impl.operators.keyedgrouping.GroupingKeys.property;
+
+/**
+ * Tests if {@link KeyedGrouping#setRetainUngroupedVertices(boolean)} works as expected.
+ */
+public class KeyedGroupingVertexRetentionTest extends VertexRetentionTestBase {
+
+  @Override
+  protected GroupingStrategy getStrategy() {
+    return GroupingStrategy.GROUP_WITH_KEYFUNCTIONS;
+  }
+
+  /**
+   * This test is overwritten here, since it does not work in the same way for {@link KeyedGrouping}.
+   */
+  @Override
+  public void testRetainVerticesFlag() {
+  }
+
+  /**
+   * Test grouping on label and two properties.<p>
+   * The expected result of this test is different, since vertices with one property or a label are grouped
+   * together according to that property or label.
+   *
+   * @throws Exception When the execution in Flink fails.
+   */
+  @Override
+  public void testGroupByLabelAndProperties() throws Exception {
+    String asciiInput = "input[" +
+      "(v1 {a : 1})" +
+      "(v2 {a : 1, b : 2})" +
+      "(v4:B {a : 1})" +
+      "(v5:B {a : 1, b : 2})" +
+      "]";
+
+    FlinkAsciiGraphLoader loader = getLoaderFromString(asciiInput);
+
+    loader.appendToDatabaseFromString(
+      "expected[" +
+        "(v01 {a : 1, b: NULL, count: 1L})" +
+        "(v02 {a : 1, b : 2, count : 1L})" +
+        "(v04:B {a : 1, b: NULL, count : 1L})" +
+        "(v05:B {a : 1, b : 2, count : 1L})" +
+        "]");
+
+    final LogicalGraph input = loader.getLogicalGraphByVariable("input");
+
+    LogicalGraph output = new Grouping.GroupingBuilder()
+      .setStrategy(getStrategy())
+      .retainVerticesWithoutGroup()
+      .useVertexLabel(true)
+      .addVertexGroupingKeys(Arrays.asList("a", "b"))
+      .addVertexAggregateFunction(new Count())
+      .<EPGMGraphHead, EPGMVertex, EPGMEdge, LogicalGraph, GraphCollection>build()
+      .execute(input);
+
+    collectAndAssertTrue(
+      output.equalsByElementData(loader.getLogicalGraphByVariable("expected")));
+  }
+
+  /**
+   * Test grouping on labels and one property with retention enabled.<p>
+   * The expected result is different, since the two vertices with label "B" and no property "a" are
+   * grouped together.
+   *
+   * @throws Exception when the execution in Flink fails.
+   */
+  @Override
+  public void testGroupByLabelAndProperty() throws Exception {
+    String asciiInput = "input[" +
+      "(v0 {})" +
+      "(v1 {a : 1})" +
+      "(v2 {b : 2})" +
+      "(v3:B {})" +
+      "(v4:B {a : 1})" +
+      "(v5:B {b : 2})" +
+      "]";
+
+    FlinkAsciiGraphLoader loader = getLoaderFromString(asciiInput);
+
+    loader.appendToDatabaseFromString(
+      "expected[" +
+        "(v00 {})" +
+        "(v01 {a : 1, count : 1L})" +
+        "(v02 {b : 2})" +
+        "(v03:B {a: NULL, count: 2L})" +
+        "(v04:B {a : 1, count : 1L})" +
+        "]");
+
+    final LogicalGraph input = loader.getLogicalGraphByVariable("input");
+
+    LogicalGraph output = new Grouping.GroupingBuilder()
+      .setStrategy(getStrategy())
+      .retainVerticesWithoutGroup()
+      .useVertexLabel(true)
+      .addVertexGroupingKey("a")
+      .addVertexAggregateFunction(new Count())
+      .<EPGMGraphHead, EPGMVertex, EPGMEdge, LogicalGraph, GraphCollection>build()
+      .execute(input);
+
+    collectAndAssertTrue(
+      output.equalsByElementData(loader.getLogicalGraphByVariable("expected")));
+  }
+
+  /**
+   * Test grouping using two properties.<p>
+   * The expected result is different here, since vertices with only one of two properties set are also
+   * grouped together.
+   *
+   * @throws Exception when the execution in Flink fails.
+   */
+  @Override
+  public void testGroupByProperties() throws Exception {
+    String asciiInput = "input[" +
+      "(v1 {a : 1})" +
+      "(v2 {a : 1, b : 2})" +
+      "(v4:B {a : 1})" +
+      "(v5:B {a : 1, b : 2})" +
+      "]";
+
+    FlinkAsciiGraphLoader loader = getLoaderFromString(asciiInput);
+
+    loader.appendToDatabaseFromString(
+      "expected[" +
+        "(v01 {a : 1, b: NULL, count : 2L})" +
+        "(v0205 {a : 1, b : 2, count : 2L})" +
+        "]");
+
+    final LogicalGraph input = loader.getLogicalGraphByVariable("input");
+
+    LogicalGraph output = new Grouping.GroupingBuilder()
+      .setStrategy(getStrategy())
+      .retainVerticesWithoutGroup()
+      .useVertexLabel(false)
+      .addVertexGroupingKeys(Arrays.asList("a", "b"))
+      .addVertexAggregateFunction(new Count())
+      .<EPGMGraphHead, EPGMVertex, EPGMEdge, LogicalGraph, GraphCollection>build()
+      .execute(input);
+
+    collectAndAssertTrue(
+      output.equalsByElementData(loader.getLogicalGraphByVariable("expected")));
+  }
+
+  /**
+   * Test label specific grouping with vertex retention enabled.
+   *
+   * @throws Exception when the execution in Flink fails.
+   */
+  @Override
+  public void testLabelSpecificGrouping() throws Exception {
+    String asciiInput = "input[" +
+      "(v0 {})" +
+      "(v1 {a : 1})" +
+      "(v2 {a : 1, b : 2})" +
+      "(v3:B {})" +
+      "(v4:B {a : 1})" +
+      "(v5:B {a : 1, b : 2})" +
+      "(v6:A {})" +
+      "(v7:A {a : 1})" +
+      "(v8:A {a : 1, b : 2})" +
+      "]";
+
+    FlinkAsciiGraphLoader loader = getLoaderFromString(asciiInput);
+
+    loader.appendToDatabaseFromString(
+      "expected[" +
+        "(v00 {})" +
+        "(v01 {a : 1})" +
+        "(v02 {a : 1, b : 2})" +
+        "(v03:B {})" +
+        "(v04:B {a : 1})" +
+        "(v05:B {a : 1, b : 2})" +
+        "(v06:A)" +
+        "(v07:A {a : 1, b : NULL, count : 1L})" +
+        "(v08:A {a : 1, b : 2, count: 1L})" +
+        "]");
+
+    final LogicalGraph input = loader.getLogicalGraphByVariable("input");
+
+    LogicalGraph output = new Grouping.GroupingBuilder()
+      .setStrategy(getStrategy())
+      .retainVerticesWithoutGroup()
+      .useVertexLabel(false)
+      .addVertexLabelGroup("A", "A", Arrays.asList("a", "b"),
+        Collections.singletonList(new Count()))
+      .<EPGMGraphHead, EPGMVertex, EPGMEdge, LogicalGraph, GraphCollection>build()
+      .execute(input);
+
+    collectAndAssertTrue(
+      output.equalsByElementData(loader.getLogicalGraphByVariable("expected")));
+  }
+
+  /**
+   * Test if edges are properly updates when the source or target vertex was retained.
+   *
+   * @throws Exception when the execution in Flink fails.
+   */
+  @Test
+  public void testEdgeUpdateWithRetainedSourceOrTarget() throws Exception {
+    FlinkAsciiGraphLoader loader = getLoaderFromString("input[" +
+      "(retained:Retained {otherprop: 1L})-[e:edge]->(notretained:NotRetained {prop: 1L, otherprop: 1L})" +
+      "-[:otherEdge {otherprop: 1L}]->(:NotRetained2 {prop:1L, otherprop: 2L})-[e2:edge2]->" +
+      "(retained2:RetainedTarget {otherprop: 2L})" +
+      "] expected [" +
+      "(retained)-->(resv {prop: 1L})-->(resv)-->(retained2)" +
+      "]");
+    LogicalGraph res = loader.getLogicalGraphByVariable("input").callForGraph(
+      new KeyedGrouping<EPGMGraphHead, EPGMVertex, EPGMEdge, LogicalGraph, GraphCollection>(
+      singletonList(property("prop")), emptyList(), emptyList(), emptyList())
+      .setRetainUngroupedVertices(true));
+    collectAndAssertTrue(res.equalsByData(loader.getLogicalGraphByVariable("expected")));
+  }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/BuildTuplesFromEdgesWithIdTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/BuildTuplesFromEdgesWithIdTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.impl.operators.keyedgrouping.functions;
+
+import org.apache.flink.api.java.tuple.Tuple;
+import org.gradoop.common.model.api.entities.Edge;
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.common.model.impl.properties.PropertyValue;
+import org.gradoop.flink.model.GradoopFlinkTestBase;
+import org.gradoop.flink.model.impl.operators.aggregation.functions.max.MaxProperty;
+import org.gradoop.flink.model.impl.operators.keyedgrouping.keys.LabelKeyFunction;
+import org.junit.Test;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for the {@link BuildTuplesFromEdgesWithId} function.
+ */
+public class BuildTuplesFromEdgesWithIdTest extends GradoopFlinkTestBase {
+
+  /**
+   * Test the {@link BuildTuplesFromEdgesWithId#map(Edge)} functionality.
+   *
+   * @throws Exception when the function throws an exception
+   */
+  @Test
+  public void testMap() throws Exception {
+    GradoopId source = GradoopId.get();
+    GradoopId target = GradoopId.get();
+    Edge testEdge = getConfig().getLogicalGraphFactory().getEdgeFactory().createEdge(source, target);
+    String testLabel = "a";
+    String testAggKey = "key";
+    PropertyValue testAggValue = PropertyValue.create(17L);
+    testEdge.setLabel(testLabel);
+    testEdge.setProperty(testAggKey, testAggValue);
+    BuildTuplesFromEdgesWithId<Edge> function = new BuildTuplesFromEdgesWithId<>(
+      singletonList(new LabelKeyFunction<>()), singletonList(new MaxProperty(testAggKey)));
+    Tuple result = function.map(testEdge);
+    assertEquals("Invalid result tuple size", 5, result.getArity());
+    assertEquals(testEdge.getId(), result.getField(0));
+    assertEquals(source, result.getField(1));
+    assertEquals(target, result.getField(2));
+    assertEquals(testLabel, result.getField(3));
+    assertEquals(testAggValue, result.getField(4));
+  }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/PickRetainedEdgeIDsTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/PickRetainedEdgeIDsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.impl.operators.keyedgrouping.functions;
+
+import org.apache.flink.api.common.functions.util.ListCollector;
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.util.Collector;
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Test for the {@link PickRetainedEdgeIDs} function.
+ */
+public class PickRetainedEdgeIDsTest {
+
+  /**
+   * Test the {@link PickRetainedEdgeIDs#flatMap(Tuple, Collector)} functionality.
+   */
+  @Test
+  public void testFlatMap() {
+    PickRetainedEdgeIDs<Tuple1<GradoopId>> toTest = new PickRetainedEdgeIDs<>();
+    List<GradoopId> result = new ArrayList<>();
+    Collector<GradoopId> collector = new ListCollector<GradoopId>(result);
+    GradoopId someId = GradoopId.get();
+    GradoopId otherId = GradoopId.get();
+    toTest.flatMap(Tuple1.of(someId), collector);
+    toTest.flatMap(Tuple1.of(GradoopId.NULL_VALUE), collector);
+    toTest.flatMap(Tuple1.of(otherId), collector);
+    collector.close();
+    assertArrayEquals(new GradoopId[] {someId, otherId}, result.toArray());
+  }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/UpdateIdFieldAndMarkTupleTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/functions/UpdateIdFieldAndMarkTupleTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.impl.operators.keyedgrouping.functions;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * Test for the {@link UpdateIdFieldAndMarkTuple} function.
+ */
+public class UpdateIdFieldAndMarkTupleTest {
+
+  /**
+   * Test the join function in cases where the update should be performed.
+   */
+  @Test
+  public void testWithUpdate() {
+    GradoopId id = GradoopId.get();
+    GradoopId foreignKey = GradoopId.get();
+    GradoopId newForeignKey = GradoopId.get();
+    Tuple2<GradoopId, GradoopId> input = Tuple2.of(id, foreignKey);
+    Tuple2<GradoopId, GradoopId> mapping = Tuple2.of(foreignKey, newForeignKey);
+    assertNotEquals(GradoopId.NULL_VALUE, input.f0);
+    Tuple2<GradoopId, GradoopId> result =
+      new UpdateIdFieldAndMarkTuple<Tuple2<GradoopId, GradoopId>>(0).join(input, mapping);
+    assertEquals(GradoopId.NULL_VALUE, result.f0);
+    assertEquals(newForeignKey, result.f1);
+  }
+
+  /**
+   * Test the join function in cases where the update should not be performed.
+   */
+  @Test
+  public void testWithNoUpdate() {
+    GradoopId id = GradoopId.get();
+    GradoopId foreignKey = GradoopId.get();
+    Tuple2<GradoopId, GradoopId> input = Tuple2.of(id, foreignKey);
+    Tuple2<GradoopId, GradoopId> mapping = Tuple2.of(foreignKey, foreignKey);
+    Tuple2<GradoopId, GradoopId> result = new UpdateIdFieldAndMarkTuple<Tuple2<GradoopId, GradoopId>>(0)
+      .join(input, mapping);
+    assertEquals(id, result.f0);
+    assertEquals(foreignKey, result.f1);
+  }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/CompositeKeyFunctionWithDefaultValuesTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/CompositeKeyFunctionWithDefaultValuesTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.impl.operators.keyedgrouping.keys;
+
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.gradoop.common.GradoopTestUtils;
+import org.gradoop.common.model.api.entities.Element;
+import org.gradoop.common.model.api.entities.VertexFactory;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
+import org.gradoop.common.model.impl.properties.PropertyValue;
+import org.gradoop.flink.model.api.functions.KeyFunction;
+import org.gradoop.flink.model.api.functions.KeyFunctionWithDefaultValue;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Test for the {@link CompositeKeyFunctionWithDefaultValues}.
+ */
+public class CompositeKeyFunctionWithDefaultValuesTest extends KeyFunctionTestBase<Element, Tuple> {
+
+  /**
+   * A property key for one component function of the test function.
+   */
+  private final String propertyKey = "key";
+
+  @Override
+  public void setUp() {
+    checkForKeyEquality = false;
+  }
+
+  @Override
+  protected KeyFunction<Element, Tuple> getInstance() {
+    return new CompositeKeyFunctionWithDefaultValues<>(
+      Arrays.asList(new PropertyKeyFunction<>(propertyKey), new LabelKeyFunction<>()));
+  }
+
+  /**
+   * Test if the default key has the correct value.<p>
+   */
+  @Test
+  public void checkDefaultKeyValue() {
+    final Tuple defaultKey = ((KeyFunctionWithDefaultValue<Element, Tuple>) getInstance()).getDefaultKey();
+    assertEquals(2, defaultKey.getArity());
+    assertArrayEquals(PropertyValue.NULL_VALUE.getRawBytes(), defaultKey.getField(0));
+    assertEquals("", defaultKey.getField(1));
+  }
+
+  @Override
+  public void testGetKey() {
+    final KeyFunction<Element, Tuple> keyFunction = getInstance();
+    final VertexFactory<EPGMVertex> vertexFactory = getConfig().getLogicalGraphFactory().getVertexFactory();
+    EPGMVertex testVertex = vertexFactory.createVertex();
+    Tuple key = keyFunction.getKey(testVertex);
+    assertEquals(2, key.getArity());
+    assertArrayEquals(PropertyValue.NULL_VALUE.getRawBytes(), key.getField(0));
+    assertEquals("", key.getField(1));
+    final String testLabel = "testLabel";
+    testVertex.setLabel(testLabel);
+    key = keyFunction.getKey(testVertex);
+    assertEquals(2, key.getArity());
+    assertArrayEquals(PropertyValue.NULL_VALUE.getRawBytes(), key.getField(0));
+    assertEquals(testLabel, key.getField(1));
+    final PropertyValue testValue = PropertyValue.create(GradoopTestUtils.DOUBLE_VAL_5);
+    testVertex.setProperty(propertyKey, testValue);
+    key = keyFunction.getKey(testVertex);
+    assertEquals(2, key.getArity());
+    assertArrayEquals(testValue.getRawBytes(), key.getField(0));
+    assertEquals(testLabel, key.getField(1));
+  }
+
+  /**
+   * Test for the {@link CompositeKeyFunctionWithDefaultValues#addKeyToElement(Object, Object)} function.
+   */
+  @Test
+  public void testAddKeyToElement() {
+    final EPGMVertex vertex = getConfig().getLogicalGraphFactory().getVertexFactory().createVertex();
+    final PropertyValue testValue = PropertyValue.create(GradoopTestUtils.BIG_DECIMAL_VAL_7);
+    final String testLabel = "testLabel";
+    assertEquals("", vertex.getLabel());
+    assertFalse(vertex.hasProperty(propertyKey));
+    getInstance().addKeyToElement(vertex, Tuple2.of(testValue.getRawBytes(), testLabel));
+    assertEquals(testValue, vertex.getPropertyValue(propertyKey));
+    assertEquals(testLabel, vertex.getLabel());
+  }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/CompositeKeyFunctionWithDefaultValuesTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/CompositeKeyFunctionWithDefaultValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,13 @@ package org.gradoop.flink.model.impl.operators.keyedgrouping.keys;
 
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.gradoop.common.GradoopTestUtils;
 import org.gradoop.common.model.api.entities.Element;
 import org.gradoop.common.model.api.entities.VertexFactory;
 import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.common.model.impl.properties.PropertyValue;
+import org.gradoop.flink.model.api.functions.DefaultKeyCheckable;
 import org.gradoop.flink.model.api.functions.KeyFunction;
 import org.gradoop.flink.model.api.functions.KeyFunctionWithDefaultValue;
 import org.junit.Test;
@@ -31,6 +33,7 @@ import java.util.Arrays;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test for the {@link CompositeKeyFunctionWithDefaultValues}.
@@ -100,5 +103,19 @@ public class CompositeKeyFunctionWithDefaultValuesTest extends KeyFunctionTestBa
     getInstance().addKeyToElement(vertex, Tuple2.of(testValue.getRawBytes(), testLabel));
     assertEquals(testValue, vertex.getPropertyValue(propertyKey));
     assertEquals(testLabel, vertex.getLabel());
+  }
+
+  /**
+   * Test for the {@link CompositeKeyFunctionWithDefaultValues#isDefaultKey(Object)} function.
+   */
+  @Test
+  public void testIsDefaultKey() {
+    KeyFunction<Element, Tuple> keyFunction = getInstance();
+    assertTrue(keyFunction instanceof DefaultKeyCheckable);
+    DefaultKeyCheckable toTest = (DefaultKeyCheckable) keyFunction;
+    assertFalse("wrong type", toTest.isDefaultKey(1L));
+    assertFalse("wrong arity", toTest.isDefaultKey(
+      Tuple3.of(PropertyValue.NULL_VALUE.getRawBytes(), "", "")));
+    assertTrue(toTest.isDefaultKey(Tuple2.of(PropertyValue.NULL_VALUE.getRawBytes(), "")));
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/ConstantKeyFunctionTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/ConstantKeyFunctionTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.impl.operators.keyedgrouping.keys;
+
+import org.gradoop.common.model.api.entities.Element;
+import org.gradoop.flink.model.api.functions.KeyFunction;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test for the {@link ConstantKeyFunction}.
+ */
+public class ConstantKeyFunctionTest extends KeyFunctionTestBase<Element, Boolean> {
+
+  @Override
+  protected KeyFunction<Element, Boolean> getInstance() {
+    return new ConstantKeyFunction<>();
+  }
+
+  @Override
+  protected Map<Element, Boolean> getTestElements() {
+    Map<Element, Boolean> testCases = new HashMap<>();
+    testCases.put(getConfig().getLogicalGraphFactory().getVertexFactory().createVertex(), Boolean.TRUE);
+    return testCases;
+  }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/ConstantKeyFunctionTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/ConstantKeyFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/KeyFunctionTestBase.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/KeyFunctionTestBase.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.impl.operators.keyedgrouping.keys;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.gradoop.flink.model.GradoopFlinkTestBase;
+import org.gradoop.flink.model.api.functions.KeyFunction;
+import org.gradoop.flink.model.api.functions.KeyFunctionWithDefaultValue;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * A base class for key-function tests. This provides some common tests that should pass by all keys to be
+ * used for grouping.
+ *
+ * @param <E> The element type.
+ * @param <K> The key type.
+ */
+public abstract class KeyFunctionTestBase<E, K> extends GradoopFlinkTestBase {
+
+  /**
+   * Flag indicating whether a serialized and deserialized key should be checked for equality.
+   * Setting this to false might be useful when testing composite keys or keys that use array types.
+   */
+  protected boolean checkForKeyEquality;
+
+  /**
+   * Get an instance of the key function to test.
+   *
+   * @return The key function.
+   */
+  protected abstract KeyFunction<E, K> getInstance();
+
+  /**
+   * Get a {@link Map} of test cases for the {@link KeyFunction#getKey(Object)} method.
+   * Keys of this map will be elements and values keys extracted from those elements.<p>
+   * The default implementation of this method provides no test elements.
+   *
+   * @return A map of test cases.
+   */
+  protected Map<E, K> getTestElements() {
+    return Collections.emptyMap();
+  }
+
+  /**
+   * Setup this test.
+   */
+  @Before
+  public void setUp() {
+    checkForKeyEquality = true;
+  }
+
+  /**
+   * Check if the {@link KeyFunction#getType()} function returns a non-{@code null} value that is a valid
+   * key type.
+   */
+  @Test
+  public void checkTypeInfo() {
+    TypeInformation<K> type = getInstance().getType();
+    assertNotNull("Type information provided by the key fuction was null.", type);
+    assertTrue("Type is not a valid key type.", type.isKeyType());
+    assertNotEquals("Key type has no fields.", 0, type.getTotalFields());
+  }
+
+  /**
+   * Check if the default key value has the correct type.<p>
+   * This test will only run if the key function has a default key.
+   *
+   * @throws IOException when serialization of a key fails.
+   */
+  @Test
+  public void checkDefaultKey() throws IOException {
+    KeyFunction<E, K> function = getInstance();
+    assumeTrue(function instanceof KeyFunctionWithDefaultValue);
+    KeyFunctionWithDefaultValue<E, K> withDefaultValue = (KeyFunctionWithDefaultValue<E, K>) function;
+    K defaultKey = withDefaultValue.getDefaultKey();
+    checkKeyType(withDefaultValue.getType(), defaultKey);
+    assertTrue(withDefaultValue.isDefaultKey(defaultKey));
+  }
+
+  /**
+   * Check if a key is of a certain type and if it is serializable as that type.
+   *
+   * @param type The type.
+   * @param key  The key to check.
+   * @throws IOException when serialization of the key fails.
+   */
+  protected void checkKeyType(TypeInformation<K> type, K key) throws IOException {
+    assertTrue(type.getTypeClass().isInstance(key));
+    // Check serializability
+    ByteArrayOutputStream byteOutput = new ByteArrayOutputStream();
+    DataOutputViewStreamWrapper output = new DataOutputViewStreamWrapper(byteOutput);
+    TypeSerializer<K> serializer = type.createSerializer(getExecutionEnvironment().getConfig());
+    serializer.serialize(key, output);
+    output.close();
+    byte[] serializedData = byteOutput.toByteArray();
+    DataInputViewStreamWrapper input = new DataInputViewStreamWrapper(
+      new ByteArrayInputStream(serializedData));
+    K deserializedKey = serializer.deserialize(input);
+    if (checkForKeyEquality) {
+      assertTrue(Objects.deepEquals(key, deserializedKey));
+    }
+    input.close();
+  }
+
+  /**
+   * Test the {@link KeyFunction#getKey(Object)} function using test cases provided by
+   * {@link #getTestElements()}.
+   *
+   * @throws IOException when serialization of a key fails
+   */
+  @Test
+  public void testGetKey() throws IOException {
+    final KeyFunction<E, K> function = getInstance();
+    TypeInformation<K> type = function.getType();
+    for (Map.Entry<E, K> testCase : getTestElements().entrySet()) {
+      final K actual = function.getKey(testCase.getKey());
+      final K expected = testCase.getValue();
+      checkKeyType(type, actual);
+      assertTrue(Objects.deepEquals(expected, actual));
+    }
+  }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/KeyFunctionTestBase.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/KeyFunctionTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/LabelKeyFunctionTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/LabelKeyFunctionTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.impl.operators.keyedgrouping.keys;
+
+import org.gradoop.common.model.api.entities.Element;
+import org.gradoop.common.model.api.entities.Labeled;
+import org.gradoop.common.model.api.entities.VertexFactory;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
+import org.gradoop.flink.model.api.functions.KeyFunction;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * Test for the {@link LabelKeyFunction}.
+ */
+public class LabelKeyFunctionTest extends KeyFunctionTestBase<Element, String> {
+
+  @Override
+  protected KeyFunction<Element, String> getInstance() {
+    return new LabelKeyFunction<>();
+  }
+
+  @Override
+  protected Map<Element, String> getTestElements() {
+    final VertexFactory<EPGMVertex> vertexFactory = getConfig().getLogicalGraphFactory().getVertexFactory();
+    Map<Element, String> testCases = new HashMap<>();
+    testCases.put(vertexFactory.createVertex(), "");
+    final String testLabel = "test";
+    testCases.put(vertexFactory.createVertex(testLabel), testLabel);
+    return testCases;
+  }
+
+  /**
+   * Test for the {@link LabelKeyFunction#addKeyToElement(Labeled, Object)} function.
+   */
+  @Test
+  public void testAddKeyToElement() {
+    final EPGMVertex testVertex = getConfig().getLogicalGraphFactory().getVertexFactory().createVertex();
+    final String testLabel = "testLabel";
+    assertNotEquals(testLabel, testVertex.getLabel());
+    getInstance().addKeyToElement(testVertex, testLabel);
+    assertEquals(testLabel, testVertex.getLabel());
+  }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/LabelKeyFunctionTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/LabelKeyFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/PropertyKeyFunctionTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/PropertyKeyFunctionTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.impl.operators.keyedgrouping.keys;
+
+import org.gradoop.common.GradoopTestUtils;
+import org.gradoop.common.model.api.entities.Attributed;
+import org.gradoop.common.model.api.entities.Element;
+import org.gradoop.common.model.api.entities.VertexFactory;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
+import org.gradoop.common.model.impl.properties.PropertyValue;
+import org.gradoop.flink.model.api.functions.KeyFunction;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test for the {@link PropertyKeyFunction}.
+ */
+public class PropertyKeyFunctionTest extends KeyFunctionTestBase<Element, byte[]> {
+
+  /**
+   * The key of the properties to extract.
+   */
+  private final String key = "key";
+
+  @Override
+  protected KeyFunction<Element, byte[]> getInstance() {
+    return new PropertyKeyFunction<>(key);
+  }
+
+  @Override
+  protected Map<Element, byte[]> getTestElements() {
+    final VertexFactory<EPGMVertex> vertexFactory = getConfig().getLogicalGraphFactory().getVertexFactory();
+    Map<Element, byte[]> testCases = new HashMap<>();
+    testCases.put(vertexFactory.createVertex(), PropertyValue.NULL_VALUE.getRawBytes());
+    EPGMVertex testVertex = vertexFactory.createVertex();
+    testVertex.setProperty(key, GradoopTestUtils.LONG_VAL_3);
+    testCases.put(testVertex, PropertyValue.create(GradoopTestUtils.LONG_VAL_3).getRawBytes());
+    return testCases;
+  }
+
+  /**
+   * Test for the {@link PropertyKeyFunction#addKeyToElement(Attributed, Object)} function.
+   */
+  @Test
+  public void testAddKeyToElement() {
+    final EPGMVertex testVertex = getConfig().getLogicalGraphFactory().getVertexFactory().createVertex();
+    final PropertyValue testValue = PropertyValue.create(GradoopTestUtils.BIG_DECIMAL_VAL_7);
+    assertFalse(testVertex.hasProperty(key));
+    getInstance().addKeyToElement(testVertex, testValue.getRawBytes());
+    assertEquals(testValue, testVertex.getPropertyValue(key));
+  }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/PropertyKeyFunctionTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/keys/PropertyKeyFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,8 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Test for the {@link PropertyKeyFunction}.

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/labelspecific/WithAllKeysSetToDefaultTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/labelspecific/WithAllKeysSetToDefaultTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.impl.operators.keyedgrouping.labelspecific;
+
+import org.apache.flink.api.java.tuple.Tuple;
+import org.gradoop.common.model.api.entities.Element;
+import org.gradoop.flink.model.GradoopFlinkTestBase;
+import org.gradoop.flink.model.api.functions.KeyFunction;
+import org.gradoop.flink.model.impl.operators.keyedgrouping.keys.CompositeKeyFunction;
+import org.gradoop.flink.model.impl.operators.keyedgrouping.keys.LabelKeyFunction;
+import org.gradoop.flink.model.impl.operators.keyedgrouping.keys.PropertyKeyFunction;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.gradoop.common.GradoopTestUtils.BIG_DECIMAL_VAL_7;
+import static org.gradoop.common.GradoopTestUtils.KEY_0;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for the {@link WithAllKeysSetToDefault} filter function.
+ */
+public class WithAllKeysSetToDefaultTest extends GradoopFlinkTestBase {
+
+  /**
+   * A key function that can not be used with the filter function.
+   */
+  private final KeyFunction<Element, Tuple> invalidKeyFunction = new CompositeKeyFunction<>(
+    Collections.emptyList());
+
+  /**
+   * A key function that can be used with the filter function.
+   */
+  private final LabelKeyFunction<Element> validKeyFunction = new LabelKeyFunction<>();
+
+  /**
+   * Another key function that can be used with the filter function.
+   */
+  private final PropertyKeyFunction<Element> validKeyFunction2 = new PropertyKeyFunction<>(KEY_0);
+
+  /**
+   * Test if the constructor throws an {@link IllegalArgumentException} when a non-supported function
+   * is supplied.
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testConstructorWithInvalidKey() {
+    new WithAllKeysSetToDefault<>(Arrays.asList(validKeyFunction, invalidKeyFunction));
+  }
+
+  /**
+   * Test if the filter works as expected.
+   */
+  @Test
+  public void testFilter() {
+    final WithAllKeysSetToDefault<Element> filter = new WithAllKeysSetToDefault<>(Arrays.asList(
+      validKeyFunction, validKeyFunction2));
+    final Element vertex = getConfig().getLogicalGraphFactory().getVertexFactory().createVertex();
+    assertTrue(filter.filter(vertex));
+    vertex.setLabel("a");
+    assertFalse(filter.filter(vertex));
+    vertex.setLabel("");
+    vertex.setProperty(KEY_0, BIG_DECIMAL_VAL_7);
+    assertFalse(filter.filter(vertex));
+    vertex.setLabel("a");
+    assertFalse(filter.filter(vertex));
+  }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/labelspecific/WithAllKeysSetToDefaultTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/keyedgrouping/labelspecific/WithAllKeysSetToDefaultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Adds the feature to retain ungrouped vertices to `KeyedGrouping`.

## Description
Adds the feature as well as tests.

## Related Issue
#1433

## Motivation and Context
This was supported in the older grouping implementation, this is now also supported here.

## How Has This Been Tested?
Reuses some old tests and adds new tests.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if necessary).
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I ran a spell checker.

