### PR TITLE
[#1510] Add indexed temporal csv source and sink

### DIFF
--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVBase.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/CSVBase.java
@@ -190,10 +190,20 @@ public abstract class CSVBase {
       CSVConstants.SIMPLE_FILE;
   }
 
+  /**
+   * Get the path to the metadata file.
+   *
+   * @return the path to the metadata file as string
+   */
   protected String getMetaDataPath() {
     return csvRoot + METADATA_FILE;
   }
 
+  /**
+   * Get the gradoop configuration.
+   *
+   * @return the gradoop configuration instance
+   */
   protected GradoopFlinkConfig getConfig() {
     return config;
   }

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/indexed/IndexedCSVDataSink.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/indexed/IndexedCSVDataSink.java
@@ -44,7 +44,7 @@ public class IndexedCSVDataSink extends CSVBase implements DataSink {
   /**
    * Path to meta data file that is used to write the output.
    */
-  protected final String metaDataPath;
+  private final String metaDataPath;
 
   /**
    * Creates a new indexed CSV data sink. Computes the meta data based on the given graph.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/indexed/IndexedCSVDataSource.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/indexed/IndexedCSVDataSource.java
@@ -56,7 +56,7 @@ public class IndexedCSVDataSource extends CSVBase implements DataSource {
   /**
    * HDFS Configuration.
    */
-  private final Configuration hdfsConfig;
+  protected final Configuration hdfsConfig;
 
   /**
    * Creates a new data source. The constructor creates a default HDFS configuration.

--- a/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/indexed/IndexedCSVDataSource.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/io/impl/csv/indexed/IndexedCSVDataSource.java
@@ -56,7 +56,7 @@ public class IndexedCSVDataSource extends CSVBase implements DataSource {
   /**
    * HDFS Configuration.
    */
-  protected final Configuration hdfsConfig;
+  private final Configuration hdfsConfig;
 
   /**
    * Creates a new data source. The constructor creates a default HDFS configuration.
@@ -77,8 +77,7 @@ public class IndexedCSVDataSource extends CSVBase implements DataSource {
    */
   public IndexedCSVDataSource(String csvPath, GradoopFlinkConfig conf, Configuration hdfsConf) {
     super(csvPath, conf);
-    Objects.requireNonNull(hdfsConf);
-    this.hdfsConfig = hdfsConf;
+    this.hdfsConfig = Objects.requireNonNull(hdfsConf);
   }
 
   /**

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraphFactory.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/epgm/BaseGraphFactory.java
@@ -90,17 +90,6 @@ public interface BaseGraphFactory<
   LG fromDataSets(DataSet<G> graphHead, DataSet<V> vertices, DataSet<E> edges);
 
   /**
-   * Creates a logical graph from the given datasets. A new graph head is created and all vertices
-   * and edges are assigned to that graph head.
-   *
-   * @param vertices label indexed vertex datasets
-   * @param edges label indexed edge datasets
-   * @return Logical graph
-   */
-  LG fromIndexedDataSets(Map<String, DataSet<V>> vertices,
-    Map<String, DataSet<E>> edges);
-
-  /**
    * Creates a logical graph from the given datasets. The method assumes that all vertices and
    * edges are already assigned to the specified graph head.
    *

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/api/layouts/LogicalGraphLayoutFactory.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/api/layouts/LogicalGraphLayoutFactory.java
@@ -71,16 +71,6 @@ public interface LogicalGraphLayoutFactory<
   /**
    * Creates a graph layout from the given datasets indexed by label.
    *
-   * @param vertices Mapping from label to vertex dataset
-   * @param edges Mapping from label to edge dataset
-   * @return Logical graph layout
-   */
-  LogicalGraphLayout<G, V, E> fromIndexedDataSets(Map<String, DataSet<V>> vertices,
-    Map<String, DataSet<E>> edges);
-
-  /**
-   * Creates a graph layout from the given datasets indexed by label.
-   *
    * The method assumes that the given vertices and edges are already assigned
    * to the given graph head.
    *

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/epgm/LogicalGraphFactory.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/epgm/LogicalGraphFactory.java
@@ -98,12 +98,6 @@ public class LogicalGraphFactory
   }
 
   @Override
-  public LogicalGraph fromIndexedDataSets(Map<String, DataSet<EPGMVertex>> vertices,
-    Map<String, DataSet<EPGMEdge>> edges) {
-    return new LogicalGraph(layoutFactory.fromIndexedDataSets(vertices, edges), config);
-  }
-
-  @Override
   public LogicalGraph fromIndexedDataSets(Map<String, DataSet<EPGMGraphHead>> graphHead,
     Map<String, DataSet<EPGMVertex>> vertices, Map<String, DataSet<EPGMEdge>> edges) {
     return new LogicalGraph(layoutFactory.fromIndexedDataSets(graphHead, vertices, edges), config);

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/layouts/gve/GVEGraphLayoutFactory.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/layouts/gve/GVEGraphLayoutFactory.java
@@ -16,7 +16,6 @@
 package org.gradoop.flink.model.impl.layouts.gve;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import org.apache.flink.api.java.DataSet;
 import org.gradoop.common.model.impl.pojo.EPGMEdge;
 import org.gradoop.common.model.impl.pojo.EPGMGraphHead;
@@ -30,7 +29,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * Responsible for creating a {@link GVELayout} from given data.
@@ -67,31 +65,6 @@ public class GVEGraphLayoutFactory extends GVEBaseFactory
   public LogicalGraphLayout<EPGMGraphHead, EPGMVertex, EPGMEdge> fromDataSets(
     DataSet<EPGMGraphHead> graphHead, DataSet<EPGMVertex> vertices, DataSet<EPGMEdge> edges) {
     return create(graphHead, vertices, edges);
-  }
-
-  @Override
-  public LogicalGraphLayout<EPGMGraphHead, EPGMVertex, EPGMEdge> fromIndexedDataSets(
-    Map<String, DataSet<EPGMVertex>> vertices, Map<String, DataSet<EPGMEdge>> edges) {
-    EPGMGraphHead graphHead = getGraphHeadFactory().createGraphHead();
-
-    DataSet<EPGMGraphHead> graphHeadSet = getConfig().getExecutionEnvironment()
-      .fromElements(graphHead);
-
-    Map<String, DataSet<EPGMGraphHead>> graphHeads = Maps.newHashMap();
-    graphHeads.put(graphHead.getLabel(), graphHeadSet);
-
-    // update vertices and edges with new graph head id
-    vertices = vertices.entrySet().stream()
-      .collect(Collectors.toMap(
-        Map.Entry::getKey, e -> e.getValue().map(new AddToGraph<>(graphHead))
-          .withForwardedFields("id;label;properties")));
-
-    edges = edges.entrySet().stream()
-      .collect(Collectors.toMap(
-        Map.Entry::getKey, e -> e.getValue().map(new AddToGraph<>(graphHead))
-          .withForwardedFields("id;sourceId;targetId;label;properties")));
-
-    return create(graphHeads, vertices, edges);
   }
 
   @Override

--- a/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/layouts/gve/indexed/IndexedGVELayout.java
+++ b/gradoop-flink/src/main/java/org/gradoop/flink/model/impl/layouts/gve/indexed/IndexedGVELayout.java
@@ -21,16 +21,17 @@ import org.gradoop.common.model.impl.pojo.EPGMGraphHead;
 import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.model.api.layouts.GraphCollectionLayout;
 import org.gradoop.flink.model.api.layouts.LogicalGraphLayout;
-import org.gradoop.flink.model.impl.layouts.gve.GVELayout;
+import org.gradoop.flink.model.impl.layouts.transactional.tuples.GraphTransaction;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
- * Like {@link GVELayout}, this layout separated between graph head, vertex and edge layouts. In
+ * This layout separated between graph head, vertex and edge layouts. In
  * addition, the datasets are separated by labels and accesses by known labels are much more
  * efficient as they avoid duplicating rows during program execution.
  */
-public class IndexedGVELayout extends GVELayout implements
+public class IndexedGVELayout implements
   LogicalGraphLayout<EPGMGraphHead, EPGMVertex, EPGMEdge>,
   GraphCollectionLayout<EPGMGraphHead, EPGMVertex, EPGMEdge> {
   /**
@@ -53,20 +54,16 @@ public class IndexedGVELayout extends GVELayout implements
    * @param vertices mapping from label to vertices
    * @param edges mapping from label to edges
    */
-  IndexedGVELayout(Map<String, DataSet<EPGMGraphHead>> graphHeads,
-    Map<String, DataSet<EPGMVertex>> vertices,
+  IndexedGVELayout(Map<String, DataSet<EPGMGraphHead>> graphHeads, Map<String, DataSet<EPGMVertex>> vertices,
     Map<String, DataSet<EPGMEdge>> edges) {
-    super(
-      graphHeads.values().stream().reduce(DataSet::union)
-        .orElseThrow(() -> new RuntimeException("Error during graph head union")),
-      vertices.values().stream().reduce(DataSet::union)
-        .orElseThrow(() -> new RuntimeException("Error during vertex union")),
-      edges.values().stream().reduce(DataSet::union)
-        .orElseThrow(() -> new RuntimeException("Error during edge union"))
-    );
-    this.graphHeads = graphHeads;
-    this.vertices = vertices;
-    this.edges = edges;
+    this.graphHeads = Objects.requireNonNull(graphHeads);
+    this.vertices = Objects.requireNonNull(vertices);
+    this.edges = Objects.requireNonNull(edges);
+  }
+
+  @Override
+  public boolean isGVELayout() {
+    return false;
   }
 
   @Override
@@ -75,13 +72,47 @@ public class IndexedGVELayout extends GVELayout implements
   }
 
   @Override
+  public boolean isTransactionalLayout() {
+    return false;
+  }
+
+  @Override
+  public DataSet<EPGMGraphHead> getGraphHead() {
+    return getGraphHeads();
+  }
+
+  @Override
+  public DataSet<EPGMGraphHead> getGraphHeads() {
+    return graphHeads.values().stream().reduce(DataSet::union)
+      .orElseThrow(() -> new RuntimeException("Error during graph head union."));
+  }
+
+  @Override
   public DataSet<EPGMGraphHead> getGraphHeadsByLabel(String label) {
     return graphHeads.get(label);
   }
 
   @Override
+  public DataSet<GraphTransaction> getGraphTransactions() {
+    throw new UnsupportedOperationException(
+      "Converting a indexed graph to graph transactions is not supported yet.");
+  }
+
+  @Override
+  public DataSet<EPGMVertex> getVertices() {
+    return vertices.values().stream().reduce(DataSet::union)
+      .orElseThrow(() -> new RuntimeException("Error during vertex union."));
+  }
+
+  @Override
   public DataSet<EPGMVertex> getVerticesByLabel(String label) {
     return vertices.get(label);
+  }
+
+  @Override
+  public DataSet<EPGMEdge> getEdges() {
+    return edges.values().stream().reduce(DataSet::union)
+      .orElseThrow(() -> new RuntimeException("Error during edge union"));
   }
 
   @Override

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/layouts/gve/BaseGVELayoutTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/layouts/gve/BaseGVELayoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/layouts/gve/BaseGVELayoutTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/layouts/gve/BaseGVELayoutTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.flink.model.impl.layouts.gve;
+
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.gradoop.common.model.impl.pojo.EPGMEdge;
+import org.gradoop.common.model.impl.pojo.EPGMGraphHead;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
+import org.gradoop.flink.model.GradoopFlinkTestBase;
+import org.gradoop.flink.model.impl.epgm.LogicalGraphFactory;
+import org.gradoop.flink.util.GradoopFlinkConfig;
+import org.junit.BeforeClass;
+
+/**
+ * Base class for layout tests. Provides some predefined graph elements.
+ */
+public abstract class BaseGVELayoutTest extends GradoopFlinkTestBase {
+
+  protected static EPGMGraphHead g0;
+  protected static EPGMGraphHead g1;
+
+  protected static EPGMVertex v0;
+  protected static EPGMVertex v1;
+  protected static EPGMVertex v2;
+
+  protected static EPGMEdge e0;
+  protected static EPGMEdge e1;
+
+  /**
+   * Create graph elements before tests.
+   */
+  @BeforeClass
+  public static void setup() {
+    ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+    LogicalGraphFactory factory = GradoopFlinkConfig.createConfig(env).getLogicalGraphFactory();
+
+    g0 = factory.getGraphHeadFactory().createGraphHead("A");
+    g1 = factory.getGraphHeadFactory().createGraphHead("B");
+
+    v0 = factory.getVertexFactory().createVertex("A");
+    v1 = factory.getVertexFactory().createVertex("B");
+    v2 = factory.getVertexFactory().createVertex("C");
+
+    e0 = factory.getEdgeFactory().createEdge("a", v0.getId(), v1.getId());
+    e1 = factory.getEdgeFactory().createEdge("b", v1.getId(), v2.getId());
+
+    v0.addGraphId(g0.getId());
+    v1.addGraphId(g0.getId());
+    v1.addGraphId(g1.getId());
+    v2.addGraphId(g1.getId());
+
+    e0.addGraphId(g0.getId());
+    e1.addGraphId(g1.getId());
+  }
+}

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/layouts/gve/GVELayoutTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/layouts/gve/GVELayoutTest.java
@@ -16,130 +16,106 @@
 package org.gradoop.flink.model.impl.layouts.gve;
 
 import com.google.common.collect.Sets;
-import org.apache.flink.api.java.ExecutionEnvironment;
 import org.gradoop.common.GradoopTestUtils;
 import org.gradoop.common.model.impl.pojo.EPGMEdge;
 import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.common.model.impl.pojo.EPGMGraphHead;
-import org.gradoop.flink.model.GradoopFlinkTestBase;
-import org.gradoop.flink.model.impl.epgm.LogicalGraphFactory;
 import org.gradoop.flink.model.impl.layouts.transactional.tuples.GraphTransaction;
-import org.gradoop.flink.util.GradoopFlinkConfig;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Collection;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
 
-public class GVELayoutTest extends GradoopFlinkTestBase {
+/**
+ * Test class {@link GVELayout}.
+ */
+public class GVELayoutTest extends BaseGVELayoutTest {
 
-  protected static EPGMGraphHead g0;
-  protected static EPGMGraphHead g1;
-
-  protected static EPGMVertex v0;
-  protected static EPGMVertex v1;
-  protected static EPGMVertex v2;
-
-  protected static EPGMEdge e0;
-  protected static EPGMEdge e1;
-
-  @BeforeClass
-  public static void setup() {
-    ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-    LogicalGraphFactory factory = GradoopFlinkConfig.createConfig(env).getLogicalGraphFactory();
-
-    g0 = factory.getGraphHeadFactory().createGraphHead("A");
-    g1 = factory.getGraphHeadFactory().createGraphHead("B");
-
-    v0 = factory.getVertexFactory().createVertex("A");
-    v1 = factory.getVertexFactory().createVertex("B");
-    v2 = factory.getVertexFactory().createVertex("C");
-
-    e0 = factory.getEdgeFactory().createEdge("a", v0.getId(), v1.getId());
-    e1 = factory.getEdgeFactory().createEdge("b", v1.getId(), v2.getId());
-
-    v0.addGraphId(g0.getId());
-    v1.addGraphId(g0.getId());
-    v1.addGraphId(g1.getId());
-    v2.addGraphId(g1.getId());
-
-    e0.addGraphId(g0.getId());
-    e1.addGraphId(g1.getId());
+  @Test
+  public void testIsGVELayout() {
+    assertTrue(createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).isGVELayout());
   }
 
-  protected GVELayout from(Collection<EPGMGraphHead> graphHeads, Collection<EPGMVertex> vertices,
+  @Test
+  public void testIsIndexedGVELayout() {
+    assertFalse(createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).isIndexedGVELayout());
+  }
+
+  @Test
+  public void testHasTransactionalLayout() {
+    assertFalse(createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).isTransactionalLayout());
+  }
+
+  @Test
+  public void testGetGraphTransactions() throws Exception {
+    GraphTransaction tx0 = new GraphTransaction(g0, Sets.newHashSet(v0, v1), Sets.newHashSet(e0));
+
+    assertEquals(tx0,
+      createLayout(singletonList(g0), asList(v0, v1), singletonList(e0)).getGraphTransactions().collect().get(0));
+  }
+
+  @Test
+  public void testGetGraphHead() throws Exception {
+    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g0),
+      createLayout(singletonList(g0), asList(v0, v1), singletonList(e0)).getGraphHead().collect());
+  }
+
+  @Test
+  public void testGetGraphHeads() throws Exception {
+    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g0, g1),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getGraphHeads().collect());
+  }
+
+  @Test
+  public void testGetGraphHeadsByLabel() throws Exception {
+    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g0),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getGraphHeadsByLabel("A").collect());
+    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g1),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getGraphHeadsByLabel("B").collect());
+  }
+
+  @Test
+  public void testGetVertices() throws Exception {
+    GradoopTestUtils.validateGraphElementCollections(Sets.newHashSet(v0, v1, v2),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getVertices().collect());
+  }
+
+  @Test
+  public void testGetVerticesByLabel() throws Exception {
+    GradoopTestUtils.validateGraphElementCollections(Sets.newHashSet(v0),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getVerticesByLabel("A").collect());
+  }
+
+  @Test
+  public void testGetEdges() throws Exception {
+    GradoopTestUtils.validateGraphElementCollections(Sets.newHashSet(e0, e1),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getEdges().collect());
+  }
+
+  @Test
+  public void testGetEdgesByLabel() throws Exception {
+    GradoopTestUtils.validateGraphElementCollections(Sets.newHashSet(e0),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getEdgesByLabel("a").collect());
+  }
+
+  /**
+   * Creates a {@link GVELayout} from collections of graph elements.
+   *
+   * @param graphHeads a collection of graph heads
+   * @param vertices a collection of vertices
+   * @param edges a collection of edges
+   * @return a GVE layout instance
+   */
+  private GVELayout createLayout(Collection<EPGMGraphHead> graphHeads, Collection<EPGMVertex> vertices,
     Collection<EPGMEdge> edges) {
     return new GVELayout(
       getExecutionEnvironment().fromCollection(graphHeads),
       getExecutionEnvironment().fromCollection(vertices),
       getExecutionEnvironment().fromCollection(edges));
-  }
-
-  @Test
-  public void isGVELayout() throws Exception {
-    assertTrue(from(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).isGVELayout());
-  }
-
-  @Test
-  public void isIndexedGVELayout() throws Exception {
-    assertFalse(from(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).isIndexedGVELayout());
-  }
-
-  @Test
-  public void hasTransactionalLayout() throws Exception {
-    assertFalse(from(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).isTransactionalLayout());
-  }
-
-  @Test
-  public void getGraphTransactions() throws Exception {
-    GraphTransaction tx0 = new GraphTransaction(g0, Sets.newHashSet(v0, v1), Sets.newHashSet(e0));
-
-    assertEquals(tx0,
-      from(singletonList(g0), asList(v0, v1), singletonList(e0)).getGraphTransactions().collect().get(0));
-  }
-
-  @Test
-  public void getGraphHead() throws Exception {
-    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g0),
-      from(singletonList(g0), asList(v0, v1), singletonList(e0)).getGraphHead().collect());
-  }
-
-  @Test
-  public void getGraphHeads() throws Exception {
-    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g0, g1),
-      from(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getGraphHeads().collect());
-  }
-
-  @Test
-  public void getGraphHeadsByLabel() throws Exception {
-    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g0),
-      from(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getGraphHeadsByLabel("A").collect());
-  }
-
-  @Test
-  public void getVertices() throws Exception {
-    GradoopTestUtils.validateGraphElementCollections(Sets.newHashSet(v0, v1, v2),
-      from(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getVertices().collect());
-  }
-
-  @Test
-  public void getVerticesByLabel() throws Exception {
-    GradoopTestUtils.validateGraphElementCollections(Sets.newHashSet(v0),
-      from(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getVerticesByLabel("A").collect());
-  }
-
-  @Test
-  public void getEdges() throws Exception {
-    GradoopTestUtils.validateGraphElementCollections(Sets.newHashSet(e0, e1),
-      from(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getEdges().collect());
-  }
-
-  @Test
-  public void getEdgesByLabel() throws Exception {
-    GradoopTestUtils.validateGraphElementCollections(Sets.newHashSet(e0),
-      from(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getEdgesByLabel("a").collect());
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/layouts/gve/indexed/IndexedGVELayoutTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/layouts/gve/indexed/IndexedGVELayoutTest.java
@@ -15,42 +15,116 @@
  */
 package org.gradoop.flink.model.impl.layouts.gve.indexed;
 
+import com.google.common.collect.Sets;
 import org.apache.flink.api.java.DataSet;
+import org.gradoop.common.GradoopTestUtils;
 import org.gradoop.common.model.impl.pojo.EPGMEdge;
-import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.common.model.impl.pojo.EPGMGraphHead;
-import org.gradoop.flink.model.impl.layouts.gve.GVELayout;
-import org.gradoop.flink.model.impl.layouts.gve.GVELayoutTest;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
+import org.gradoop.flink.model.impl.layouts.gve.BaseGVELayoutTest;
+import org.junit.Test;
 
 import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class IndexedGVELayoutTest extends GVELayoutTest {
 
-  @Override
-  protected GVELayout from(Collection<EPGMGraphHead> graphHeads, Collection<EPGMVertex> vertices,
-    Collection<EPGMEdge> edges) {
-    Map<String, DataSet<EPGMGraphHead>> indexedGraphHeads = graphHeads.stream()
-      .collect(Collectors.groupingBy(EPGMGraphHead::getLabel)).entrySet().stream()
-      .collect(Collectors.toMap(Map.Entry::getKey, e -> getExecutionEnvironment().fromCollection(e.getValue())));
+/**
+ * Test class {@link IndexedGVELayout}.
+ */
+public class IndexedGVELayoutTest extends BaseGVELayoutTest {
 
-    Map<String, DataSet<EPGMVertex>> indexedVertices = vertices.stream()
-      .collect(Collectors.groupingBy(EPGMVertex::getLabel)).entrySet().stream()
-      .collect(Collectors.toMap(Map.Entry::getKey, e -> getExecutionEnvironment().fromCollection(e.getValue())));
-
-    Map<String, DataSet<EPGMEdge>> indexedEdges = edges.stream()
-      .collect(Collectors.groupingBy(EPGMEdge::getLabel)).entrySet().stream()
-      .collect(Collectors.toMap(Map.Entry::getKey, e -> getExecutionEnvironment().fromCollection(e.getValue())));
-
-    return new IndexedGVELayout(indexedGraphHeads, indexedVertices, indexedEdges);
+  @Test
+  public void testIsGVELayout() {
+    assertFalse(createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).isGVELayout());
   }
 
-  @Override
-  public void isIndexedGVELayout() throws Exception {
-    assertTrue(from(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).isIndexedGVELayout());
+  @Test
+  public void testIsTransactionalLayout() {
+    assertFalse(createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).isTransactionalLayout());
+  }
+
+  @Test
+  public void testGetGraphHead() throws Exception {
+    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g0),
+      createLayout(singletonList(g0), asList(v0, v1), singletonList(e0)).getGraphHead().collect());
+  }
+
+  @Test
+  public void testGetGraphHeads() throws Exception {
+    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g0, g1),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getGraphHeads().collect());
+  }
+
+  @Test
+  public void testGetGraphHeadsByLabel() throws Exception {
+    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g0),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getGraphHeadsByLabel("A").collect());
+    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g1),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getGraphHeadsByLabel("B").collect());
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testGetGraphTransactions() {
+    createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getGraphTransactions();
+  }
+
+  @Test
+  public void testGetVertices() throws Exception {
+    GradoopTestUtils.validateGraphElementCollections(Sets.newHashSet(v0, v1, v2),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getVertices().collect());
+  }
+
+  @Test
+  public void testGetVerticesByLabel() throws Exception {
+    GradoopTestUtils.validateGraphElementCollections(Sets.newHashSet(v1),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getVerticesByLabel("B").collect());
+  }
+
+  @Test
+  public void testGetEdges() throws Exception {
+    GradoopTestUtils.validateGraphElementCollections(Sets.newHashSet(e0, e1),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getEdges().collect());
+  }
+
+  @Test
+  public void testGetEdgesByLabel() throws Exception {
+    GradoopTestUtils.validateGraphElementCollections(Sets.newHashSet(e1),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getEdgesByLabel("b").collect());
+  }
+
+  @Test
+  public void isIndexedGVELayout() {
+    assertTrue(createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).isIndexedGVELayout());
+  }
+
+  /**
+   * Creates a {@link IndexedGVELayout} from collections of graph elements.
+   *
+   * @param graphHeads a collection of graph heads
+   * @param vertices a collection of vertices
+   * @param edges a collection of edges
+   * @return an indexed GVE layout instance
+   */
+  private IndexedGVELayout createLayout(Collection<EPGMGraphHead> graphHeads, Collection<EPGMVertex> vertices,
+    Collection<EPGMEdge> edges) {
+    Map<String, DataSet<EPGMGraphHead>> indexedGraphHeads =
+      graphHeads.stream().collect(Collectors.groupingBy(EPGMGraphHead::getLabel)).entrySet().stream().collect(
+        Collectors.toMap(Map.Entry::getKey, e -> getExecutionEnvironment().fromCollection(e.getValue())));
+
+    Map<String, DataSet<EPGMVertex>> indexedVertices =
+      vertices.stream().collect(Collectors.groupingBy(EPGMVertex::getLabel)).entrySet().stream().collect(
+        Collectors.toMap(Map.Entry::getKey, e -> getExecutionEnvironment().fromCollection(e.getValue())));
+
+    Map<String, DataSet<EPGMEdge>> indexedEdges =
+      edges.stream().collect(Collectors.groupingBy(EPGMEdge::getLabel)).entrySet().stream().collect(
+        Collectors.toMap(Map.Entry::getKey, e -> getExecutionEnvironment().fromCollection(e.getValue())));
+
+    return new IndexedGVELayout(indexedGraphHeads, indexedVertices, indexedEdges);
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/layouts/gve/indexed/IndexedGVELayoutTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/layouts/gve/indexed/IndexedGVELayoutTest.java
@@ -99,7 +99,7 @@ public class IndexedGVELayoutTest extends BaseGVELayoutTest {
   }
 
   @Test
-  public void isIndexedGVELayout() {
+  public void testIsIndexedGVELayout() {
     assertTrue(createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).isIndexedGVELayout());
   }
 

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSink.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSink.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSink.java
@@ -19,8 +19,8 @@ import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.core.fs.FileSystem.WriteMode;
 import org.apache.flink.core.fs.Path;
+import org.gradoop.flink.io.impl.csv.CSVBase;
 import org.gradoop.flink.io.impl.csv.CSVConstants;
-import org.gradoop.flink.io.impl.csv.indexed.IndexedCSVDataSink;
 import org.gradoop.flink.io.impl.csv.indexed.functions.IndexedCSVFileFormat;
 import org.gradoop.flink.io.impl.csv.metadata.CSVMetaDataSink;
 import org.gradoop.flink.io.impl.csv.metadata.CSVMetaDataSource;
@@ -40,7 +40,11 @@ import java.io.IOException;
 /**
  * A temporal graph data sink for CSV files indexed by label.
  */
-public class TemporalIndexedCSVDataSink extends IndexedCSVDataSink implements TemporalDataSink {
+public class TemporalIndexedCSVDataSink extends CSVBase implements TemporalDataSink {
+  /**
+   * Path to meta data file that is used to write the output.
+   */
+  private final String metaDataPath;
 
   /**
    * Creates a new indexed CSV data sink. Computes the meta data based on the given graph.
@@ -60,7 +64,8 @@ public class TemporalIndexedCSVDataSink extends IndexedCSVDataSink implements Te
    * @param config       Gradoop Flink configuration
    */
   public TemporalIndexedCSVDataSink(String csvPath, String metaDataPath, GradoopFlinkConfig config) {
-    super(csvPath, metaDataPath, config);
+    super(csvPath, config);
+    this.metaDataPath = metaDataPath;
   }
 
   @Override

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSink.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSink.java
@@ -13,38 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradoop.flink.io.impl.csv.indexed;
+package org.gradoop.temporal.io.impl.csv.indexed;
 
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.core.fs.FileSystem.WriteMode;
 import org.apache.flink.core.fs.Path;
-import org.gradoop.flink.io.api.DataSink;
-import org.gradoop.flink.io.impl.csv.CSVBase;
 import org.gradoop.flink.io.impl.csv.CSVConstants;
-import org.gradoop.flink.io.impl.csv.functions.EdgeToCSVEdge;
-import org.gradoop.flink.io.impl.csv.functions.GraphHeadToCSVGraphHead;
-import org.gradoop.flink.io.impl.csv.functions.VertexToCSVVertex;
+import org.gradoop.flink.io.impl.csv.indexed.IndexedCSVDataSink;
 import org.gradoop.flink.io.impl.csv.indexed.functions.IndexedCSVFileFormat;
 import org.gradoop.flink.io.impl.csv.metadata.CSVMetaDataSink;
 import org.gradoop.flink.io.impl.csv.metadata.CSVMetaDataSource;
-import org.gradoop.flink.io.impl.csv.tuples.CSVEdge;
-import org.gradoop.flink.io.impl.csv.tuples.CSVGraphHead;
-import org.gradoop.flink.io.impl.csv.tuples.CSVVertex;
-import org.gradoop.flink.model.impl.epgm.GraphCollection;
-import org.gradoop.flink.model.impl.epgm.LogicalGraph;
 import org.gradoop.flink.util.GradoopFlinkConfig;
+import org.gradoop.temporal.io.api.TemporalDataSink;
+import org.gradoop.temporal.io.impl.csv.functions.TemporalEdgeToTemporalCSVEdge;
+import org.gradoop.temporal.io.impl.csv.functions.TemporalGraphHeadToTemporalCSVGraphHead;
+import org.gradoop.temporal.io.impl.csv.functions.TemporalVertexToTemporalCSVVertex;
+import org.gradoop.temporal.io.impl.csv.tuples.TemporalCSVEdge;
+import org.gradoop.temporal.io.impl.csv.tuples.TemporalCSVGraphHead;
+import org.gradoop.temporal.io.impl.csv.tuples.TemporalCSVVertex;
+import org.gradoop.temporal.model.impl.TemporalGraph;
+import org.gradoop.temporal.model.impl.TemporalGraphCollection;
 
 import java.io.IOException;
 
 /**
- * A graph data sink for CSV files indexed by label.
+ * A temporal graph data sink for CSV files indexed by label.
  */
-public class IndexedCSVDataSink extends CSVBase implements DataSink {
-  /**
-   * Path to meta data file that is used to write the output.
-   */
-  protected final String metaDataPath;
+public class TemporalIndexedCSVDataSink extends IndexedCSVDataSink implements TemporalDataSink {
 
   /**
    * Creates a new indexed CSV data sink. Computes the meta data based on the given graph.
@@ -52,7 +48,7 @@ public class IndexedCSVDataSink extends CSVBase implements DataSink {
    * @param csvPath directory to write to
    * @param config  Gradoop Flink configuration
    */
-  public IndexedCSVDataSink(String csvPath, GradoopFlinkConfig config) {
+  public TemporalIndexedCSVDataSink(String csvPath, GradoopFlinkConfig config) {
     this(csvPath, null, config);
   }
 
@@ -60,59 +56,58 @@ public class IndexedCSVDataSink extends CSVBase implements DataSink {
    * Creates an new indexed CSV data sink. Uses the specified meta data to write the CSV output.
    *
    * @param csvPath      directory to write CSV files to
-   * @param metaDataPath path to meta data CSV file
+   * @param metaDataPath path to meta data CSV file that is reused to prevent the creation of metadata
    * @param config       Gradoop Flink configuration
    */
-  public IndexedCSVDataSink(String csvPath, String metaDataPath, GradoopFlinkConfig config) {
-    super(csvPath, config);
-    this.metaDataPath = metaDataPath;
+  public TemporalIndexedCSVDataSink(String csvPath, String metaDataPath, GradoopFlinkConfig config) {
+    super(csvPath, metaDataPath, config);
   }
 
   @Override
-  public void write(LogicalGraph logicalGraph) throws IOException {
-    write(logicalGraph, false);
+  public void write(TemporalGraph temporalGraph) throws IOException {
+    write(temporalGraph, false);
   }
 
   @Override
-  public void write(GraphCollection graphCollection) throws IOException {
-    write(graphCollection, false);
+  public void write(TemporalGraphCollection temporalGraphCollection) throws IOException {
+    write(temporalGraphCollection, false);
   }
 
   @Override
-  public void write(LogicalGraph logicalGraph, boolean overwrite) throws IOException {
-    write(logicalGraph.getCollectionFactory().fromGraph(logicalGraph), overwrite);
+  public void write(TemporalGraph temporalGraph, boolean overwrite) throws IOException {
+    write(temporalGraph.getCollectionFactory().fromGraph(temporalGraph), overwrite);
   }
 
   @Override
-  public void write(GraphCollection graphCollection, boolean overwrite) throws IOException {
+  public void write(TemporalGraphCollection temporalGraphCollection, boolean overwrite) throws IOException {
     WriteMode writeMode = overwrite ?
       WriteMode.OVERWRITE : WriteMode.NO_OVERWRITE;
 
     DataSet<Tuple3<String, String, String>> metaData;
     CSVMetaDataSource source = new CSVMetaDataSource();
-    if (!reuseMetadata()) {
-      metaData = source.tuplesFromCollection(graphCollection);
-    } else {
+    if (isMetadataReusable()) {
       metaData = source.readDistributed(metaDataPath, getConfig());
+    } else {
+      metaData = source.tuplesFromCollection(temporalGraphCollection);
     }
 
-    DataSet<CSVGraphHead> csvGraphHeads = graphCollection.getGraphHeads()
-      .map(new GraphHeadToCSVGraphHead())
+    DataSet<TemporalCSVGraphHead> csvGraphHeads = temporalGraphCollection.getGraphHeads()
+      .map(new TemporalGraphHeadToTemporalCSVGraphHead())
       .withBroadcastSet(metaData, BC_METADATA);
 
-    DataSet<CSVVertex> csvVertices = graphCollection.getVertices()
-      .map(new VertexToCSVVertex())
+    DataSet<TemporalCSVVertex> csvVertices = temporalGraphCollection.getVertices()
+      .map(new TemporalVertexToTemporalCSVVertex())
       .withBroadcastSet(metaData, BC_METADATA);
 
-    DataSet<CSVEdge> csvEdges = graphCollection.getEdges()
-      .map(new EdgeToCSVEdge())
+    DataSet<TemporalCSVEdge> csvEdges = temporalGraphCollection.getEdges()
+      .map(new TemporalEdgeToTemporalCSVEdge())
       .withBroadcastSet(metaData, BC_METADATA);
 
-    if (!getMetaDataPath().equals(metaDataPath) || !reuseMetadata()) {
+    if (!getMetaDataPath().equals(metaDataPath) || !isMetadataReusable()) {
       new CSVMetaDataSink().writeDistributed(getMetaDataPath(), metaData, writeMode);
     }
 
-    IndexedCSVFileFormat<CSVGraphHead> graphHeadFormat = new IndexedCSVFileFormat<>(
+    IndexedCSVFileFormat<TemporalCSVGraphHead> graphHeadFormat = new IndexedCSVFileFormat<>(
       new Path(getGraphHeadPath()),
       CSVConstants.ROW_DELIMITER,
       CSVConstants.TOKEN_DELIMITER);
@@ -120,7 +115,7 @@ public class IndexedCSVDataSink extends CSVBase implements DataSink {
     graphHeadFormat.setWriteMode(writeMode);
     csvGraphHeads.output(graphHeadFormat);
 
-    IndexedCSVFileFormat<CSVVertex> vertexFormat = new IndexedCSVFileFormat<>(
+    IndexedCSVFileFormat<TemporalCSVVertex> vertexFormat = new IndexedCSVFileFormat<>(
       new Path(getVertexPath()),
       CSVConstants.ROW_DELIMITER,
       CSVConstants.TOKEN_DELIMITER);
@@ -128,7 +123,7 @@ public class IndexedCSVDataSink extends CSVBase implements DataSink {
     vertexFormat.setWriteMode(writeMode);
     csvVertices.output(vertexFormat);
 
-    IndexedCSVFileFormat<CSVEdge> edgeFormat = new IndexedCSVFileFormat<>(
+    IndexedCSVFileFormat<TemporalCSVEdge> edgeFormat = new IndexedCSVFileFormat<>(
       new Path(getEdgePath()),
       CSVConstants.ROW_DELIMITER,
       CSVConstants.TOKEN_DELIMITER);
@@ -142,7 +137,7 @@ public class IndexedCSVDataSink extends CSVBase implements DataSink {
    *
    * @return true, iff reuse is possible
    */
-  private boolean reuseMetadata() {
+  private boolean isMetadataReusable() {
     return this.metaDataPath != null && !this.metaDataPath.isEmpty();
   }
 }

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSource.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSource.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSource.java
@@ -48,10 +48,19 @@ import java.util.stream.Collectors;
  * The datasource expects files separated by label, e.g. in the following directory structure:
  * <p>
  * csvRoot
- * |- Person.csv     # contains all vertices with label 'Person'
- * |- University.csv # contains all vertices with label 'University'
- * |- knows.csv      # contains all edges with label 'knows'
- * |- studyAt.csv    # contains all edges with label 'studyAt'
+ * |- vertices
+ *   |- person
+ *     |- data.csv    # contains all vertices with label 'Person'
+ *   |- university
+ *     |- data.csv    # contains all vertices with label 'University'
+ * |- edges
+ *   |- knows
+ *     |- data.csv    # contains all edges with label 'knows'
+ *   |- studyAt
+ *     |- data.csv    # contains all edges with label 'studyAt'
+ * |- graphs
+ *   |- myGraph
+ *     |- data.csv
  * |- metadata.csv   # Meta data for all data contained in the graph
  */
 public class TemporalIndexedCSVDataSource extends IndexedCSVDataSource implements TemporalDataSource {
@@ -67,16 +76,27 @@ public class TemporalIndexedCSVDataSource extends IndexedCSVDataSource implement
   }
 
   /**
-   * Will use a single graph head of the collection as final graph head for the graph.
-   * Issue #1217 (https://github.com/dbs-leipzig/gradoop/issues/1217) will optimize further.
+   * Reads a {@link TemporalGraph} and converts it to a {@link LogicalGraph} via function
+   * {@link TemporalGraph##getLogicalGraph()}.
    *
-   * {@inheritDoc}
+   * @return a logical graph instance
+   * @throws IOException in case of an error while reading the graph
    */
   @Override
   public LogicalGraph getLogicalGraph() throws IOException {
-    GraphCollection collection = getGraphCollection();
-    return collection.getGraphFactory()
-      .fromDataSets(collection.getGraphHeads().first(1), collection.getVertices(), collection.getEdges());
+    return getTemporalGraph().toLogicalGraph();
+  }
+
+  /**
+   * Reads a {@link TemporalGraphCollection} and converts it to a {@link GraphCollection} via function
+   * {@link TemporalGraphCollection##getGraphCollection()}.
+   *
+   * @return a graph collection instance
+   * @throws IOException in case of an error while reading the graph collection
+   */
+  @Override
+  public GraphCollection getGraphCollection() throws IOException {
+    return getTemporalGraphCollection().toGraphCollection();
   }
 
   @Override

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSource.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSource.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.io.impl.csv.indexed;
+
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.hadoop.conf.Configuration;
+import org.gradoop.flink.io.impl.csv.indexed.IndexedCSVDataSource;
+import org.gradoop.flink.io.impl.csv.metadata.CSVMetaData;
+import org.gradoop.flink.io.impl.csv.metadata.CSVMetaDataSource;
+import org.gradoop.flink.model.impl.epgm.GraphCollection;
+import org.gradoop.flink.model.impl.epgm.LogicalGraph;
+import org.gradoop.temporal.io.api.TemporalDataSource;
+import org.gradoop.temporal.io.impl.csv.functions.CSVLineToTemporalEdge;
+import org.gradoop.temporal.io.impl.csv.functions.CSVLineToTemporalGraphHead;
+import org.gradoop.temporal.io.impl.csv.functions.CSVLineToTemporalVertex;
+import org.gradoop.temporal.model.impl.TemporalGraph;
+import org.gradoop.temporal.model.impl.TemporalGraphCollection;
+import org.gradoop.temporal.model.impl.TemporalGraphCollectionFactory;
+import org.gradoop.temporal.model.impl.TemporalGraphFactory;
+import org.gradoop.temporal.model.impl.pojo.TemporalEdge;
+import org.gradoop.temporal.model.impl.pojo.TemporalGraphHead;
+import org.gradoop.temporal.model.impl.pojo.TemporalVertex;
+import org.gradoop.temporal.util.TemporalGradoopConfig;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * A temporal graph data source for CSV files indexed by label.
+ * <p>
+ * The datasource expects files separated by label, e.g. in the following directory structure:
+ * <p>
+ * csvRoot
+ * |- Person.csv     # contains all vertices with label 'Person'
+ * |- University.csv # contains all vertices with label 'University'
+ * |- knows.csv      # contains all edges with label 'knows'
+ * |- studyAt.csv    # contains all edges with label 'studyAt'
+ * |- metadata.csv   # Meta data for all data contained in the graph
+ */
+public class TemporalIndexedCSVDataSource extends IndexedCSVDataSource implements TemporalDataSource {
+
+  /**
+   * Creates a new data source. The constructor creates a default HDFS configuration.
+   *
+   * @param csvPath root path of csv files
+   * @param config  gradoop configuration
+   */
+  public TemporalIndexedCSVDataSource(String csvPath, TemporalGradoopConfig config) {
+    super(csvPath, config, new Configuration());
+  }
+
+  /**
+   * Will use a single graph head of the collection as final graph head for the graph.
+   * Issue #1217 (https://github.com/dbs-leipzig/gradoop/issues/1217) will optimize further.
+   *
+   * {@inheritDoc}
+   */
+  @Override
+  public LogicalGraph getLogicalGraph() throws IOException {
+    GraphCollection collection = getGraphCollection();
+    return collection.getGraphFactory()
+      .fromDataSets(collection.getGraphHeads().first(1), collection.getVertices(), collection.getEdges());
+  }
+
+  @Override
+  public TemporalGraph getTemporalGraph() throws IOException {
+
+    CSVMetaDataSource source = new CSVMetaDataSource();
+    CSVMetaData metaData = source.readLocal(getMetaDataPath(), hdfsConfig);
+    DataSet<Tuple3<String, String, String>> metaDataBroadcast =
+      source.readDistributed(getMetaDataPath(), getConfig());
+
+    ExecutionEnvironment env = getConfig().getExecutionEnvironment();
+    TemporalGraphFactory factory = getConfig().getTemporalGraphFactory();
+
+    Map<String, DataSet<TemporalGraphHead>> graphHeads = metaData.getGraphLabels().stream()
+      .map(label -> Tuple2.of(label, env.readTextFile(getGraphHeadCSVPath(label))
+        .map(new CSVLineToTemporalGraphHead(factory.getGraphHeadFactory()))
+        .withBroadcastSet(metaDataBroadcast, BC_METADATA)
+        .filter(graphHead -> graphHead.getLabel().equals(label))))
+      .collect(Collectors.toMap(t -> t.f0, t -> t.f1));
+
+    Map<String, DataSet<TemporalVertex>> vertices = metaData.getVertexLabels().stream()
+      .map(label -> Tuple2.of(label, env.readTextFile(getVertexCSVPath(label))
+        .map(new CSVLineToTemporalVertex(factory.getVertexFactory()))
+        .withBroadcastSet(metaDataBroadcast, BC_METADATA)
+        .filter(vertex -> vertex.getLabel().equals(label))))
+      .collect(Collectors.toMap(t -> t.f0, t -> t.f1));
+
+    Map<String, DataSet<TemporalEdge>> edges = metaData.getEdgeLabels().stream()
+      .map(label -> Tuple2.of(label, env.readTextFile(getEdgeCSVPath(label))
+        .map(new CSVLineToTemporalEdge(factory.getEdgeFactory()))
+        .withBroadcastSet(metaDataBroadcast, BC_METADATA)
+        .filter(edge -> edge.getLabel().equals(label))))
+      .collect(Collectors.toMap(t -> t.f0, t -> t.f1));
+
+    return factory.fromIndexedDataSets(graphHeads, vertices, edges);
+  }
+
+  @Override
+  public TemporalGraphCollection getTemporalGraphCollection() throws IOException {
+    CSVMetaDataSource source = new CSVMetaDataSource();
+    CSVMetaData metaData = source.readLocal(getMetaDataPath(), hdfsConfig);
+    DataSet<Tuple3<String, String, String>> metaDataBroadcast =
+      source.readDistributed(getMetaDataPath(), getConfig());
+
+    ExecutionEnvironment env = getConfig().getExecutionEnvironment();
+    TemporalGraphCollectionFactory factory = getConfig().getTemporalGraphCollectionFactory();
+
+    Map<String, DataSet<TemporalGraphHead>> graphHeads = metaData.getGraphLabels().stream()
+      .map(label -> Tuple2.of(label, env.readTextFile(getGraphHeadCSVPath(label))
+        .map(new CSVLineToTemporalGraphHead(factory.getGraphHeadFactory()))
+        .withBroadcastSet(metaDataBroadcast, BC_METADATA)
+        .filter(graphHead -> graphHead.getLabel().equals(label))))
+      .collect(Collectors.toMap(t -> t.f0, t -> t.f1));
+
+    Map<String, DataSet<TemporalVertex>> vertices = metaData.getVertexLabels().stream()
+      .map(label -> Tuple2.of(label, env.readTextFile(getVertexCSVPath(label))
+        .map(new CSVLineToTemporalVertex(factory.getVertexFactory()))
+        .withBroadcastSet(metaDataBroadcast, BC_METADATA)
+        .filter(vertex -> vertex.getLabel().equals(label))))
+      .collect(Collectors.toMap(t -> t.f0, t -> t.f1));
+
+    Map<String, DataSet<TemporalEdge>> edges = metaData.getEdgeLabels().stream()
+      .map(label -> Tuple2.of(label, env.readTextFile(getEdgeCSVPath(label))
+        .map(new CSVLineToTemporalEdge(factory.getEdgeFactory()))
+        .withBroadcastSet(metaDataBroadcast, BC_METADATA)
+        .filter(edge -> edge.getLabel().equals(label))))
+      .collect(Collectors.toMap(t -> t.f0, t -> t.f1));
+
+    return factory.fromIndexedDataSets(graphHeads, vertices, edges);
+  }
+
+  @Override
+  protected TemporalGradoopConfig getConfig() {
+    return (TemporalGradoopConfig) super.getConfig();
+  }
+}

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/io/impl/csv/indexed/package-info.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/io/impl/csv/indexed/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/io/impl/csv/indexed/package-info.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/io/impl/csv/indexed/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * A DataSource and -Sink implementation storing temporal graphs and graph collections as label partitioned
+ * CSV files.
+ */
+package org.gradoop.temporal.io.impl.csv.indexed;

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/TemporalGraphCollectionFactory.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/TemporalGraphCollectionFactory.java
@@ -26,6 +26,7 @@ import org.gradoop.common.model.api.entities.Vertex;
 import org.gradoop.common.model.api.entities.VertexFactory;
 import org.gradoop.flink.model.api.epgm.BaseGraphCollection;
 import org.gradoop.flink.model.api.epgm.BaseGraphCollectionFactory;
+import org.gradoop.flink.model.api.layouts.GraphCollectionLayout;
 import org.gradoop.flink.model.api.layouts.GraphCollectionLayoutFactory;
 import org.gradoop.flink.model.api.layouts.LogicalGraphLayout;
 import org.gradoop.flink.model.impl.functions.epgm.Id;
@@ -80,6 +81,17 @@ public class TemporalGraphCollectionFactory implements BaseGraphCollectionFactor
   public void setLayoutFactory(GraphCollectionLayoutFactory<TemporalGraphHead, TemporalVertex,
     TemporalEdge> factory) {
     this.layoutFactory = factory;
+  }
+
+  /**
+   * Creates a temporal graph collection instance from an existing layout.
+   *
+   * @param layout the layout that is used to store the graph data of this temporal graph collection instance
+   * @return a temporal graph collection
+   */
+  public TemporalGraphCollection fromLayout(
+    GraphCollectionLayout<TemporalGraphHead, TemporalVertex, TemporalEdge> layout) {
+    return new TemporalGraphCollection(layout, config);
   }
 
   @Override

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/TemporalGraphFactory.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/TemporalGraphFactory.java
@@ -25,6 +25,7 @@ import org.gradoop.common.model.api.entities.Vertex;
 import org.gradoop.common.model.api.entities.VertexFactory;
 import org.gradoop.flink.model.api.epgm.BaseGraph;
 import org.gradoop.flink.model.api.epgm.BaseGraphFactory;
+import org.gradoop.flink.model.api.layouts.LogicalGraphLayout;
 import org.gradoop.flink.model.api.layouts.LogicalGraphLayoutFactory;
 import org.gradoop.temporal.model.api.functions.TimeIntervalExtractor;
 import org.gradoop.temporal.model.impl.functions.tpgm.EdgeToTemporalEdge;
@@ -75,6 +76,17 @@ public class TemporalGraphFactory implements
     this.layoutFactory = layoutFactory;
   }
 
+  /**
+   * Creates a temporal graph instance from an existing layout.
+   *
+   * @param layout the layout that is used to store the graph data of this temporal graph instance
+   * @return a temporal graph
+   */
+  public TemporalGraph fromLayout(
+    LogicalGraphLayout<TemporalGraphHead, TemporalVertex, TemporalEdge> layout) {
+    return new TemporalGraph(layout, config);
+  }
+
   @Override
   public TemporalGraph fromDataSets(DataSet<TemporalVertex> vertices) {
     return new TemporalGraph(this.layoutFactory.fromDataSets(vertices), config);
@@ -89,12 +101,6 @@ public class TemporalGraphFactory implements
   public TemporalGraph fromDataSets(DataSet<TemporalGraphHead> graphHead,
     DataSet<TemporalVertex> vertices, DataSet<TemporalEdge> edges) {
     return new TemporalGraph(this.layoutFactory.fromDataSets(graphHead, vertices, edges), config);
-  }
-
-  @Override
-  public TemporalGraph fromIndexedDataSets(Map<String, DataSet<TemporalVertex>> vertices,
-    Map<String, DataSet<TemporalEdge>> edges) {
-    return new TemporalGraph(this.layoutFactory.fromIndexedDataSets(vertices, edges), config);
   }
 
   @Override

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/layout/TemporalGraphCollectionLayoutFactory.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/layout/TemporalGraphCollectionLayoutFactory.java
@@ -52,17 +52,12 @@ public class TemporalGraphCollectionLayoutFactory extends TemporalBaseLayoutFact
       Objects.requireNonNull(edges));
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * Creating a temporal graph layout from an indexed dataset is not supported yet.
-   */
   @Override
   public GraphCollectionLayout<TemporalGraphHead, TemporalVertex, TemporalEdge> fromIndexedDataSets(
     Map<String, DataSet<TemporalGraphHead>> graphHeads,
     Map<String, DataSet<TemporalVertex>> vertices, Map<String, DataSet<TemporalEdge>> edges) {
-    throw new UnsupportedOperationException(
-      "Creating a temporal graph layout from an indexed dataset is not supported yet.");
+    return new TemporalIndexedLayout(graphHeads, vertices, edges);
+
   }
 
   @Override

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/layout/TemporalGraphLayoutFactory.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/layout/TemporalGraphLayoutFactory.java
@@ -75,18 +75,6 @@ public class TemporalGraphLayoutFactory extends TemporalBaseLayoutFactory
   }
 
   /**
-   * {@inheritDoc}
-   *
-   * Creating a temporal graph layout from an indexed dataset is not supported yet.
-   */
-  @Override
-  public LogicalGraphLayout<TemporalGraphHead, TemporalVertex, TemporalEdge> fromIndexedDataSets(
-    Map<String, DataSet<TemporalVertex>> vertices, Map<String, DataSet<TemporalEdge>> edges) {
-    throw new UnsupportedOperationException(
-      "Creating a temporal graph layout from an indexed dataset is not supported yet.");
-  }
-
-  /**
    * Creates a graph layout from the given datasets indexed by label.
    *
    * @param graphHeads 1-element Mapping from label to GraphHead DataSet

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/layout/TemporalGraphLayoutFactory.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/layout/TemporalGraphLayoutFactory.java
@@ -87,16 +87,18 @@ public class TemporalGraphLayoutFactory extends TemporalBaseLayoutFactory
   }
 
   /**
-   * {@inheritDoc}
+   * Creates a graph layout from the given datasets indexed by label.
    *
-   * Creating a temporal graph layout from an indexed dataset is not supported yet.
+   * @param graphHeads 1-element Mapping from label to GraphHead DataSet
+   * @param vertices Mapping from label to vertex dataset
+   * @param edges Mapping from label to edge dataset
+   * @return a temporal indexed graph layout
    */
   @Override
   public LogicalGraphLayout<TemporalGraphHead, TemporalVertex, TemporalEdge> fromIndexedDataSets(
     Map<String, DataSet<TemporalGraphHead>> graphHeads,
     Map<String, DataSet<TemporalVertex>> vertices, Map<String, DataSet<TemporalEdge>> edges) {
-    throw new UnsupportedOperationException(
-      "Creating a temporal graph layout from an indexed dataset is not supported yet.");
+    return new TemporalIndexedLayout(graphHeads, vertices, edges);
   }
 
   @Override

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/layout/TemporalIndexedLayout.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/layout/TemporalIndexedLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/layout/TemporalIndexedLayout.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/layout/TemporalIndexedLayout.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.layout;
+
+import org.apache.flink.api.java.DataSet;
+import org.gradoop.flink.model.api.layouts.GraphCollectionLayout;
+import org.gradoop.flink.model.api.layouts.LogicalGraphLayout;
+import org.gradoop.temporal.model.impl.pojo.TemporalEdge;
+import org.gradoop.temporal.model.impl.pojo.TemporalGraphHead;
+import org.gradoop.temporal.model.impl.pojo.TemporalVertex;
+
+import java.util.Map;
+
+/**
+ * Represents a temporal graph or graph collection using one dataset per label and graph instance:
+ * <ol>
+ *   <li>a Map<L, G> containing the graph label L as key and a graph head dataset G as value</li>
+ *   <li>a Map<L, V> containing the vertex label L as key and a vertex dataset V as value</li>
+ *   <li>a Map<L, E> containing the edge label L as key and a edge dataset E as value</li>
+ * </ol>
+ */
+public class TemporalIndexedLayout extends TemporalGVELayout implements
+  LogicalGraphLayout<TemporalGraphHead, TemporalVertex, TemporalEdge>,
+  GraphCollectionLayout<TemporalGraphHead, TemporalVertex, TemporalEdge> {
+
+  /**
+   * Mapping from graph label to graph heads with that label.
+   */
+  private final Map<String, DataSet<TemporalGraphHead>> graphHeads;
+  /**
+   * Mapping from vertex label to vertices with that label.
+   */
+  private final Map<String, DataSet<TemporalVertex>> vertices;
+  /**
+   * Mapping from edge label to edges with that label.
+   */
+  private final Map<String, DataSet<TemporalEdge>> edges;
+
+  /**
+   * Creates a new temporal indexed layout.
+   *
+   * @param graphHeads mapping from label to graph heads
+   * @param vertices mapping from label to vertices
+   * @param edges mapping from label to edges
+   */
+  TemporalIndexedLayout(Map<String, DataSet<TemporalGraphHead>> graphHeads,
+    Map<String, DataSet<TemporalVertex>> vertices,
+    Map<String, DataSet<TemporalEdge>> edges) {
+    super(
+      graphHeads.values().stream().reduce(DataSet::union)
+        .orElseThrow(() -> new RuntimeException("Error during graph head union")),
+      vertices.values().stream().reduce(DataSet::union)
+        .orElseThrow(() -> new RuntimeException("Error during vertex union")),
+      edges.values().stream().reduce(DataSet::union)
+        .orElseThrow(() -> new RuntimeException("Error during edge union"))
+    );
+    this.graphHeads = graphHeads;
+    this.vertices = vertices;
+    this.edges = edges;
+  }
+
+  @Override
+  public boolean isIndexedGVELayout() {
+    return true;
+  }
+
+  @Override
+  public DataSet<TemporalGraphHead> getGraphHeadsByLabel(String label) {
+    if (!graphHeads.containsKey(label)) {
+      throw new IllegalArgumentException("The given graph label [" + label +
+        "] is not available in the (indexed) graph layout.");
+    }
+    return graphHeads.get(label);
+  }
+
+  @Override
+  public DataSet<TemporalVertex> getVerticesByLabel(String label) {
+    if (!vertices.containsKey(label)) {
+      throw new IllegalArgumentException("The given vertex label [" + label +
+        "] is not available in the (indexed) graph layout.");
+    }
+    return vertices.get(label);
+  }
+
+  @Override
+  public DataSet<TemporalEdge> getEdgesByLabel(String label) {
+    if (!edges.containsKey(label)) {
+      throw new IllegalArgumentException("The given edge label [" + label +
+        "] is not available in the (indexed) graph layout.");
+    }
+    return edges.get(label);
+  }
+
+  @Override
+  public DataSet<TemporalGraphHead> getGraphHead() {
+    return getGraphHeads();
+  }
+
+  /**
+   * The request for all elements without specifying a label results in a union of all label-partitioned
+   * datasets.
+   *
+   * @return the whole graph head dataset created by a union of all single datasets
+   */
+  @Override
+  public DataSet<TemporalGraphHead> getGraphHeads() {
+    return graphHeads.values().stream().reduce(DataSet::union)
+      .orElseThrow(() -> new RuntimeException("Error during graph head union"));
+  }
+
+  /**
+   * The request for all elements without specifying a label results in a union of all label-partitioned
+   * datasets.
+   *
+   * @return the whole vertex dataset created by a union of all single datasets
+   */
+  @Override
+  public DataSet<TemporalVertex> getVertices() {
+    return vertices.values().stream().reduce(DataSet::union)
+      .orElseThrow(() -> new RuntimeException("Error during vertex union"));
+  }
+
+  /**
+   * The request for all elements without specifying a label results in a union of all label-partitioned
+   * datasets.
+   *
+   * @return the whole edge dataset created by a union of all single datasets
+   */
+  @Override
+  public DataSet<TemporalEdge> getEdges() {
+    return edges.values().stream().reduce(DataSet::union)
+      .orElseThrow(() -> new RuntimeException("Error during edge union."));
+  }
+}

--- a/gradoop-temporal/src/test/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSinkTest.java
+++ b/gradoop-temporal/src/test/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSinkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-temporal/src/test/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSinkTest.java
+++ b/gradoop-temporal/src/test/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSinkTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.io.impl.csv.indexed;
+
+import org.gradoop.common.model.impl.properties.PropertyValue;
+import org.gradoop.temporal.io.api.TemporalDataSource;
+import org.gradoop.temporal.model.impl.TemporalGraph;
+import org.gradoop.temporal.util.TemporalGradoopTestBase;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test class to test {@link TemporalIndexedCSVDataSink}.
+ */
+public class TemporalIndexedCSVDataSinkTest extends TemporalGradoopTestBase {
+
+  /**
+   * Temporal graph to test
+   */
+  private TemporalGraph testGraph;
+
+  /**
+   * Temporary test folder to write the test graph.
+   */
+  @Rule
+  public TemporaryFolder testFolder = new TemporaryFolder();
+
+  /**
+   * Creates a test temporal graph from the social network loader.
+   *
+   * @throws Exception if loading the graph fails
+   */
+  @Before
+  public void setUp() throws Exception {
+    testGraph = toTemporalGraph(getSocialNetworkLoader().getLogicalGraph())
+      .transformGraphHead((current, trans) -> {
+        current.setProperty("testGraphHeadProperty", PropertyValue.create(1L));
+        return current;
+      });
+  }
+
+  /**
+   * Test writing a temporal graph to an indexed csv sink.
+   *
+   * @throws Exception in case of a write error
+   */
+  @Test
+  public void testWrite() throws Exception {
+    File file = testFolder.newFolder();
+    String tempFolderPath = file.getPath();
+
+    testGraph.writeTo(new TemporalIndexedCSVDataSink(tempFolderPath, getConfig()));
+    getExecutionEnvironment().execute();
+
+    final File[] subdirs = file.listFiles(File::isDirectory);
+
+    assertNotNull(subdirs);
+    assertEquals(3, subdirs.length);
+    final List<File> files = Arrays.asList(subdirs);
+    final List<String> subDirList = files.stream().map(File::getName).collect(Collectors.toList());
+    assertTrue(subDirList.contains("vertices"));
+    assertTrue(subDirList.contains("edges"));
+    assertTrue(subDirList.contains("graphs"));
+
+    for (File elementDir : files) {
+      if (elementDir.getName().equals("vertices")) {
+        final File[] vertexLabelArray = elementDir.listFiles(File::isDirectory);
+        assertNotNull(vertexLabelArray);
+        final List<String> vertexLabelDirs = Arrays.stream(vertexLabelArray).map(File::getName)
+          .collect(Collectors.toList());
+        assertNotNull(vertexLabelDirs);
+        assertEquals(3, vertexLabelDirs.size());
+        assertTrue(vertexLabelDirs.contains("person"));
+        assertTrue(vertexLabelDirs.contains("forum"));
+        assertTrue(vertexLabelDirs.contains("tag"));
+
+      } else if (elementDir.getName().equals("edges")) {
+        final File[] edgeLabelArray = elementDir.listFiles(File::isDirectory);
+        assertNotNull(edgeLabelArray);
+        final List<String> edgeLabelDirs = Arrays.stream(edgeLabelArray).map(File::getName)
+          .collect(Collectors.toList());
+        assertNotNull(edgeLabelDirs);
+        assertEquals(5, edgeLabelDirs.size());
+        assertTrue(edgeLabelDirs.contains("hasmember"));
+        assertTrue(edgeLabelDirs.contains("hasinterest"));
+        assertTrue(edgeLabelDirs.contains("knows"));
+        assertTrue(edgeLabelDirs.contains("hasmoderator"));
+        assertTrue(edgeLabelDirs.contains("hastag"));
+
+      } else if (elementDir.getName().equals("graphs")) {
+        final File[] graphLabelArray = elementDir.listFiles(File::isDirectory);
+        assertNotNull(graphLabelArray);
+        final List<String> graphLabelDirs = Arrays.stream(graphLabelArray).map(File::getName)
+          .collect(Collectors.toList());
+        assertNotNull(graphLabelDirs);
+        assertEquals(1, graphLabelDirs.size());
+        assertTrue(graphLabelDirs.contains("_db"));
+      }
+    }
+  }
+
+  /**
+   * Test the {@link TemporalIndexedCSVDataSink#write(TemporalGraph)} method as well as the
+   * {@link TemporalIndexedCSVDataSource}.
+   *
+   * @throws Exception in case of a write error
+   */
+  @Test
+  public void testWriteAndReadAfterwards() throws Exception {
+    File file = testFolder.newFolder();
+    String tempFolderPath = file.getPath();
+    new TemporalIndexedCSVDataSink(tempFolderPath, getConfig()).write(testGraph);
+    getExecutionEnvironment().execute();
+    TemporalDataSource dataSource = new TemporalIndexedCSVDataSource(tempFolderPath, getConfig());
+    collectAndAssertTrue(dataSource.getTemporalGraph().equalsByData(testGraph));
+  }
+}

--- a/gradoop-temporal/src/test/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSourceTest.java
+++ b/gradoop-temporal/src/test/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-temporal/src/test/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSourceTest.java
+++ b/gradoop-temporal/src/test/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSourceTest.java
@@ -94,14 +94,14 @@ public class TemporalIndexedCSVDataSourceTest extends TemporalGradoopTestBase {
     getExecutionEnvironment().execute();
     TemporalIndexedCSVDataSource source = new TemporalIndexedCSVDataSource(testFolder.getRoot().getPath(),
       getConfig());
-    collectAndAssertTrue(source.getTemporalGraphCollection().equalsByGraphElementData(testGraphCollection));
+    collectAndAssertTrue(source.getTemporalGraphCollection().equalsByGraphData(testGraphCollection));
   }
 
   /**
    * Tests the function {@link TemporalIndexedCSVDataSource#getConfig()}.
    */
   @Test
-  public void testTestGetConfig() {
+  public void testGetConfig() {
     TemporalIndexedCSVDataSource source = new TemporalIndexedCSVDataSource(testFolder.getRoot().getPath(),
       getConfig());
     assertEquals(getConfig(), source.getConfig());

--- a/gradoop-temporal/src/test/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSourceTest.java
+++ b/gradoop-temporal/src/test/java/org/gradoop/temporal/io/impl/csv/indexed/TemporalIndexedCSVDataSourceTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.io.impl.csv.indexed;
+
+import org.gradoop.common.model.impl.properties.PropertyValue;
+import org.gradoop.temporal.model.impl.TemporalGraph;
+import org.gradoop.temporal.model.impl.TemporalGraphCollection;
+import org.gradoop.temporal.util.TemporalGradoopTestBase;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test class to test {@link TemporalIndexedCSVDataSource}.
+ */
+public class TemporalIndexedCSVDataSourceTest extends TemporalGradoopTestBase {
+
+  /**
+   * Temporal graph to test
+   */
+  private TemporalGraph testGraph;
+
+  /**
+   * Temporal graph collection to test
+   */
+  private TemporalGraphCollection testGraphCollection;
+
+  /**
+   * Temporary test folder to write the test graph.
+   */
+  @Rule
+  public TemporaryFolder testFolder = new TemporaryFolder();
+
+  /**
+   * Temporary test folder to write the test graph.
+   */
+  @Rule
+  public TemporaryFolder testCollectionFolder = new TemporaryFolder();
+
+  /**
+   * Creates a test temporal graph from the social network loader.
+   *
+   * @throws Exception if loading the graph fails
+   */
+  @Before
+  public void setUp() throws Exception {
+    testGraph = toTemporalGraph(getSocialNetworkLoader().getLogicalGraph())
+      .transformGraphHead((current, trans) -> {
+        current.setProperty("testGraphHeadProperty", PropertyValue.create(1L));
+        return current;
+      });
+
+    testGraphCollection = toTemporalGraphCollection(getSocialNetworkLoader().getGraphCollection());
+  }
+
+  /**
+   * Tests the function {@link TemporalIndexedCSVDataSource#getTemporalGraph()}.
+   *
+   * @throws Exception if loading the graph fails
+   */
+  @Test
+  public void testGetTemporalGraph() throws Exception {
+    new TemporalIndexedCSVDataSink(testFolder.getRoot().getPath(), getConfig()).write(testGraph);
+    getExecutionEnvironment().execute();
+    TemporalIndexedCSVDataSource source = new TemporalIndexedCSVDataSource(testFolder.getRoot().getPath(),
+      getConfig());
+    collectAndAssertTrue(source.getTemporalGraph().equalsByData(testGraph));
+  }
+
+  /**
+   * Tests the function {@link TemporalIndexedCSVDataSource#getTemporalGraphCollection()}.
+   *
+   * @throws Exception if loading the collection fails
+   */
+  @Test
+  public void testGetTemporalGraphCollection() throws Exception {
+    new TemporalIndexedCSVDataSink(testFolder.getRoot().getPath(), getConfig()).write(testGraphCollection);
+    getExecutionEnvironment().execute();
+    TemporalIndexedCSVDataSource source = new TemporalIndexedCSVDataSource(testFolder.getRoot().getPath(),
+      getConfig());
+    collectAndAssertTrue(source.getTemporalGraphCollection().equalsByGraphElementData(testGraphCollection));
+  }
+
+  /**
+   * Tests the function {@link TemporalIndexedCSVDataSource#getConfig()}.
+   */
+  @Test
+  public void testTestGetConfig() {
+    TemporalIndexedCSVDataSource source = new TemporalIndexedCSVDataSource(testFolder.getRoot().getPath(),
+      getConfig());
+    assertEquals(getConfig(), source.getConfig());
+  }
+}

--- a/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/layout/BaseTemporalGVELayoutTest.java
+++ b/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/layout/BaseTemporalGVELayoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/layout/BaseTemporalGVELayoutTest.java
+++ b/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/layout/BaseTemporalGVELayoutTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.layout;
+
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.gradoop.common.model.api.entities.EdgeFactory;
+import org.gradoop.common.model.api.entities.GraphHeadFactory;
+import org.gradoop.common.model.api.entities.VertexFactory;
+import org.gradoop.temporal.model.impl.TemporalGraphFactory;
+import org.gradoop.temporal.model.impl.pojo.TemporalEdge;
+import org.gradoop.temporal.model.impl.pojo.TemporalGraphHead;
+import org.gradoop.temporal.model.impl.pojo.TemporalVertex;
+import org.gradoop.temporal.util.TemporalGradoopConfig;
+import org.gradoop.temporal.util.TemporalGradoopTestBase;
+import org.junit.BeforeClass;
+
+/**
+ * Base class for layout tests. Provides some predefined graph elements.
+ */
+public abstract class BaseTemporalGVELayoutTest extends TemporalGradoopTestBase {
+
+  protected static TemporalGraphHead g0;
+  protected static TemporalGraphHead g1;
+
+  protected static TemporalVertex v0;
+  protected static TemporalVertex v1;
+  protected static TemporalVertex v2;
+  protected static TemporalVertex v3;
+  protected static TemporalVertex v4;
+  protected static TemporalVertex v5;
+
+  protected static TemporalEdge e0;
+  protected static TemporalEdge e1;
+  protected static TemporalEdge e2;
+  protected static TemporalEdge e3;
+  protected static TemporalEdge e4;
+
+  /**
+   * Create temporal graph elements before tests.
+   */
+  @BeforeClass
+  public static void setup() {
+    ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+    TemporalGraphFactory factory = TemporalGradoopConfig.createConfig(env).getTemporalGraphFactory();
+
+    GraphHeadFactory<TemporalGraphHead> temporalGraphHeadFactory = factory.getGraphHeadFactory();
+    VertexFactory<TemporalVertex> temporalVertexFactory = factory.getVertexFactory();
+    EdgeFactory<TemporalEdge> temporalEdgeFactory = factory.getEdgeFactory();
+
+    g0 = temporalGraphHeadFactory.createGraphHead("G");
+    g1 = temporalGraphHeadFactory.createGraphHead("Q");
+
+    v0 = temporalVertexFactory.createVertex("A");
+    v1 = temporalVertexFactory.createVertex("A");
+    v2 = temporalVertexFactory.createVertex("A");
+    v3 = temporalVertexFactory.createVertex("B");
+    v4 = temporalVertexFactory.createVertex("B");
+    v5 = temporalVertexFactory.createVertex();
+
+    e0 = temporalEdgeFactory.createEdge("X", v0.getId(), v1.getId());
+    e1 = temporalEdgeFactory.createEdge("X", v1.getId(), v1.getId());
+    e2 = temporalEdgeFactory.createEdge("Y", v3.getId(), v4.getId());
+    e3 = temporalEdgeFactory.createEdge("Y", v3.getId(), v1.getId());
+
+    v0.addGraphId(g0.getId());
+    v1.addGraphId(g0.getId());
+    v1.addGraphId(g1.getId());
+    v2.addGraphId(g1.getId());
+    v3.addGraphId(g1.getId());
+    v4.addGraphId(g1.getId());
+    v5.addGraphId(g1.getId());
+
+    e0.addGraphId(g0.getId());
+    e1.addGraphId(g0.getId());
+    e2.addGraphId(g1.getId());
+    e3.addGraphId(g1.getId());
+  }
+}

--- a/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/layout/TemporalGVELayoutTest.java
+++ b/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/layout/TemporalGVELayoutTest.java
@@ -15,17 +15,11 @@
  */
 package org.gradoop.temporal.model.impl.layout;
 
-import com.google.common.collect.Sets;
 import org.gradoop.common.GradoopTestUtils;
 import org.gradoop.temporal.model.impl.pojo.TemporalEdge;
-import org.gradoop.temporal.model.impl.pojo.TemporalEdgeFactory;
 import org.gradoop.temporal.model.impl.pojo.TemporalGraphHead;
-import org.gradoop.temporal.model.impl.pojo.TemporalGraphHeadFactory;
 import org.gradoop.temporal.model.impl.pojo.TemporalVertex;
-import org.gradoop.temporal.model.impl.pojo.TemporalVertexFactory;
-import org.gradoop.temporal.util.TemporalGradoopTestBase;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
+import org.junit.Test;
 
 import java.util.Collection;
 
@@ -35,48 +29,69 @@ import static java.util.Collections.singletonList;
 /**
  * Tests of {@link TemporalGVELayout}.
  */
-public class TemporalGVELayoutTest extends TemporalGradoopTestBase {
-
-  protected static TemporalGraphHead g0;
-  protected static TemporalGraphHead g1;
-
-  protected static TemporalVertex v0;
-  protected static TemporalVertex v1;
-  protected static TemporalVertex v2;
-
-  protected static TemporalEdge e0;
-  protected static TemporalEdge e1;
+public class TemporalGVELayoutTest extends BaseTemporalGVELayoutTest {
 
   /**
-   * Create temporal graph elements before tests.
+   * Test {@link TemporalGVELayout#getGraphHead()}
    */
-  @BeforeClass
-  public static void setup() {
-    TemporalGraphHeadFactory temporalGraphHeadFactory = new TemporalGraphHeadFactory();
-    TemporalVertexFactory temporalVertexFactory = new TemporalVertexFactory();
-    TemporalEdgeFactory temporalEdgeFactory = new TemporalEdgeFactory();
+  @Test
+  public void getGraphHead() throws Exception {
+    GradoopTestUtils.validateElementCollections(singletonList(g0),
+      createLayout(singletonList(g0), asList(v0, v1), singletonList(e0)).getGraphHead().collect());
+  }
 
-    g0 = temporalGraphHeadFactory.createGraphHead();
-    g0.setLabel("A");
-    g1 = temporalGraphHeadFactory.createGraphHead();
-    g1.setLabel("B");
+  /**
+   * Test {@link TemporalGVELayout#getGraphHeads()}
+   */
+  @Test
+  public void getGraphHeads() throws Exception {
+    GradoopTestUtils.validateElementCollections(asList(g0, g1),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getGraphHeads().collect());
+  }
 
-    v0 = temporalVertexFactory.createVertex();
-    v0.setLabel("A");
-    v1 = temporalVertexFactory.createVertex();
-    v2 = temporalVertexFactory.createVertex();
+  /**
+   * Test {@link TemporalGVELayout#getGraphHeadsByLabel(String)}
+   */
+  @Test
+  public void getGraphHeadsByLabel() throws Exception {
+    GradoopTestUtils.validateElementCollections(singletonList(g0),
+      createLayout(singletonList(g0), asList(v0, v1, v2), asList(e0, e1)).getGraphHeadsByLabel("G").collect());
+  }
 
-    e0 = temporalEdgeFactory.createEdge(v0.getId(), v1.getId());
-    e0.setLabel("a");
-    e1 = temporalEdgeFactory.createEdge(v1.getId(), v2.getId());
+  /**
+   * Test {@link TemporalGVELayout#getVertices()}
+   */
+  @Test
+  public void getVertices() throws Exception {
+    GradoopTestUtils.validateGraphElementCollections(asList(v0, v1),
+      createLayout(asList(g0, g1), asList(v0, v1), asList(e0, e1)).getVertices().collect());
+  }
 
-    v0.addGraphId(g0.getId());
-    v1.addGraphId(g0.getId());
-    v1.addGraphId(g1.getId());
-    v2.addGraphId(g1.getId());
+  /**
+   * Test {@link TemporalGVELayout#getVerticesByLabel(String)}
+   */
+  @Test
+  public void getVerticesByLabel() throws Exception {
+    GradoopTestUtils.validateGraphElementCollections(asList(v0, v1, v2),
+      createLayout(asList(g0, g1), asList(v0, v1, v2, v3, v4, v5), asList(e0, e1)).getVerticesByLabel("A").collect());
+  }
 
-    e0.addGraphId(g0.getId());
-    e1.addGraphId(g1.getId());
+  /**
+   * Test {@link TemporalGVELayout#getEdges()}
+   */
+  @Test
+  public void getEdges() throws Exception {
+    GradoopTestUtils.validateGraphElementCollections(asList(e0, e1),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getEdges().collect());
+  }
+
+  /**
+   * Test {@link TemporalGVELayout#getEdgesByLabel(String)}
+   */
+  @Test
+  public void getEdgesByLabel() throws Exception {
+    GradoopTestUtils.validateGraphElementCollections(asList(e0, e1),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getEdgesByLabel("X").collect());
   }
 
   /**
@@ -87,75 +102,12 @@ public class TemporalGVELayoutTest extends TemporalGradoopTestBase {
    * @param edges edges to use
    * @return the temporal layout
    */
-  private TemporalGVELayout from(Collection<TemporalGraphHead> graphHeads,
+  private TemporalGVELayout createLayout(Collection<TemporalGraphHead> graphHeads,
     Collection<TemporalVertex> vertices,
     Collection<TemporalEdge> edges) {
     return new TemporalGVELayout(
       getExecutionEnvironment().fromCollection(graphHeads),
       getExecutionEnvironment().fromCollection(vertices),
       getExecutionEnvironment().fromCollection(edges));
-  }
-
-  /**
-   * Test {@link TemporalGVELayout#getGraphHead()}
-   */
-  @Test
-  public void getGraphHead() throws Exception {
-    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g0),
-      from(singletonList(g0), asList(v0, v1), singletonList(e0)).getGraphHead().collect());
-  }
-
-  /**
-   * Test {@link TemporalGVELayout#getGraphHeads()}
-   */
-  @Test
-  public void getGraphHeads() throws Exception {
-    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g0, g1),
-      from(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getGraphHeads().collect());
-  }
-
-  /**
-   * Test {@link TemporalGVELayout#getGraphHeadsByLabel(String)}
-   */
-  @Test
-  public void getGraphHeadsByLabel() throws Exception {
-    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g0),
-      from(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getGraphHeadsByLabel("A").collect());
-  }
-
-  /**
-   * Test {@link TemporalGVELayout#getVertices()}
-   */
-  @Test
-  public void getVertices() throws Exception {
-    GradoopTestUtils.validateGraphElementCollections(Sets.newHashSet(v0, v1, v2),
-      from(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getVertices().collect());
-  }
-
-  /**
-   * Test {@link TemporalGVELayout#getVerticesByLabel(String)}
-   */
-  @Test
-  public void getVerticesByLabel() throws Exception {
-    GradoopTestUtils.validateGraphElementCollections(Sets.newHashSet(v0),
-      from(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getVerticesByLabel("A").collect());
-  }
-
-  /**
-   * Test {@link TemporalGVELayout#getEdges()}
-   */
-  @Test
-  public void getEdges() throws Exception {
-    GradoopTestUtils.validateGraphElementCollections(Sets.newHashSet(e0, e1),
-      from(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getEdges().collect());
-  }
-
-  /**
-   * Test {@link TemporalGVELayout#getEdgesByLabel(String)}
-   */
-  @Test
-  public void getEdgesByLabel() throws Exception {
-    GradoopTestUtils.validateGraphElementCollections(Sets.newHashSet(e0),
-      from(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getEdgesByLabel("a").collect());
   }
 }

--- a/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/layout/TemporalIndexedLayoutTest.java
+++ b/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/layout/TemporalIndexedLayoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/layout/TemporalIndexedLayoutTest.java
+++ b/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/layout/TemporalIndexedLayoutTest.java
@@ -15,124 +15,117 @@
  */
 package org.gradoop.temporal.model.impl.layout;
 
-import com.google.common.collect.Sets;
 import org.apache.flink.api.java.DataSet;
 import org.gradoop.common.GradoopTestUtils;
+import org.gradoop.common.model.api.entities.Edge;
+import org.gradoop.common.model.api.entities.GraphHead;
+import org.gradoop.common.model.api.entities.Vertex;
 import org.gradoop.temporal.model.impl.pojo.TemporalEdge;
 import org.gradoop.temporal.model.impl.pojo.TemporalGraphHead;
 import org.gradoop.temporal.model.impl.pojo.TemporalVertex;
-import org.gradoop.temporal.util.TemporalGradoopTestBase;
-import org.junit.Before;
 import org.junit.Test;
 
-import java.util.HashMap;
+import java.util.Collection;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
  * Tests class {@link TemporalIndexedLayout}.
  */
-public class TemporalIndexedLayoutTest extends TemporalGradoopTestBase {
+public class TemporalIndexedLayoutTest extends BaseTemporalGVELayoutTest {
 
-  private TemporalIndexedLayout graphLayout;
-
-  private final TemporalGraphHead g0 = getGraphHeadFactory().createGraphHead("G0");
-  private final TemporalGraphHead g1 = getGraphHeadFactory().createGraphHead("G0");
-
-  private final TemporalVertex v0 = getVertexFactory().createVertex("A");
-  private final TemporalVertex v1 = getVertexFactory().createVertex("A");
-  private final TemporalVertex v2 = getVertexFactory().createVertex("A");
-  private final TemporalVertex v3 = getVertexFactory().createVertex("B");
-  private final TemporalVertex v4 = getVertexFactory().createVertex("B");
-  private final TemporalVertex v5 = getVertexFactory().createVertex();
-
-  private final TemporalEdge e0 = getEdgeFactory().createEdge("X", v0.getId(), v1.getId());
-  private final TemporalEdge e1 = getEdgeFactory().createEdge("X", v1.getId(), v1.getId());
-  private final TemporalEdge e2 = getEdgeFactory().createEdge("Y", v3.getId(), v4.getId());
-  private final TemporalEdge e3 = getEdgeFactory().createEdge("Y", v3.getId(), v1.getId());
-
-  @Before
-  public void setUp() throws Exception {
-    Map<String, DataSet<TemporalGraphHead>> graphHeads = new HashMap<>();
-    Map<String, DataSet<TemporalVertex>> vertices = new HashMap<>();
-    Map<String, DataSet<TemporalEdge>> edges = new HashMap<>();
-
-    graphHeads.put(g0.getLabel(), getExecutionEnvironment().fromElements(g0, g1));
-
-    vertices.put(v0.getLabel(), getExecutionEnvironment().fromElements(v0, v1, v2));
-    vertices.put(v3.getLabel(), getExecutionEnvironment().fromElements(v3, v4));
-    vertices.put(v5.getLabel(), getExecutionEnvironment().fromElements(v5));
-
-    edges.put(e0.getLabel(), getExecutionEnvironment().fromElements(e0, e1));
-    edges.put(e2.getLabel(), getExecutionEnvironment().fromElements(e2, e3));
-
-    graphLayout = new TemporalIndexedLayout(graphHeads, vertices, edges);
+  @Test
+  public void testIsGVELayout() {
+    assertFalse(createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).isGVELayout());
   }
 
   @Test
-  public void testIsIndexedGVELayout() {
-    assertTrue(graphLayout.isIndexedGVELayout());
-  }
-
-  @Test
-  public void testGetGraphHeadsByLabel() throws Exception {
-    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g0, g1),
-      graphLayout.getGraphHeadsByLabel("G0").collect());
-  }
-
-  @Test
-  public void testGetVerticesByLabel() throws Exception {
-    GradoopTestUtils.validateElementCollections(Sets.newHashSet(v0, v1, v2),
-      graphLayout.getVerticesByLabel("A").collect());
-
-    GradoopTestUtils.validateElementCollections(Sets.newHashSet(v3, v4),
-      graphLayout.getVerticesByLabel("B").collect());
-
-    GradoopTestUtils.validateElementCollections(Sets.newHashSet(v5),
-      graphLayout.getVerticesByLabel("").collect());
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetVerticesForNonExistingLabel() throws Exception {
-    graphLayout.getVerticesByLabel("X").collect();
-  }
-
-  @Test
-  public void testGetEdgesByLabel() throws Exception {
-    GradoopTestUtils.validateElementCollections(Sets.newHashSet(e0, e1),
-      graphLayout.getEdgesByLabel("X").collect());
-
-    GradoopTestUtils.validateElementCollections(Sets.newHashSet(e2, e3),
-      graphLayout.getEdgesByLabel("Y").collect());
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetEdgesForNonExistingLabel() throws Exception {
-    graphLayout.getEdgesByLabel("A").collect();
+  public void testIsTransactionalLayout() {
+    assertFalse(createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).isTransactionalLayout());
   }
 
   @Test
   public void testGetGraphHead() throws Exception {
-    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g0, g1),
-      graphLayout.getGraphHeads().collect());
+    GradoopTestUtils.validateElementCollections(singletonList(g0),
+      createLayout(singletonList(g0), asList(v0, v1), singletonList(e0)).getGraphHead().collect());
   }
 
   @Test
   public void testGetGraphHeads() throws Exception {
-    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g0, g1),
-      graphLayout.getGraphHeads().collect());
+    GradoopTestUtils.validateElementCollections(asList(g0, g1),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getGraphHeads().collect());
+  }
+
+  @Test
+  public void testGetGraphHeadsByLabel() throws Exception {
+    GradoopTestUtils.validateElementCollections(singletonList(g0),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getGraphHeadsByLabel("G").collect());
+    GradoopTestUtils.validateElementCollections(singletonList(g1),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getGraphHeadsByLabel("Q").collect());
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testGetGraphTransactions() {
+    createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getGraphTransactions();
   }
 
   @Test
   public void testGetVertices() throws Exception {
-    GradoopTestUtils.validateElementCollections(Sets.newHashSet(v0, v1, v2, v3, v4, v5),
-      graphLayout.getVertices().collect());
+    GradoopTestUtils.validateGraphElementCollections(asList(v0, v1, v2),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).getVertices().collect());
+  }
+
+  @Test
+  public void testGetVerticesByLabel() throws Exception {
+    GradoopTestUtils.validateGraphElementCollections(asList(v3, v4),
+      createLayout(asList(g0, g1), asList(v0, v1, v2, v3, v4), asList(e0, e1)).getVerticesByLabel("B").collect());
   }
 
   @Test
   public void testGetEdges() throws Exception {
-    GradoopTestUtils.validateElementCollections(Sets.newHashSet(e0, e1, e2, e3),
-      graphLayout.getEdges().collect());
+    GradoopTestUtils.validateGraphElementCollections(asList(e0, e1, e2, e3),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1, e2, e3)).getEdges().collect());
+  }
+
+  @Test
+  public void testGetEdgesByLabel() throws Exception {
+    GradoopTestUtils.validateGraphElementCollections(asList(e2, e3),
+      createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1, e2, e3)).getEdgesByLabel("Y").collect());
+  }
+
+  @Test
+  public void isIndexedGVELayout() {
+    assertTrue(createLayout(asList(g0, g1), asList(v0, v1, v2), asList(e0, e1)).isIndexedGVELayout());
+  }
+
+  /**
+   * Creates a temporal indexed GVE layout fom collections.
+   *
+   * @param graphHeads graph heads to use
+   * @param vertices vertices to use
+   * @param edges edges to use
+   * @return the temporal indexed layout
+   */
+  private TemporalIndexedLayout createLayout(Collection<TemporalGraphHead> graphHeads,
+    Collection<TemporalVertex> vertices, Collection<TemporalEdge> edges) {
+
+    Map<String, DataSet<TemporalGraphHead>> indexedGraphHeads =
+      graphHeads.stream().collect(Collectors.groupingBy(GraphHead::getLabel)).entrySet().stream().collect(
+        Collectors.toMap(Map.Entry::getKey, e -> getExecutionEnvironment().fromCollection(e.getValue())));
+
+    Map<String, DataSet<TemporalVertex>> indexedVertices =
+      vertices.stream().collect(Collectors.groupingBy(Vertex::getLabel)).entrySet().stream().collect(
+        Collectors.toMap(Map.Entry::getKey, e -> getExecutionEnvironment().fromCollection(e.getValue())));
+
+    Map<String, DataSet<TemporalEdge>> indexedEdges =
+      edges.stream().collect(Collectors.groupingBy(Edge::getLabel)).entrySet().stream().collect(
+        Collectors.toMap(Map.Entry::getKey, e -> getExecutionEnvironment().fromCollection(e.getValue())));
+
+    return new TemporalIndexedLayout(indexedGraphHeads, indexedVertices, indexedEdges);
   }
 }

--- a/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/layout/TemporalIndexedLayoutTest.java
+++ b/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/layout/TemporalIndexedLayoutTest.java
@@ -26,10 +26,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests class {@link TemporalIndexedLayout}.

--- a/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/layout/TemporalIndexedLayoutTest.java
+++ b/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/layout/TemporalIndexedLayoutTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.layout;
+
+import com.google.common.collect.Sets;
+import org.apache.flink.api.java.DataSet;
+import org.gradoop.common.GradoopTestUtils;
+import org.gradoop.temporal.model.impl.pojo.TemporalEdge;
+import org.gradoop.temporal.model.impl.pojo.TemporalGraphHead;
+import org.gradoop.temporal.model.impl.pojo.TemporalVertex;
+import org.gradoop.temporal.util.TemporalGradoopTestBase;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests class {@link TemporalIndexedLayout}.
+ */
+public class TemporalIndexedLayoutTest extends TemporalGradoopTestBase {
+
+  private TemporalIndexedLayout graphLayout;
+
+  private final TemporalGraphHead g0 = getGraphHeadFactory().createGraphHead("G0");
+  private final TemporalGraphHead g1 = getGraphHeadFactory().createGraphHead("G0");
+
+  private final TemporalVertex v0 = getVertexFactory().createVertex("A");
+  private final TemporalVertex v1 = getVertexFactory().createVertex("A");
+  private final TemporalVertex v2 = getVertexFactory().createVertex("A");
+  private final TemporalVertex v3 = getVertexFactory().createVertex("B");
+  private final TemporalVertex v4 = getVertexFactory().createVertex("B");
+  private final TemporalVertex v5 = getVertexFactory().createVertex();
+
+  private final TemporalEdge e0 = getEdgeFactory().createEdge("X", v0.getId(), v1.getId());
+  private final TemporalEdge e1 = getEdgeFactory().createEdge("X", v1.getId(), v1.getId());
+  private final TemporalEdge e2 = getEdgeFactory().createEdge("Y", v3.getId(), v4.getId());
+  private final TemporalEdge e3 = getEdgeFactory().createEdge("Y", v3.getId(), v1.getId());
+
+  @Before
+  public void setUp() throws Exception {
+    Map<String, DataSet<TemporalGraphHead>> graphHeads = new HashMap<>();
+    Map<String, DataSet<TemporalVertex>> vertices = new HashMap<>();
+    Map<String, DataSet<TemporalEdge>> edges = new HashMap<>();
+
+    graphHeads.put(g0.getLabel(), getExecutionEnvironment().fromElements(g0, g1));
+
+    vertices.put(v0.getLabel(), getExecutionEnvironment().fromElements(v0, v1, v2));
+    vertices.put(v3.getLabel(), getExecutionEnvironment().fromElements(v3, v4));
+    vertices.put(v5.getLabel(), getExecutionEnvironment().fromElements(v5));
+
+    edges.put(e0.getLabel(), getExecutionEnvironment().fromElements(e0, e1));
+    edges.put(e2.getLabel(), getExecutionEnvironment().fromElements(e2, e3));
+
+    graphLayout = new TemporalIndexedLayout(graphHeads, vertices, edges);
+  }
+
+  @Test
+  public void testIsIndexedGVELayout() {
+    assertTrue(graphLayout.isIndexedGVELayout());
+  }
+
+  @Test
+  public void testGetGraphHeadsByLabel() throws Exception {
+    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g0, g1),
+      graphLayout.getGraphHeadsByLabel("G0").collect());
+  }
+
+  @Test
+  public void testGetVerticesByLabel() throws Exception {
+    GradoopTestUtils.validateElementCollections(Sets.newHashSet(v0, v1, v2),
+      graphLayout.getVerticesByLabel("A").collect());
+
+    GradoopTestUtils.validateElementCollections(Sets.newHashSet(v3, v4),
+      graphLayout.getVerticesByLabel("B").collect());
+
+    GradoopTestUtils.validateElementCollections(Sets.newHashSet(v5),
+      graphLayout.getVerticesByLabel("").collect());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetVerticesForNonExistingLabel() throws Exception {
+    graphLayout.getVerticesByLabel("X").collect();
+  }
+
+  @Test
+  public void testGetEdgesByLabel() throws Exception {
+    GradoopTestUtils.validateElementCollections(Sets.newHashSet(e0, e1),
+      graphLayout.getEdgesByLabel("X").collect());
+
+    GradoopTestUtils.validateElementCollections(Sets.newHashSet(e2, e3),
+      graphLayout.getEdgesByLabel("Y").collect());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetEdgesForNonExistingLabel() throws Exception {
+    graphLayout.getEdgesByLabel("A").collect();
+  }
+
+  @Test
+  public void testGetGraphHead() throws Exception {
+    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g0, g1),
+      graphLayout.getGraphHeads().collect());
+  }
+
+  @Test
+  public void testGetGraphHeads() throws Exception {
+    GradoopTestUtils.validateElementCollections(Sets.newHashSet(g0, g1),
+      graphLayout.getGraphHeads().collect());
+  }
+
+  @Test
+  public void testGetVertices() throws Exception {
+    GradoopTestUtils.validateElementCollections(Sets.newHashSet(v0, v1, v2, v3, v4, v5),
+      graphLayout.getVertices().collect());
+  }
+
+  @Test
+  public void testGetEdges() throws Exception {
+    GradoopTestUtils.validateElementCollections(Sets.newHashSet(e0, e1, e2, e3),
+      graphLayout.getEdges().collect());
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I added an indexed source and sink for temporal graphs and collections. I also added a TemporalIndexedLayout that is automatically used as a layout, if the function "fromIndexedDatasets" are used in the layout factories.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1510 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It is used as an alternative graph layout and will be used to test the performance improvements on operators like pattern matching.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Unit and integration tests.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if necessary).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I ran a spell checker.

