### PR TITLE
[#1463] Use -DskipITs to skip maven archetype integration-test

### DIFF
--- a/gradoop-quickstart/pom.xml
+++ b/gradoop-quickstart/pom.xml
@@ -65,6 +65,9 @@
         <plugin>
           <artifactId>maven-archetype-plugin</artifactId>
           <version>3.1.2</version>
+          <configuration>
+            <skip>${skipITs}</skip>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Use -DskipITs to skip maven archetype integration-test

## Description
<!--- Describe your changes in detail -->
Use -DskipITs to skip maven archetype integration-test. -DskipITs is used in the maven-failsafe-plugin to skip integration tests.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1463

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#1463

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Running it with -DskipITs

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if necessary).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I ran a spell checker.

