### PR TITLE
[#1496] Extended min and max aggregation with date and datetime types

### DIFF
--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValueUtils.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValueUtils.java
@@ -618,6 +618,7 @@ public class PropertyValueUtils {
    * Date and DateTime utilities.
    */
   public static class Date {
+
     /**
      * Compares two time property values and returns the chronological first one.
      * <p>
@@ -631,7 +632,7 @@ public class PropertyValueUtils {
      * @return the time property value that is the chronological first
      */
     public static PropertyValue min(PropertyValue a, PropertyValue b) {
-      return isLessOrEqualThan(a, b) ? a : b;
+      return compare(a, b) <= 0 ? a : b;
     }
 
     /**
@@ -647,30 +648,33 @@ public class PropertyValueUtils {
      * @return the time property value that is the chronological last
      */
     public static PropertyValue max(PropertyValue a, PropertyValue b) {
-      return isLessOrEqualThan(a, b) ? b : a;
+      return compare(a, b) <= 0 ? b : a;
     }
 
     /**
-     * Compares two date or datetime property values and returns true, if the first one is earlier or equal to
-     * the second one. Note that the comparison of a {@link java.time.LocalDate} with a {@link LocalDateTime}
+     * Compares two date or datetime property values and returns {@code -1}, if the first one is earlier,
+     * {@code 0} equal or {@code 1} later than the second one.
+     * Note that the comparison of a {@link java.time.LocalDate} with a {@link LocalDateTime}
      * will cause casting the {@link java.time.LocalDate} to a {@link java.time.LocalDateTime} instance.
      *
      * @param aValue first value
      * @param bValue second value
      *
-     * @return true, iff the first time is earlier or equal to the second one
+     * @return returns {@code -1}, if the first one is earlier, {@code 0} equal or {@code 1} later than the
+     *         second one
+     * @throws IllegalArgumentException if arguments are not of type Date or DateTime
      */
-    private static boolean isLessOrEqualThan(PropertyValue aValue, PropertyValue bValue) {
+    private static int compare(PropertyValue aValue, PropertyValue bValue) {
       if (aValue.isDateTime() && bValue.isDateTime()) {
-        return aValue.getDateTime().compareTo(bValue.getDateTime()) <= 0;
+        return aValue.getDateTime().compareTo(bValue.getDateTime());
       } else if (aValue.isDate() && bValue.isDate()) {
-        return aValue.getDate().compareTo(bValue.getDate()) <= 0;
+        return aValue.getDate().compareTo(bValue.getDate());
       } else if (aValue.isDate() && bValue.isDateTime()) {
         // cast a to DateTime
-        return LocalDateTime.of(aValue.getDate(), LocalTime.MIN).compareTo(bValue.getDateTime()) <= 0;
+        return LocalDateTime.of(aValue.getDate(), LocalTime.MIN).compareTo(bValue.getDateTime());
       } else if (aValue.isDateTime() && bValue.isDate()) {
         // cast b to DateTime
-        return aValue.getDateTime().compareTo(LocalDateTime.of(bValue.getDate(), LocalTime.MIN)) <= 0;
+        return aValue.getDateTime().compareTo(LocalDateTime.of(bValue.getDate(), LocalTime.MIN));
       } else {
         throw new IllegalArgumentException("Arguments to compare are not of type Date or DateTime.");
       }

--- a/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValueUtils.java
+++ b/gradoop-common/src/main/java/org/gradoop/common/model/impl/properties/PropertyValueUtils.java
@@ -18,6 +18,8 @@ package org.gradoop.common.model.impl.properties;
 import org.gradoop.common.exceptions.UnsupportedTypeException;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -416,8 +418,7 @@ public class PropertyValueUtils {
      *
      * @return a < b
      */
-    private static boolean isLessOrEqualThan(
-      PropertyValue aValue, PropertyValue bValue) {
+    private static boolean isLessOrEqualThan(PropertyValue aValue, PropertyValue bValue) {
 
       int aType = checkNumericalAndGetType(aValue);
       int bType = checkNumericalAndGetType(bValue);
@@ -610,6 +611,79 @@ public class PropertyValueUtils {
       default:
         return value.getLong();
       }
+    }
+  }
+
+  /**
+   * Date and DateTime utilities.
+   */
+  public static class Date {
+    /**
+     * Compares two time property values and returns the chronological first one.
+     * <p>
+     * Note that the comparison of a {@link java.time.LocalDate} with a {@link LocalDateTime}
+     * will cause casting the {@link java.time.LocalDate} to a {@link java.time.LocalDateTime}
+     * instance, but just for the comparison. The return value is not casted.
+     *
+     * @param a first value
+     * @param b second value
+     *
+     * @return the time property value that is the chronological first
+     */
+    public static PropertyValue min(PropertyValue a, PropertyValue b) {
+      return isLessOrEqualThan(a, b) ? a : b;
+    }
+
+    /**
+     * Compares two time property values and returns the chronological last one.
+     * <p>
+     * Note that the comparison of a {@link java.time.LocalDate} with a {@link LocalDateTime}
+     * will cause casting the {@link java.time.LocalDate} to a {@link java.time.LocalDateTime}
+     * instance, but just for the comparison. The return value is not casted.
+     *
+     * @param a first value
+     * @param b second value
+     *
+     * @return the time property value that is the chronological last
+     */
+    public static PropertyValue max(PropertyValue a, PropertyValue b) {
+      return isLessOrEqualThan(a, b) ? b : a;
+    }
+
+    /**
+     * Compares two date or datetime property values and returns true, if the first one is earlier or equal to
+     * the second one. Note that the comparison of a {@link java.time.LocalDate} with a {@link LocalDateTime}
+     * will cause casting the {@link java.time.LocalDate} to a {@link java.time.LocalDateTime} instance.
+     *
+     * @param aValue first value
+     * @param bValue second value
+     *
+     * @return true, iff the first time is earlier or equal to the second one
+     */
+    private static boolean isLessOrEqualThan(PropertyValue aValue, PropertyValue bValue) {
+      if (aValue.isDateTime() && bValue.isDateTime()) {
+        return aValue.getDateTime().compareTo(bValue.getDateTime()) <= 0;
+      } else if (aValue.isDate() && bValue.isDate()) {
+        return aValue.getDate().compareTo(bValue.getDate()) <= 0;
+      } else if (aValue.isDate() && bValue.isDateTime()) {
+        // cast a to DateTime
+        return LocalDateTime.of(aValue.getDate(), LocalTime.MIN).compareTo(bValue.getDateTime()) <= 0;
+      } else if (aValue.isDateTime() && bValue.isDate()) {
+        // cast b to DateTime
+        return aValue.getDateTime().compareTo(LocalDateTime.of(bValue.getDate(), LocalTime.MIN)) <= 0;
+      } else {
+        throw new IllegalArgumentException("Arguments to compare are not of type Date or DateTime.");
+      }
+    }
+
+    /**
+     * Checks the property value type for Date or DateTime.
+     *
+     * @param value the property value to check
+     * @return true, iff the value is a Date or DateTime type
+     */
+    public static boolean isDateOrDateTime(PropertyValue value) {
+      return value.isDate() || value.isDateTime();
     }
   }
 

--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/properties/PropertyValueUtilsTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/properties/PropertyValueUtilsTest.java
@@ -18,6 +18,8 @@ package org.gradoop.common.model.impl.properties;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 
 import static org.gradoop.common.GradoopTestUtils.*;
@@ -991,6 +993,133 @@ public class PropertyValueUtilsTest {
         .createFromTypeValueBytes(new byte[] {type},
           Arrays.copyOfRange(propertyValue.getRawBytes(),
             1, propertyValue.getRawBytes().length)));
+    }
+  }
+
+  /**
+   * Test class for {@link PropertyValueUtils.Date}
+   */
+  public static class DateTest {
+
+    private final PropertyValue date1 = PropertyValue.create(LocalDate.of(2020, 1, 16));
+    private final PropertyValue date2 = PropertyValue.create(LocalDate.of(2020, 1, 17));
+    private final PropertyValue dateTime1 = PropertyValue.create(LocalDateTime.of(2020, 1, 16, 12, 10, 55));
+    private final PropertyValue dateTime2 = PropertyValue.create(LocalDateTime.of(2020, 1, 16, 12, 10, 56));
+
+    @Test
+    public void testMin() {
+      PropertyValue p;
+
+      // Compare two dates
+      p = PropertyValueUtils.Date.min(date1, date2);
+      assertTrue(p.isDate());
+      assertEquals(date1, p);
+
+      p = PropertyValueUtils.Date.min(date2, date1);
+      assertTrue(p.isDate());
+      assertEquals(date1, p);
+
+      p = PropertyValueUtils.Date.min(date1, date1);
+      assertTrue(p.isDate());
+      assertEquals(date1, p);
+
+      // Compare two date times
+      p = PropertyValueUtils.Date.min(dateTime1, dateTime2);
+      assertTrue(p.isDateTime());
+      assertEquals(dateTime1, p);
+
+      p = PropertyValueUtils.Date.min(dateTime2, dateTime1);
+      assertTrue(p.isDateTime());
+      assertEquals(dateTime1, p);
+
+      p = PropertyValueUtils.Date.min(dateTime1, dateTime1);
+      assertTrue(p.isDateTime());
+      assertEquals(dateTime1, p);
+
+      // Compare a date with date time
+      p = PropertyValueUtils.Date.min(date1, dateTime1);
+      assertTrue(p.isDate());
+      assertEquals(date1, p);
+
+      p = PropertyValueUtils.Date.min(date2, dateTime1);
+      assertTrue(p.isDateTime());
+      assertEquals(dateTime1, p);
+
+      p = PropertyValueUtils.Date.min(dateTime2, date2);
+      assertTrue(p.isDateTime());
+      assertEquals(dateTime2, p);
+
+      p = PropertyValueUtils.Date.min(dateTime1, date1);
+      assertTrue(p.isDate());
+      assertEquals(date1, p);
+    }
+
+    @Test(expectedExceptions = { IllegalArgumentException.class })
+    public void testMinTypeException() {
+      PropertyValueUtils.Date.min(date1, PropertyValue.create(5));
+    }
+
+    @Test
+    public void testMax() {
+      PropertyValue p;
+
+      // Compare two dates
+      p = PropertyValueUtils.Date.max(date1, date2);
+      assertTrue(p.isDate());
+      assertEquals(date2, p);
+
+      p = PropertyValueUtils.Date.max(date2, date1);
+      assertTrue(p.isDate());
+      assertEquals(date2, p);
+
+      p = PropertyValueUtils.Date.max(date1, date1);
+      assertTrue(p.isDate());
+      assertEquals(date1, p);
+
+      // Compare two date times
+      p = PropertyValueUtils.Date.max(dateTime1, dateTime2);
+      assertTrue(p.isDateTime());
+      assertEquals(dateTime2, p);
+
+      p = PropertyValueUtils.Date.max(dateTime2, dateTime1);
+      assertTrue(p.isDateTime());
+      assertEquals(dateTime2, p);
+
+      p = PropertyValueUtils.Date.max(dateTime1, dateTime1);
+      assertTrue(p.isDateTime());
+      assertEquals(dateTime1, p);
+
+      // Compare a date with date time
+      p = PropertyValueUtils.Date.max(date1, dateTime1);
+      assertTrue(p.isDateTime());
+      assertEquals(dateTime1, p);
+
+      p = PropertyValueUtils.Date.max(date2, dateTime1);
+      assertTrue(p.isDate());
+      assertEquals(date2, p);
+
+      p = PropertyValueUtils.Date.max(dateTime2, date2);
+      assertTrue(p.isDate());
+      assertEquals(date2, p);
+
+      p = PropertyValueUtils.Date.max(dateTime1, date1);
+      assertTrue(p.isDateTime());
+      assertEquals(dateTime1, p);
+    }
+
+    @Test(expectedExceptions = { IllegalArgumentException.class })
+    public void testMaxTypeException() {
+      PropertyValueUtils.Date.max(date1, PropertyValue.create(5));
+    }
+
+    @Test
+    public void testIisDateOrDateTime() {
+      assertTrue(PropertyValueUtils.Date.isDateOrDateTime(date1));
+      assertTrue(PropertyValueUtils.Date.isDateOrDateTime(date2));
+      assertTrue(PropertyValueUtils.Date.isDateOrDateTime(dateTime1));
+      assertTrue(PropertyValueUtils.Date.isDateOrDateTime(dateTime2));
+      assertFalse(PropertyValueUtils.Date.isDateOrDateTime(PropertyValue.create(5)));
+      assertFalse(PropertyValueUtils.Date.isDateOrDateTime(PropertyValue.create("date")));
     }
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/functions/max/Max.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/functions/max/Max.java
@@ -26,6 +26,11 @@ public interface Max extends AggregateFunction {
 
   @Override
   default PropertyValue aggregate(PropertyValue aggregate, PropertyValue increment) {
+    // If both values are of either type date or datetime, use the corresponding utility class.
+    if (PropertyValueUtils.Date.isDateOrDateTime(aggregate) &&
+      PropertyValueUtils.Date.isDateOrDateTime(increment)) {
+      return PropertyValueUtils.Date.max(aggregate, increment);
+    }
     return PropertyValueUtils.Numeric.max(aggregate, increment);
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/functions/max/Max.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/functions/max/Max.java
@@ -20,7 +20,9 @@ import org.gradoop.common.model.impl.properties.PropertyValueUtils;
 import org.gradoop.flink.model.api.functions.AggregateFunction;
 
 /**
- * Interface of aggregate functions that determine a maximal value.
+ * Interface of aggregate functions that determine a maximal value.<br>
+ * This aggregation supports numerical property value types (short, int, long, float, double, big decimal) and
+ * date and datetime types.
  */
 public interface Max extends AggregateFunction {
 

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/functions/min/Min.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/functions/min/Min.java
@@ -23,9 +23,13 @@ import org.gradoop.flink.model.api.functions.AggregateFunction;
  * Interface of aggregate functions that determine a minimal value.
  */
 public interface Min extends AggregateFunction {
-
   @Override
   default PropertyValue aggregate(PropertyValue aggregate, PropertyValue increment) {
+    // If both values are of either type date or datetime, use the corresponding utility class.
+    if (PropertyValueUtils.Date.isDateOrDateTime(aggregate) &&
+      PropertyValueUtils.Date.isDateOrDateTime(increment)) {
+      return PropertyValueUtils.Date.min(aggregate, increment);
+    }
     return PropertyValueUtils.Numeric.min(aggregate, increment);
   }
 }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/functions/min/Min.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/operators/aggregation/functions/min/Min.java
@@ -20,9 +20,12 @@ import org.gradoop.common.model.impl.properties.PropertyValueUtils;
 import org.gradoop.flink.model.api.functions.AggregateFunction;
 
 /**
- * Interface of aggregate functions that determine a minimal value.
+ * Interface of aggregate functions that determine a minimal value.<br>
+ * This aggregation supports numerical property value types (short, int, long, float, double, big decimal) and
+ * date and datetime types.
  */
 public interface Min extends AggregateFunction {
+
   @Override
   default PropertyValue aggregate(PropertyValue aggregate, PropertyValue increment) {
     // If both values are of either type date or datetime, use the corresponding utility class.

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/aggregation/functions/max/MaxTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/aggregation/functions/max/MaxTest.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.assertThrows;
  */
 @RunWith(Parameterized.class)
 public class MaxTest extends GradoopFlinkTestBase {
+
   /**
    * An instance of the interface to test.
    */

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/aggregation/functions/max/MaxTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/aggregation/functions/max/MaxTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.impl.operators.aggregation.functions.max;
+
+import org.gradoop.common.exceptions.UnsupportedTypeException;
+import org.gradoop.common.model.api.entities.Element;
+import org.gradoop.common.model.impl.properties.PropertyValue;
+import org.gradoop.flink.model.GradoopFlinkTestBase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Test class for {@link Max} interface.
+ */
+@RunWith(Parameterized.class)
+public class MaxTest extends GradoopFlinkTestBase {
+  /**
+   * An instance of the interface to test.
+   */
+  private final Max maxInstance = new MaxInstance();
+  /**
+   * Test datetime object.
+   */
+  private static final LocalDateTime testDateTime = LocalDateTime.ofEpochSecond(1610633705, 0, ZoneOffset.UTC);
+  /**
+   * Test date object.
+   */
+  private static final LocalDate testDate = LocalDate.of(2021, 1, 14);
+
+  /**
+   * The aggregate value of the aggregate function.
+   */
+  @Parameterized.Parameter(0)
+  public PropertyValue aggregate;
+
+  /**
+   * The increment value of the aggregate function.
+   */
+  @Parameterized.Parameter(1)
+  public PropertyValue increment;
+
+  /**
+   * The return value of the aggregate function.
+   */
+  @Parameterized.Parameter(2)
+  public PropertyValue returnProperty;
+
+  /**
+   * A possible exception. Should be {@code null} if no exception is expected.
+   */
+  @Parameterized.Parameter(3)
+  public Class<Throwable> exception;
+
+  /**
+   * The test parameters.
+   *
+   * @return an array of test parameters.
+   */
+  @Parameterized.Parameters(name = "Test Min({0}, {1}) == {2} (throws {3})")
+  public static Iterable<Object[]> parameters() {
+    return Arrays.asList(
+      new Object[]{PropertyValue.create(1L), PropertyValue.create(2L), PropertyValue.create(2L), null},
+      new Object[]{PropertyValue.create(2), PropertyValue.create(1), PropertyValue.create(2), null},
+      new Object[]{PropertyValue.create(0.3f), PropertyValue.create(0.33), PropertyValue.create(0.33), null},
+      new Object[]{PropertyValue.create(BigDecimal.TEN), PropertyValue.create(BigDecimal.ZERO), PropertyValue.create(BigDecimal.TEN), null},
+      new Object[]{PropertyValue.create(testDate), PropertyValue.create(testDate.minusDays(1)), PropertyValue.create(testDate), null},
+      new Object[]{PropertyValue.create(testDate), PropertyValue.create(testDate), PropertyValue.create(testDate), null},
+      new Object[]{PropertyValue.create(testDateTime), PropertyValue.create(testDateTime), PropertyValue.create(testDateTime), null},
+      new Object[]{PropertyValue.create(testDateTime), PropertyValue.create(testDateTime.minusHours(1)), PropertyValue.create(testDateTime), null},
+      new Object[]{PropertyValue.create(testDateTime), PropertyValue.create(5L), PropertyValue.create(null), UnsupportedTypeException.class},
+      new Object[]{PropertyValue.create("foo"), PropertyValue.create(5L), PropertyValue.create(null), UnsupportedTypeException.class}
+      );
+  }
+
+  /**
+   * Tests the {@link Max#aggregate(PropertyValue, PropertyValue)} function.
+   */
+  @Test
+  public void testAggregate() {
+    if (exception == null) {
+      assertEquals(returnProperty, maxInstance.aggregate(aggregate, increment));
+    } else {
+      assertThrows(exception, () -> maxInstance.aggregate(aggregate, increment));
+    }
+  }
+
+  /**
+   * Test class implementing the interface to be tested.
+   */
+  public static class MaxInstance implements Max {
+    @Override
+    public String getAggregatePropertyKey() {
+      return null;
+    }
+
+    @Override
+    public PropertyValue getIncrement(Element element) {
+      return null;
+    }
+  }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/aggregation/functions/min/MinTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/aggregation/functions/min/MinTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.impl.operators.aggregation.functions.min;
+
+import org.gradoop.common.exceptions.UnsupportedTypeException;
+import org.gradoop.common.model.api.entities.Element;
+import org.gradoop.common.model.impl.properties.PropertyValue;
+import org.gradoop.flink.model.GradoopFlinkTestBase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Test class for {@link Min} interface.
+ */
+@RunWith(Parameterized.class)
+public class MinTest extends GradoopFlinkTestBase {
+  /**
+   * An instance of the interface to test.
+   */
+  private final Min minInstance = new MinInstance();
+  /**
+   * Test datetime object.
+   */
+  private static final LocalDateTime testDateTime = LocalDateTime.ofEpochSecond(1610633705, 0, ZoneOffset.UTC);
+  /**
+   * Test date object.
+   */
+  private static final LocalDate testDate = LocalDate.of(2021, 1, 14);
+
+  /**
+   * The aggregate value of the aggregate function.
+   */
+  @Parameterized.Parameter(0)
+  public PropertyValue aggregate;
+
+  /**
+   * The increment value of the aggregate function.
+   */
+  @Parameterized.Parameter(1)
+  public PropertyValue increment;
+
+  /**
+   * The return value of the aggregate function.
+   */
+  @Parameterized.Parameter(2)
+  public PropertyValue returnProperty;
+
+  /**
+   * A possible exception. Should be {@code null} if no exception is expected.
+   */
+  @Parameterized.Parameter(3)
+  public Class<Throwable> exception;
+
+  /**
+   * The test parameters.
+   *
+   * @return an array of test parameters.
+   */
+  @Parameterized.Parameters(name = "Test Min({0}, {1}) == {2} (throws {3})")
+  public static Iterable<Object[]> parameters() {
+    return Arrays.asList(
+      new Object[]{PropertyValue.create(1L), PropertyValue.create(2L), PropertyValue.create(1L), null},
+      new Object[]{PropertyValue.create(2), PropertyValue.create(1), PropertyValue.create(1), null},
+      new Object[]{PropertyValue.create(0.3f), PropertyValue.create(0.33), PropertyValue.create(0.3f), null},
+      new Object[]{PropertyValue.create(BigDecimal.TEN), PropertyValue.create(BigDecimal.ZERO), PropertyValue.create(BigDecimal.ZERO), null},
+      new Object[]{PropertyValue.create(testDate), PropertyValue.create(testDate.plusDays(1)), PropertyValue.create(testDate), null},
+      new Object[]{PropertyValue.create(testDate), PropertyValue.create(testDate), PropertyValue.create(testDate), null},
+      new Object[]{PropertyValue.create(testDateTime), PropertyValue.create(testDate), PropertyValue.create(testDate), null},
+      new Object[]{PropertyValue.create(testDate), PropertyValue.create(testDateTime), PropertyValue.create(testDate), null},
+      new Object[]{PropertyValue.create(testDateTime), PropertyValue.create(testDateTime), PropertyValue.create(testDateTime), null},
+      new Object[]{PropertyValue.create(testDateTime), PropertyValue.create(testDateTime.plusHours(1)), PropertyValue.create(testDateTime), null},
+      new Object[]{PropertyValue.create(testDateTime), PropertyValue.create(5L), PropertyValue.create(null), UnsupportedTypeException.class},
+      new Object[]{PropertyValue.create("foo"), PropertyValue.create(5L), PropertyValue.create(null), UnsupportedTypeException.class}
+      );
+  }
+
+  /**
+   * Tests the {@link Min#aggregate(PropertyValue, PropertyValue)} function.
+   */
+  @Test
+  public void testAggregate() {
+    if (exception == null) {
+      assertEquals(returnProperty, minInstance.aggregate(aggregate, increment));
+    } else {
+      assertThrows(exception, () -> minInstance.aggregate(aggregate, increment));
+    }
+  }
+
+  /**
+   * Test class implementing the interface to be tested.
+   */
+  public static class MinInstance implements Min {
+    @Override
+    public String getAggregatePropertyKey() {
+      return null;
+    }
+
+    @Override
+    public PropertyValue getIncrement(Element element) {
+      return null;
+    }
+  }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/aggregation/functions/min/MinTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/aggregation/functions/min/MinTest.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.assertThrows;
  */
 @RunWith(Parameterized.class)
 public class MinTest extends GradoopFlinkTestBase {
+
   /**
    * An instance of the interface to test.
    */

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
         <dep.guava.version>11.0.2</dep.guava.version>
         <dep.hbase.version>1.4.3</dep.hbase.version>
         <dep.javafastpfor.version>0.1.10</dep.javafastpfor.version>
-        <dep.junit.version>4.12</dep.junit.version>
+        <dep.junit.version>4.13.1</dep.junit.version>
         <dep.jettison.version>1.3.7</dep.jettison.version>
         <dep.jsonassert.version>1.2.3</dep.jsonassert.version>
         <dep.kryo.version>4.0.2</dep.kryo.version>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Extended min and max aggregation with date and datetime support

## Related Issue
#1496
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Atm, just numerical types PropertyValue types can be used in min/max aggregations. It's not possible to use date or datetime types

## How Has This Been Tested?
Several JUnit and testNG classes with coverage.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if necessary).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I ran a spell checker.

