### PR TITLE
[#1481] Add support for quoted csv fields in MinimalCSVImporter

### DIFF
--- a/gradoop-data-integration/src/main/java/org/gradoop/dataintegration/importer/impl/csv/MinimalCSVImporter.java
+++ b/gradoop-data-integration/src/main/java/org/gradoop/dataintegration/importer/impl/csv/MinimalCSVImporter.java
@@ -59,19 +59,18 @@ public class MinimalCSVImporter implements DataSource {
   /**
    * The charset used in the csv file, e.g., "UTF-8".
    */
-  private final String charset;
+  private String charset = "UTF-8";
 
   /**
    * The property names for all columns in the file. If {@code null}, the first line will be
    * interpreted as header row.
    */
-  private List<String> columnNames;
+  private final List<String> columnNames;
 
   /**
-   * Flag to specify if each row of the file should be checked for reoccurring of the column
-   * property names.
+   * Flag to specify if each row of the file should be checked for reoccurring of the column property names.
    */
-  private boolean checkReoccurringHeader;
+  private boolean checkReoccurringHeader = false;
 
   /**
    * Flag to specify if quoted strings should be considered. Will escape delimiters inside quoted strings.
@@ -95,53 +94,41 @@ public class MinimalCSVImporter implements DataSource {
    * @param tokenSeparator the token delimiter of the csv file
    * @param config GradoopFlinkConfig configuration
    * @param columnNames property identifiers for each column
-   * @param checkReoccurringHeader if each row of the file should be checked for reoccurring of
-   *                               the column property names
    */
   public MinimalCSVImporter(String path, String tokenSeparator, GradoopFlinkConfig config,
-                            List<String> columnNames, boolean checkReoccurringHeader) {
-    this(path, tokenSeparator, config, checkReoccurringHeader);
-    this.columnNames = Objects.requireNonNull(columnNames);
+                            List<String> columnNames) {
+    this.path = Objects.requireNonNull(path);
+    this.tokenSeparator = Objects.requireNonNull(tokenSeparator);
+    this.config = Objects.requireNonNull(config);
+    this.columnNames = columnNames;
   }
 
   /**
-   * Create a new MinimalCSVImporter instance by the given parameters.
-   * Use the UTF-8 charset as default. The first line of the file will be set as the property
-   * names for each column.
-   *
-   * @param path the path to the csv file
-   * @param tokenSeparator the token delimiter of the csv file
-   * @param config GradoopFlinkConfig configuration
-   * @param checkReoccurringHeader if each row of the file should be checked for reoccurring of
-   *                               the column property names.
-   */
-  public MinimalCSVImporter(String path, String tokenSeparator, GradoopFlinkConfig config,
-                            boolean checkReoccurringHeader) {
-    this(path, tokenSeparator, config, "UTF-8", checkReoccurringHeader);
-  }
-
-  /**
-   * Create a new MinimalCSVImporter with a user set charset. The first line of the file
+   * Create a new MinimalCSVImporter instance by the given parameters. The first line of the file
    * will set as the property names for each column.
    *
    * @param path the path to the csv file
    * @param tokenSeparator the token delimiter of the csv file
    * @param config GradoopFlinkConfig configuration
-   * @param charset the charset used in the csv file
-   * @param checkReoccurringHeader if each row of the file should be checked for reoccurring of
-   *                               the column property names.
    */
-  public MinimalCSVImporter(String path, String tokenSeparator, GradoopFlinkConfig config,
-                            String charset, boolean checkReoccurringHeader) {
-    this.path = Objects.requireNonNull(path);
-    this.tokenSeparator = Objects.requireNonNull(tokenSeparator);
-    this.config = Objects.requireNonNull(config);
-    this.charset = Objects.requireNonNull(charset);
-    this.checkReoccurringHeader = checkReoccurringHeader;
+  public MinimalCSVImporter(String path, String tokenSeparator, GradoopFlinkConfig config) {
+    this(path, tokenSeparator, config, null);
+  }
+
+  /**
+   * Set charset of CSV file. UTF-8 is used as default.
+   *
+   * @param charset the charset used in the csv file, e.g., "UTF-8"
+   * @return this
+   */
+  public MinimalCSVImporter setCharset(String charset) {
+    this.charset = charset;
+    return this;
   }
 
   /**
    * Set checkReoccurringHeader flag.
+   * Each row of the file will be checked for reoccurrence of the column property names.
    *
    * @return this
    */

--- a/gradoop-data-integration/src/test/java/org/gradoop/dataintegration/importer/impl/csv/MinimalCSVImporterTest.java
+++ b/gradoop-data-integration/src/test/java/org/gradoop/dataintegration/importer/impl/csv/MinimalCSVImporterTest.java
@@ -57,7 +57,8 @@ public class MinimalCSVImporterTest extends GradoopFlinkTestBase {
   public void testImportVertexWithHeader() throws Exception {
     String csvPath = MinimalCSVImporterTest.class.getResource("/csv/input.csv").getPath();
 
-    DataSource importVertexImporter = new MinimalCSVImporter(csvPath, DELIMITER, getConfig(), true);
+    DataSource importVertexImporter = new MinimalCSVImporter(csvPath, DELIMITER, getConfig())
+      .checkReoccurringHeader();
 
     DataSet<EPGMVertex> importVertex = importVertexImporter.getLogicalGraph().getVertices();
 
@@ -78,7 +79,8 @@ public class MinimalCSVImporterTest extends GradoopFlinkTestBase {
   public void testImportGraphCollection() throws Exception {
     String csvPath = MinimalCSVImporterTest.class.getResource("/csv/input.csv").getPath();
 
-    DataSource importVertexImporter = new MinimalCSVImporter(csvPath, DELIMITER, getConfig(), true);
+    DataSource importVertexImporter = new MinimalCSVImporter(csvPath, DELIMITER, getConfig())
+      .checkReoccurringHeader();
 
     DataSet<EPGMVertex> importVertex = importVertexImporter.getGraphCollection().getVertices();
 
@@ -104,7 +106,7 @@ public class MinimalCSVImporterTest extends GradoopFlinkTestBase {
 
     List<String> columnNames = Arrays.asList("name", "value1", "value2", "value3");
 
-    DataSource importer = new MinimalCSVImporter(csvPath, DELIMITER, getConfig(), columnNames, false);
+    DataSource importer = new MinimalCSVImporter(csvPath, DELIMITER, getConfig(), columnNames);
     DataSet<EPGMVertex> importVertex = importer.getLogicalGraph().getVertices();
 
     List<EPGMVertex> lv = new ArrayList<>();
@@ -125,8 +127,7 @@ public class MinimalCSVImporterTest extends GradoopFlinkTestBase {
     // Create an empty file
     File emptyFile = File.createTempFile("empty-csv", null);
 
-    DataSource importer =
-      new MinimalCSVImporter(emptyFile.getPath(), DELIMITER, getConfig(), false);
+    DataSource importer = new MinimalCSVImporter(emptyFile.getPath(), DELIMITER, getConfig());
 
     checkExceptions(importer, emptyFile);
   }
@@ -144,8 +145,7 @@ public class MinimalCSVImporterTest extends GradoopFlinkTestBase {
     fileWriter.write(System.getProperty("line.separator"));
     fileWriter.close();
 
-    DataSource importer =
-      new MinimalCSVImporter(emptyFile.getPath(), DELIMITER, getConfig(), false);
+    DataSource importer = new MinimalCSVImporter(emptyFile.getPath(), DELIMITER, getConfig());
 
     checkExceptions(importer, emptyFile);
   }
@@ -163,7 +163,8 @@ public class MinimalCSVImporterTest extends GradoopFlinkTestBase {
 
     FlinkAsciiGraphLoader loader = getLoaderFromFile(gdlPath);
 
-    DataSource importVertexImporter = new MinimalCSVImporter(csvPath, DELIMITER, getConfig(), true);
+    DataSource importVertexImporter = new MinimalCSVImporter(csvPath, DELIMITER, getConfig())
+      .checkReoccurringHeader();
     LogicalGraph resultGraph = importVertexImporter.getLogicalGraph();
 
     LogicalGraph expectedGraph = loader.getLogicalGraphByVariable("expected");
@@ -188,8 +189,7 @@ public class MinimalCSVImporterTest extends GradoopFlinkTestBase {
     FlinkAsciiGraphLoader loader = getLoaderFromFile(gdlPath);
 
     List<String> columnNames = Arrays.asList("name", "value1", "value2", "value3");
-    DataSource importVertexImporter =
-      new MinimalCSVImporter(csvPath, DELIMITER, getConfig(), columnNames, false);
+    DataSource importVertexImporter = new MinimalCSVImporter(csvPath, DELIMITER, getConfig(), columnNames);
     LogicalGraph resultGraph = importVertexImporter.getLogicalGraph();
 
     LogicalGraph expectedGraph = loader.getLogicalGraphByVariable("expected");
@@ -211,13 +211,13 @@ public class MinimalCSVImporterTest extends GradoopFlinkTestBase {
 
     //set the first line of the file as column property names and check file of reoccurring and skip
     //header row as vertex
-    DataSource importerWithHeader =
-      new MinimalCSVImporter(csvPathWithHeader, DELIMITER, getConfig(), true);
+    DataSource importerWithHeader = new MinimalCSVImporter(csvPathWithHeader, DELIMITER, getConfig())
+      .checkReoccurringHeader();
 
     //read all rows of the csv files as vertices
     List<String> columnNames = Arrays.asList("name", "value1", "value2", "value3");
     DataSource importerWithoutHeader =
-      new MinimalCSVImporter(csvPathWithoutHeader, DELIMITER, getConfig(), columnNames, false);
+      new MinimalCSVImporter(csvPathWithoutHeader, DELIMITER, getConfig(), columnNames);
 
     LogicalGraph resultWithHeader = importerWithHeader.getLogicalGraph();
     LogicalGraph resultWithoutHeader = importerWithoutHeader.getLogicalGraph();
@@ -239,7 +239,7 @@ public class MinimalCSVImporterTest extends GradoopFlinkTestBase {
 
     FlinkAsciiGraphLoader loader = getLoaderFromFile(gdlPath);
 
-    DataSource importer = new MinimalCSVImporter(csvPath, DELIMITER, getConfig(), true);
+    DataSource importer = new MinimalCSVImporter(csvPath, DELIMITER, getConfig()).checkReoccurringHeader();
     LogicalGraph result = importer.getLogicalGraph();
 
     LogicalGraph expected = loader.getLogicalGraphByVariable("expected");
@@ -247,7 +247,7 @@ public class MinimalCSVImporterTest extends GradoopFlinkTestBase {
   }
 
   /**
-   * Test if no property will be created if a row contains empty entries .
+   * Test if no property will be created if a row contains empty entries.
    *
    * @throws Exception on failure
    */
@@ -256,7 +256,7 @@ public class MinimalCSVImporterTest extends GradoopFlinkTestBase {
     String csvPath = MinimalCSVImporterTest.class
       .getResource("/csv/inputEmptyPropertyValues.csv").getPath();
 
-    DataSource importer = new MinimalCSVImporter(csvPath, DELIMITER, getConfig(), true);
+    DataSource importer = new MinimalCSVImporter(csvPath, DELIMITER, getConfig()).checkReoccurringHeader();
     LogicalGraph result = importer.getLogicalGraph();
 
     List<EPGMVertex> lv = new ArrayList<>();
@@ -281,14 +281,19 @@ public class MinimalCSVImporterTest extends GradoopFlinkTestBase {
     }
   }
 
+  /**
+   * Test if delimiters in quoted CSV fields are ignored.
+   *
+   * @throws Exception on failure
+   */
   @Test
   public void testQuotedFields() throws Exception {
     String csvPath = MinimalCSVImporterTest.class.getResource("/csv/inputQuoted.csv").getPath();
     String gdlPath = MinimalCSVImporterTest.class.getResource("/csv/expectedQuoted.gdl").getPath();
 
     FlinkAsciiGraphLoader loader = getLoaderFromFile(gdlPath);
-    DataSource importVertexImporter = new MinimalCSVImporter(csvPath, DELIMITER, getConfig(), true)
-      .parseQuotedStrings().quoteCharacter('"');
+    DataSource importVertexImporter = new MinimalCSVImporter(csvPath, DELIMITER, getConfig())
+      .checkReoccurringHeader().parseQuotedStrings().quoteCharacter('"');
     LogicalGraph resultGraph = importVertexImporter.getLogicalGraph();
     LogicalGraph expectedGraph = loader.getLogicalGraphByVariable("expected");
 

--- a/gradoop-data-integration/src/test/java/org/gradoop/dataintegration/importer/impl/csv/MinimalCSVImporterTest.java
+++ b/gradoop-data-integration/src/test/java/org/gradoop/dataintegration/importer/impl/csv/MinimalCSVImporterTest.java
@@ -281,6 +281,20 @@ public class MinimalCSVImporterTest extends GradoopFlinkTestBase {
     }
   }
 
+  @Test
+  public void testQuotedFields() throws Exception {
+    String csvPath = MinimalCSVImporterTest.class.getResource("/csv/inputQuoted.csv").getPath();
+    String gdlPath = MinimalCSVImporterTest.class.getResource("/csv/expectedQuoted.gdl").getPath();
+
+    FlinkAsciiGraphLoader loader = getLoaderFromFile(gdlPath);
+    DataSource importVertexImporter = new MinimalCSVImporter(csvPath, DELIMITER, getConfig(), true)
+      .parseQuotedStrings().quoteCharacter('"');
+    LogicalGraph resultGraph = importVertexImporter.getLogicalGraph();
+    LogicalGraph expectedGraph = loader.getLogicalGraphByVariable("expected");
+
+    collectAndAssertTrue(expectedGraph.equalsByElementData(resultGraph));
+  }
+
   /**
    * Checks if the csv file import is equals to the assert import.
    *

--- a/gradoop-data-integration/src/test/resources/csv/expectedQuoted.gdl
+++ b/gradoop-data-integration/src/test/resources/csv/expectedQuoted.gdl
@@ -1,0 +1,5 @@
+expected [
+ (v0 {name:"fo;o", value1:"453", value3:"71.03"}),
+ (v1 {name:"bar", value1:"76", value2:"false", value3:"33.4"}),
+ (v2 {name:"bla;", value1:"4568", value3:";9.4;2;"})
+]

--- a/gradoop-data-integration/src/test/resources/csv/inputQuoted.csv
+++ b/gradoop-data-integration/src/test/resources/csv/inputQuoted.csv
@@ -1,0 +1,4 @@
+name;value1;value2;value3
+"fo;o";453;"";"71.03"
+bar;76;false;33.4
+"bla;";4568;;";9.4;2;"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add parseQuotedStrings flag to MinimalCSVImporter. Replace readFile with Flink CSVReader to use the flag.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1481 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Quoting is popular in CSV files to escape delimiters.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
New test added. 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if necessary).
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I ran a spell checker.

