### PR TITLE
Remove use of org.hamcrest in Unit Tests

### DIFF
--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/id/GradoopIdsTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/id/GradoopIdsTest.java
@@ -28,8 +28,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.testng.AssertJUnit.*;
 import static org.testng.Assert.assertNotEquals;
 
@@ -66,7 +64,7 @@ public class GradoopIdsTest {
     GradoopIdSet ids = new GradoopIdSet();
     ids.add(id1);
 
-    assertThat(ids.size(), is(1));
+    assertEquals(1, ids.size());
     assertTrue(ids.contains(id1));
     assertFalse(ids.contains(id2));
   }
@@ -80,13 +78,13 @@ public class GradoopIdsTest {
     GradoopIdSet ids = new GradoopIdSet();
     ids.addAll(Arrays.asList(id1, id2));
 
-    assertThat(ids.size(), is(2));
+    assertEquals(2, ids.size());
     assertTrue(ids.contains(id1));
     assertTrue(ids.contains(id2));
     assertFalse(ids.contains(id3));
 
     ids.addAll(Arrays.asList(id1, id2));
-    assertThat(ids.size(), is(2));
+    assertEquals(2, ids.size());
   }
 
   @Test
@@ -100,12 +98,12 @@ public class GradoopIdsTest {
     GradoopIdSet list2 = new GradoopIdSet();
     list2.addAll(list1);
 
-    assertThat(list2.size(), is(2));
+    assertEquals(2, list2.size());
     assertTrue(list2.contains(id1));
     assertTrue(list2.contains(id2));
 
     list2.addAll(list1);
-    assertThat(list2.size(), is(2));
+    assertEquals(2, list2.size());
   }
 
   @Test
@@ -200,7 +198,7 @@ public class GradoopIdsTest {
     DataInputView dataInputView = new DataInputViewStreamWrapper(in);
     idsRead.read(dataInputView);
 
-    assertThat(idsRead.size(), is(2));
+    assertEquals(2, idsRead.size());
     assertTrue(idsRead.contains(id1));
     assertTrue(idsRead.contains(id2));
   }
@@ -240,11 +238,11 @@ public class GradoopIdsTest {
     ids.add(id1);
     ids.add(id2);
 
-    assertThat(ids.size(), is(2));
+    assertEquals(2, ids.size());
 
     ids.clear();
 
-    assertThat(ids.size(), is(0));
+    assertEquals(0, ids.size());
   }
 
   @Test
@@ -253,13 +251,13 @@ public class GradoopIdsTest {
     GradoopId id2 = GradoopId.get();
 
     GradoopIdSet ids = new GradoopIdSet();
-    assertThat(ids.size(), is(0));
+    assertEquals(0, ids.size());
     ids.add(id1);
-    assertThat(ids.size(), is(1));
+    assertEquals(1, ids.size());
     ids.add(id1);
-    assertThat(ids.size(), is(1));
+    assertEquals(1, ids.size());
     ids.add(id2);
-    assertThat(ids.size(), is(2));
+    assertEquals(2, ids.size());
   }
 
   @Test
@@ -268,7 +266,7 @@ public class GradoopIdsTest {
     GradoopId id2 = GradoopId.get();
     GradoopId id3 = GradoopId.get();
     GradoopIdSet ids = GradoopIdSet.fromExisting(id1, id2, id3);
-    assertThat(ids.size(), is(3));
+    assertEquals(3, ids.size());
   }
 
   @Test

--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/pojo/EdgeTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/pojo/EdgeTest.java
@@ -20,11 +20,8 @@ import org.gradoop.common.model.impl.id.GradoopId;
 import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.common.util.GradoopConstants;
-import org.hamcrest.core.Is;
 import org.testng.annotations.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -36,11 +33,11 @@ public class EdgeTest {
     GradoopId sourceId = GradoopId.get();
     GradoopId targetId = GradoopId.get();
     Edge e = new EPGMEdgeFactory().initEdge(edgeId, sourceId, targetId);
-    assertThat(e.getId(), is(edgeId));
-    assertThat(e.getSourceId(), is(sourceId));
-    assertThat(e.getTargetId(), is(targetId));
-    assertThat(e.getPropertyCount(), is(0));
-    assertThat(e.getGraphCount(), is(0));
+    assertEquals(edgeId, e.getId());
+    assertEquals(sourceId, e.getSourceId());
+    assertEquals(targetId, e.getTargetId());
+    assertEquals(0, e.getPropertyCount());
+    assertEquals(0, e.getGraphCount());
   }
 
   @Test
@@ -58,14 +55,14 @@ public class EdgeTest {
 
     Edge edge = new EPGMEdgeFactory().initEdge(edgeId, label, sourceId, targetId, props, graphIds);
 
-    assertThat(edge.getId(), is(edgeId));
+    assertEquals(edgeId, edge.getId());
     assertEquals(label, edge.getLabel());
-    assertThat(edge.getSourceId(), is(sourceId));
-    assertThat(edge.getTargetId(), is(targetId));
-    assertThat(edge.getPropertyCount(), is(2));
-    assertThat(edge.getPropertyValue("k1").getString(), Is.<Object>is("v1"));
-    assertThat(edge.getPropertyValue("k2").getString(), Is.<Object>is("v2"));
-    assertThat(edge.getGraphCount(), is(2));
+    assertEquals(sourceId, edge.getSourceId());
+    assertEquals(targetId, edge.getTargetId());
+    assertEquals(2, edge.getPropertyCount());
+    assertEquals("v1", edge.getPropertyValue("k1").getString());
+    assertEquals("v2", edge.getPropertyValue("k2").getString());
+    assertEquals(2, edge.getGraphCount());
 
     for (GradoopId graphId : graphIds) {
       assertTrue(edge.getGraphIds().contains(graphId));
@@ -79,7 +76,7 @@ public class EdgeTest {
     GradoopId targetId = GradoopId.get();
     Edge e =
       new EPGMEdgeFactory().initEdge(edgeId, sourceId, targetId);
-    assertThat(e.getLabel(), is(GradoopConstants.DEFAULT_EDGE_LABEL));
+    assertEquals(GradoopConstants.DEFAULT_EDGE_LABEL, e.getLabel());
   }
 
   @Test(expectedExceptions = NullPointerException.class)

--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/pojo/GraphHeadTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/pojo/GraphHeadTest.java
@@ -19,11 +19,8 @@ import org.gradoop.common.model.api.entities.GraphHead;
 import org.gradoop.common.model.impl.id.GradoopId;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.common.util.GradoopConstants;
-import org.hamcrest.core.Is;
 import org.testng.annotations.Test;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.testng.AssertJUnit.*;
 import static org.testng.Assert.assertNotEquals;
 
@@ -32,8 +29,8 @@ public class GraphHeadTest {
   public void createWithIDTest() {
     GradoopId graphID = GradoopId.get();
     GraphHead g = new EPGMGraphHeadFactory().initGraphHead(graphID);
-    assertThat(g.getId(), is(graphID));
-    assertThat(g.getPropertyCount(), is(0));
+    assertEquals(graphID, g.getId());
+    assertEquals(0, g.getPropertyCount());
   }
 
   @Test
@@ -46,18 +43,18 @@ public class GraphHeadTest {
 
     GraphHead graphHead = new EPGMGraphHeadFactory().initGraphHead(graphID, label, props);
 
-    assertThat(graphHead.getId(), is(graphID));
+    assertEquals(graphID, graphHead.getId());
     assertEquals(label, graphHead.getLabel());
-    assertThat(graphHead.getPropertyCount(), is(2));
-    assertThat(graphHead.getPropertyValue("k1").getString(), Is.<Object>is("v1"));
-    assertThat(graphHead.getPropertyValue("k2").getString(), Is.<Object>is("v2"));
+    assertEquals(2, graphHead.getPropertyCount());
+    assertEquals("v1", graphHead.getPropertyValue("k1").getString());
+    assertEquals("v2", graphHead.getPropertyValue("k2").getString());
   }
 
   @Test
   public void createWithMissingLabelTest() {
     GradoopId graphID = GradoopId.get();
     GraphHead g = new EPGMGraphHeadFactory().initGraphHead(graphID);
-    assertThat(g.getLabel(), is(GradoopConstants.DEFAULT_GRAPH_LABEL));
+    assertEquals(GradoopConstants.DEFAULT_GRAPH_LABEL, g.getLabel());
   }
 
   @Test(expectedExceptions = NullPointerException.class)

--- a/gradoop-common/src/test/java/org/gradoop/common/model/impl/pojo/VertexTest.java
+++ b/gradoop-common/src/test/java/org/gradoop/common/model/impl/pojo/VertexTest.java
@@ -20,10 +20,8 @@ import org.gradoop.common.model.impl.id.GradoopId;
 import org.gradoop.common.model.impl.id.GradoopIdSet;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.common.util.GradoopConstants;
-import org.hamcrest.core.Is;
 import org.testng.annotations.Test;
 
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
 public class VertexTest {
@@ -32,9 +30,9 @@ public class VertexTest {
   public void createWithIDTest() {
     GradoopId vertexID = GradoopId.get();
     Vertex v = new EPGMVertexFactory().initVertex(vertexID);
-    assertThat(v.getId(), is(vertexID));
-    assertThat(v.getPropertyCount(), is(0));
-    assertThat(v.getGraphCount(), is(0));
+    assertEquals(vertexID, v.getId());
+    assertEquals(0, v.getPropertyCount());
+    assertEquals(0, v.getGraphCount());
   }
 
   @Test
@@ -55,12 +53,12 @@ public class VertexTest {
     Vertex vertex = new EPGMVertexFactory()
       .initVertex(vertexID, label, props, graphIds);
 
-    assertThat(vertex.getId(), is(vertexID));
+    assertEquals(vertexID, vertex.getId());
     assertEquals(label, vertex.getLabel());
-    assertThat(vertex.getPropertyCount(), is(2));
-    assertThat(vertex.getPropertyValue("k1").getString(), Is.<Object>is("v1"));
-    assertThat(vertex.getPropertyValue("k2").getString(), Is.<Object>is("v2"));
-    assertThat(vertex.getGraphCount(), is(2));
+    assertEquals(2, vertex.getPropertyCount());
+    assertEquals("v1", vertex.getPropertyValue("k1").getString());
+    assertEquals("v2", vertex.getPropertyValue("k2").getString());
+    assertEquals(2, vertex.getGraphCount());
     assertTrue(vertex.getGraphIds().contains(graphId1));
     assertTrue(vertex.getGraphIds().contains(graphId2));
   }
@@ -69,7 +67,7 @@ public class VertexTest {
   public void createWithMissingLabelTest() {
     GradoopId vertexID = GradoopId.get();
     Vertex v = new EPGMVertexFactory().initVertex(vertexID);
-    assertThat(v.getLabel(), is(GradoopConstants.DEFAULT_VERTEX_LABEL));
+    assertEquals(GradoopConstants.DEFAULT_VERTEX_LABEL, v.getLabel());
   }
 
   @Test(expectedExceptions = NullPointerException.class)

--- a/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/statistics/GraphStatisticsDataSinkTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/statistics/GraphStatisticsDataSinkTest.java
@@ -15,8 +15,7 @@
  */
 package org.gradoop.flink.io.impl.statistics;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import org.gradoop.flink.io.api.DataSink;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
@@ -45,7 +44,7 @@ public class GraphStatisticsDataSinkTest extends GradoopFlinkTestBase {
 
     GraphStatistics statistics = GraphStatisticsLocalFSReader.read(tmpPath);
 
-    assertThat(statistics.getVertexCount(), is(11L));
+    assertEquals(11L, (long)statistics.getVertexCount());
   }
 
 
@@ -63,7 +62,7 @@ public class GraphStatisticsDataSinkTest extends GradoopFlinkTestBase {
 
     GraphStatistics statistics = GraphStatisticsLocalFSReader.read(tmpPath);
 
-    assertThat(statistics.getEdgeCount(), is(24L));
+    assertEquals(24L, statistics.getEdgeCount());
   }
 
   @Test
@@ -79,9 +78,9 @@ public class GraphStatisticsDataSinkTest extends GradoopFlinkTestBase {
 
     GraphStatistics statistics = GraphStatisticsLocalFSReader.read(tmpPath);
 
-    assertThat(statistics.getVertexCount("Person"), is(6L));
-    assertThat(statistics.getVertexCount("Forum"), is(2L));
-    assertThat(statistics.getVertexCount("Tag"), is(3L));
+    assertEquals(6L, statistics.getVertexCount("Person"));
+    assertEquals(2L, statistics.getVertexCount("Forum"));
+    assertEquals(3L, statistics.getVertexCount("Tag"));
   }
 
   @Test
@@ -97,11 +96,11 @@ public class GraphStatisticsDataSinkTest extends GradoopFlinkTestBase {
 
     GraphStatistics statistics = GraphStatisticsLocalFSReader.read(tmpPath);
 
-    assertThat(statistics.getEdgeCount("hasInterest"), is(4L));
-    assertThat(statistics.getEdgeCount("hasModerator"), is(2L));
-    assertThat(statistics.getEdgeCount("knows"), is(10L));
-    assertThat(statistics.getEdgeCount("hasTag"), is(4L));
-    assertThat(statistics.getEdgeCount("hasMember"), is(4L));
+    assertEquals(4L, statistics.getEdgeCount("hasInterest"));
+    assertEquals(2L, statistics.getEdgeCount("hasModerator"));
+    assertEquals(10L, statistics.getEdgeCount("knows"));
+    assertEquals(4L, statistics.getEdgeCount("hasTag"));
+    assertEquals(4L, statistics.getEdgeCount("hasMember"));
   }
 
   @Test
@@ -117,11 +116,11 @@ public class GraphStatisticsDataSinkTest extends GradoopFlinkTestBase {
 
     GraphStatistics statistics = GraphStatisticsLocalFSReader.read(tmpPath);
 
-    assertThat(statistics.getEdgeCountBySource("Forum", "hasMember"), is(4L));
-    assertThat(statistics.getEdgeCountBySource("Forum", "hasModerator"), is(2L));
-    assertThat(statistics.getEdgeCountBySource("Forum", "hasTag"), is(4L));
-    assertThat(statistics.getEdgeCountBySource("Person", "hasInterest"), is(4L));
-    assertThat(statistics.getEdgeCountBySource("Person", "knows"), is(10L));
+    assertEquals(4L, statistics.getEdgeCountBySource("Forum", "hasMember"));
+    assertEquals(2L, statistics.getEdgeCountBySource("Forum", "hasModerator"));
+    assertEquals(4L, statistics.getEdgeCountBySource("Forum", "hasTag"));
+    assertEquals(4L, statistics.getEdgeCountBySource("Person", "hasInterest"));
+    assertEquals(10L, statistics.getEdgeCountBySource("Person", "knows"));
   }
 
   @Test
@@ -137,11 +136,11 @@ public class GraphStatisticsDataSinkTest extends GradoopFlinkTestBase {
 
     GraphStatistics statistics = GraphStatisticsLocalFSReader.read(tmpPath);
 
-    assertThat(statistics.getEdgeCountByTarget("Tag", "hasTag"), is(4L));
-    assertThat(statistics.getEdgeCountByTarget("Tag", "hasInterest"), is(4L));
-    assertThat(statistics.getEdgeCountByTarget("Person", "knows"), is(10L));
-    assertThat(statistics.getEdgeCountByTarget("Person", "hasMember"), is(4L));
-    assertThat(statistics.getEdgeCountByTarget("Person", "hasModerator"), is(2L));
+    assertEquals(4L, statistics.getEdgeCountByTarget("Tag", "hasTag"));
+    assertEquals(4L, statistics.getEdgeCountByTarget("Tag", "hasInterest"));
+    assertEquals(10L, statistics.getEdgeCountByTarget("Person", "knows"));
+    assertEquals(4L, statistics.getEdgeCountByTarget("Person", "hasMember"));
+    assertEquals(2L, statistics.getEdgeCountByTarget("Person", "hasModerator"));
   }
 
   @Test
@@ -157,7 +156,7 @@ public class GraphStatisticsDataSinkTest extends GradoopFlinkTestBase {
 
     GraphStatistics statistics = GraphStatisticsLocalFSReader.read(tmpPath);
 
-    assertThat(statistics.getDistinctSourceVertexCount(), is(8L));
+    assertEquals(8L, statistics.getDistinctSourceVertexCount());
   }
 
   @Test
@@ -173,7 +172,7 @@ public class GraphStatisticsDataSinkTest extends GradoopFlinkTestBase {
 
     GraphStatistics statistics = GraphStatisticsLocalFSReader.read(tmpPath);
 
-    assertThat(statistics.getDistinctTargetVertexCount(), is(7L));
+    assertEquals(7L, statistics.getDistinctTargetVertexCount());
   }
 
   @Test
@@ -189,11 +188,11 @@ public class GraphStatisticsDataSinkTest extends GradoopFlinkTestBase {
 
     GraphStatistics statistics = GraphStatisticsLocalFSReader.read(tmpPath);
 
-    assertThat(statistics.getDistinctSourceVertexCount("hasInterest"), is(4L));
-    assertThat(statistics.getDistinctSourceVertexCount("hasModerator"), is(2L));
-    assertThat(statistics.getDistinctSourceVertexCount("knows"), is(6L));
-    assertThat(statistics.getDistinctSourceVertexCount("hasTag"), is(2L));
-    assertThat(statistics.getDistinctSourceVertexCount("hasMember"), is(2L));
+    assertEquals(4L, statistics.getDistinctSourceVertexCount("hasInterest"));
+    assertEquals(2L, statistics.getDistinctSourceVertexCount("hasModerator"));
+    assertEquals(6L, statistics.getDistinctSourceVertexCount("knows"));
+    assertEquals(2L, statistics.getDistinctSourceVertexCount("hasTag"));
+    assertEquals(2L, statistics.getDistinctSourceVertexCount("hasMember"));
   }
 
   @Test
@@ -209,11 +208,11 @@ public class GraphStatisticsDataSinkTest extends GradoopFlinkTestBase {
 
     GraphStatistics statistics = GraphStatisticsLocalFSReader.read(tmpPath);
 
-    assertThat(statistics.getDistinctTargetVertexCount("hasInterest"), is(2L));
-    assertThat(statistics.getDistinctTargetVertexCount("hasModerator"), is(2L));
-    assertThat(statistics.getDistinctTargetVertexCount("knows"), is(4L));
-    assertThat(statistics.getDistinctTargetVertexCount("hasMember"), is(4L));
-    assertThat(statistics.getDistinctTargetVertexCount("hasTag"), is(3L));
+    assertEquals(2L, statistics.getDistinctTargetVertexCount("hasInterest"));
+    assertEquals(2L, statistics.getDistinctTargetVertexCount("hasModerator"));
+    assertEquals(4L, statistics.getDistinctTargetVertexCount("knows"));
+    assertEquals(4L, statistics.getDistinctTargetVertexCount("hasMember"));
+    assertEquals(3L, statistics.getDistinctTargetVertexCount("hasTag"));
   }
 
   @Test
@@ -228,8 +227,8 @@ public class GraphStatisticsDataSinkTest extends GradoopFlinkTestBase {
     getExecutionEnvironment().execute();
     GraphStatistics statistics = GraphStatisticsLocalFSReader.read(tmpPath);
 
-    assertThat(statistics.getDistinctEdgeProperties("knows", "since"), is(3L));
-    assertThat(statistics.getDistinctEdgeProperties("hasModerator", "since"), is(1L));
+    assertEquals(3L, statistics.getDistinctEdgeProperties("knows", "since"));
+    assertEquals(1L, statistics.getDistinctEdgeProperties("hasModerator", "since"));
   }
 
   @Test
@@ -245,14 +244,14 @@ public class GraphStatisticsDataSinkTest extends GradoopFlinkTestBase {
 
     GraphStatistics statistics = GraphStatisticsLocalFSReader.read(tmpPath);
 
-    assertThat(statistics.getDistinctVertexProperties("Person", "name"), is(6L));
-    assertThat(statistics.getDistinctVertexProperties("Person", "gender"), is(2L));
-    assertThat(statistics.getDistinctVertexProperties("Person", "city"), is(3L));
-    assertThat(statistics.getDistinctVertexProperties("Person", "age"), is(4L));
-    assertThat(statistics.getDistinctVertexProperties("Person", "speaks"), is(1L));
-    assertThat(statistics.getDistinctVertexProperties("Person", "locIP"), is(1L));
-    assertThat(statistics.getDistinctVertexProperties("Tag", "name"), is(3L));
-    assertThat(statistics.getDistinctVertexProperties("Forum", "title"), is(2L));
+    assertEquals(6L, statistics.getDistinctVertexProperties("Person", "name"));
+    assertEquals(2L, statistics.getDistinctVertexProperties("Person", "gender"));
+    assertEquals(3L, statistics.getDistinctVertexProperties("Person", "city"));
+    assertEquals(4L, statistics.getDistinctVertexProperties("Person", "age"));
+    assertEquals(1L, statistics.getDistinctVertexProperties("Person", "speaks"));
+    assertEquals(1L, statistics.getDistinctVertexProperties("Person", "locIP"));
+    assertEquals(3L, statistics.getDistinctVertexProperties("Tag", "name"));
+    assertEquals(2L, statistics.getDistinctVertexProperties("Forum", "title"));
   }
 
   @Test
@@ -268,7 +267,7 @@ public class GraphStatisticsDataSinkTest extends GradoopFlinkTestBase {
 
     GraphStatistics statistics = GraphStatisticsLocalFSReader.read(tmpPath);
 
-    assertThat(statistics.getDistinctEdgeProperties("since"), is(3L));
+    assertEquals(3L, statistics.getDistinctEdgeProperties("since"));
   }
 
   @Test
@@ -284,13 +283,13 @@ public class GraphStatisticsDataSinkTest extends GradoopFlinkTestBase {
 
     GraphStatistics statistics = GraphStatisticsLocalFSReader.read(tmpPath);
 
-    assertThat(statistics.getDistinctVertexProperties("name"),    is(9L));
-    assertThat(statistics.getDistinctVertexProperties("gender"),  is(2L));
-    assertThat(statistics.getDistinctVertexProperties("city"),    is(3L));
-    assertThat(statistics.getDistinctVertexProperties("age"),     is(4L));
-    assertThat(statistics.getDistinctVertexProperties("speaks"),  is(1L));
-    assertThat(statistics.getDistinctVertexProperties("locIP"),   is(1L));
-    assertThat(statistics.getDistinctVertexProperties("title"),   is(2L));
+    assertEquals(9L, statistics.getDistinctVertexProperties("name"));
+    assertEquals(2L, statistics.getDistinctVertexProperties("gender"));
+    assertEquals(3L, statistics.getDistinctVertexProperties("city"));
+    assertEquals(4L, statistics.getDistinctVertexProperties("age"));
+    assertEquals(1L, statistics.getDistinctVertexProperties("speaks"));
+    assertEquals(1L, statistics.getDistinctVertexProperties("locIP"));
+    assertEquals(2L, statistics.getDistinctVertexProperties("title"));
   }
 
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/statistics/GraphStatisticsDataSinkTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/io/impl/statistics/GraphStatisticsDataSinkTest.java
@@ -44,7 +44,7 @@ public class GraphStatisticsDataSinkTest extends GradoopFlinkTestBase {
 
     GraphStatistics statistics = GraphStatisticsLocalFSReader.read(tmpPath);
 
-    assertEquals(11L, (long)statistics.getVertexCount());
+    assertEquals(11L, statistics.getVertexCount());
   }
 
 

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/RenameLabelTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/RenameLabelTest.java
@@ -25,11 +25,9 @@ import org.gradoop.common.model.impl.pojo.EPGMVertexFactory;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
 import org.gradoop.flink.model.api.functions.TransformationFunction;
-import org.hamcrest.core.Is;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class RenameLabelTest extends GradoopFlinkTestBase {
 
@@ -52,8 +50,8 @@ public class RenameLabelTest extends GradoopFlinkTestBase {
     renameFunction.apply(graphHead, graphHead);
 
     assertEquals(newLabel, graphHead.getLabel());
-    assertThat(graphHead.getPropertyValue("k1").toString(), Is.<Object>is("v1"));
-    assertThat(graphHead.getPropertyValue("k2").toString(), Is.<Object>is("v2"));
+    assertEquals("v1", graphHead.getPropertyValue("k1").toString());
+    assertEquals("v2", graphHead.getPropertyValue("k2").toString());
   }
 
   @Test
@@ -77,8 +75,8 @@ public class RenameLabelTest extends GradoopFlinkTestBase {
     renameFunction.apply(edge, edge);
 
     assertEquals(newLabel, edge.getLabel());
-    assertThat(edge.getPropertyValue("k1").toString(), Is.<Object>is("v1"));
-    assertThat(edge.getPropertyValue("k2").toString(), Is.<Object>is("v2"));
+    assertEquals("v1", edge.getPropertyValue("k1").toString());
+    assertEquals("v2", edge.getPropertyValue("k2").toString());
   }
 
   @Test
@@ -100,7 +98,7 @@ public class RenameLabelTest extends GradoopFlinkTestBase {
     renameFunction.apply(vertex, vertex);
 
     assertEquals(newLabel, vertex.getLabel());
-    assertThat(vertex.getPropertyValue("k1").toString(), Is.<Object>is("v1"));
-    assertThat(vertex.getPropertyValue("k2").toString(), Is.<Object>is("v2"));
+    assertEquals("v1", vertex.getPropertyValue("k1").toString());
+    assertEquals("v2", vertex.getPropertyValue("k2").toString());
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/RenamePropertyKeysTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/functions/epgm/RenamePropertyKeysTest.java
@@ -15,10 +15,8 @@
  */
 package org.gradoop.flink.model.impl.functions.epgm;
 
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 
 import java.util.HashMap;
 
@@ -32,7 +30,6 @@ import org.gradoop.common.model.impl.pojo.EPGMVertexFactory;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
 import org.gradoop.flink.model.api.functions.TransformationFunction;
-import org.hamcrest.core.Is;
 import org.junit.Test;
 
 public class RenamePropertyKeysTest extends GradoopFlinkTestBase {
@@ -57,10 +54,10 @@ public class RenamePropertyKeysTest extends GradoopFlinkTestBase {
 
     renameFunction.apply(graphHead, graphHead);
 
-    assertThat(graphHead.getPropertyCount(), is(2));
+    assertEquals(2, graphHead.getPropertyCount());
     assertEquals(label, graphHead.getLabel());
-    assertThat(graphHead.getPropertyValue("new_k1").toString(), Is.<Object>is("v1"));
-    assertThat(graphHead.getPropertyValue("k2").toString(), Is.<Object>is("v2"));
+    assertEquals("v1", graphHead.getPropertyValue("new_k1").toString());
+    assertEquals("v2", graphHead.getPropertyValue("k2").toString());
     assertNull(graphHead.getPropertyValue("k1"));
   }
 
@@ -86,10 +83,10 @@ public class RenamePropertyKeysTest extends GradoopFlinkTestBase {
 
     renameFunction.apply(edge, edge);
 
-    assertThat(edge.getPropertyCount(), is(2));
+    assertEquals(2, edge.getPropertyCount());
     assertEquals(label, edge.getLabel());
-    assertThat(edge.getPropertyValue("new_k1").toString(), Is.<Object>is("v1"));
-    assertThat(edge.getPropertyValue("k2").toString(), Is.<Object>is("v2"));
+    assertEquals("v1", edge.getPropertyValue("new_k1").toString());
+    assertEquals("v2", edge.getPropertyValue("k2").toString());
     assertNull(edge.getPropertyValue("k1"));
   }
 
@@ -113,10 +110,10 @@ public class RenamePropertyKeysTest extends GradoopFlinkTestBase {
 
     renameFunction.apply(vertex, vertex);
 
-    assertThat(vertex.getPropertyCount(), is(2));
+    assertEquals(2, vertex.getPropertyCount());
     assertEquals(label, vertex.getLabel());
-    assertThat(vertex.getPropertyValue("new_k1").toString(), Is.<Object>is("v1"));
-    assertThat(vertex.getPropertyValue("k2").toString(), Is.<Object>is("v2"));
+    assertEquals("v1", vertex.getPropertyValue("new_k1").toString());
+    assertEquals("v2", vertex.getPropertyValue("k2").toString());
     assertNull(vertex.getPropertyValue("k1"));
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/common/statistics/GraphStatisticsTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/common/statistics/GraphStatisticsTest.java
@@ -17,8 +17,7 @@ package org.gradoop.flink.model.impl.operators.matching.common.statistics;
 
 import org.junit.Test;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 public abstract class GraphStatisticsTest {
   /**
@@ -28,175 +27,151 @@ public abstract class GraphStatisticsTest {
 
   @Test
   public void testGetVertexCount() throws Exception {
-    assertThat(TEST_STATISTICS.getVertexCount(), is(11L));
+    assertEquals(11L, TEST_STATISTICS.getVertexCount());
   }
 
   @Test
   public void testGetEdgeCount() throws Exception {
-    assertThat(TEST_STATISTICS.getEdgeCount(), is(24L));
+    assertEquals(24L, TEST_STATISTICS.getEdgeCount());
   }
 
   @Test
   public void testGetVertexCountByLabel() throws Exception {
-    assertThat(TEST_STATISTICS.getVertexCount("Person"), is(6L));
-    assertThat(TEST_STATISTICS.getVertexCount("Forum"), is(2L));
-    assertThat(TEST_STATISTICS.getVertexCount("Tag"), is(3L));
+    assertEquals(6L, TEST_STATISTICS.getVertexCount("Person"));
+    assertEquals(2L, TEST_STATISTICS.getVertexCount("Forum"));
+    assertEquals(3L, TEST_STATISTICS.getVertexCount("Tag"));
     // nonexistent vertex label
-    assertThat(TEST_STATISTICS.getVertexCount("Foo"), is(0L));
+    assertEquals(0L, TEST_STATISTICS.getVertexCount("Foo"));
   }
 
   @Test
   public void testGetEdgeCountByLabel() throws Exception {
-    assertThat(TEST_STATISTICS.getEdgeCount("hasInterest"), is(4L));
-    assertThat(TEST_STATISTICS.getEdgeCount("hasModerator"), is(2L));
-    assertThat(TEST_STATISTICS.getEdgeCount("knows"), is(10L));
-    assertThat(TEST_STATISTICS.getEdgeCount("hasTag"), is(4L));
-    assertThat(TEST_STATISTICS.getEdgeCount("hasMember"), is(4L));
+    assertEquals(4L, TEST_STATISTICS.getEdgeCount("hasInterest"));
+    assertEquals(2L, TEST_STATISTICS.getEdgeCount("hasModerator"));
+    assertEquals(10L, TEST_STATISTICS.getEdgeCount("knows"));
+    assertEquals(4L, TEST_STATISTICS.getEdgeCount("hasTag"));
+    assertEquals(4L, TEST_STATISTICS.getEdgeCount("hasMember"));
     // nonexistent edge label
-    assertThat(TEST_STATISTICS.getEdgeCount("foo"), is(0L));
+    assertEquals(0L, TEST_STATISTICS.getEdgeCount("foo"));
   }
 
   @Test
   public void testGetEdgeCountBySourceVertexAndEdgeLabel() throws Exception {
-    assertThat(TEST_STATISTICS.getEdgeCountBySource("Forum", "hasMember"), is(4L));
-    assertThat(TEST_STATISTICS.getEdgeCountBySource("Forum", "hasModerator"), is(2L));
-    assertThat(TEST_STATISTICS.getEdgeCountBySource("Forum", "hasTag"), is(4L));
-    assertThat(TEST_STATISTICS.getEdgeCountBySource("Person", "hasInterest"), is(4L));
-    assertThat(TEST_STATISTICS.getEdgeCountBySource("Person", "knows"), is(10L));
+    assertEquals(4L, TEST_STATISTICS.getEdgeCountBySource("Forum", "hasMember"));
+    assertEquals(2L, TEST_STATISTICS.getEdgeCountBySource("Forum", "hasModerator"));
+    assertEquals(4L, TEST_STATISTICS.getEdgeCountBySource("Forum", "hasTag"));
+    assertEquals(4L, TEST_STATISTICS.getEdgeCountBySource("Person", "hasInterest"));
+    assertEquals(10L, TEST_STATISTICS.getEdgeCountBySource("Person", "knows"));
     // nonexistent edge label
-    assertThat(TEST_STATISTICS.getEdgeCountBySource("Person", "foo"), is(0L));
+    assertEquals(0L, TEST_STATISTICS.getEdgeCountBySource("Person", "foo"));
     // nonexistent vertex label
-    assertThat(TEST_STATISTICS.getEdgeCountBySource("Foo", "knows"), is(0L));
+    assertEquals(0L, TEST_STATISTICS.getEdgeCountBySource("Foo", "knows"));
   }
 
   @Test
   public void testGetEdgeCountByTargetVertexAndEdgeLabel() throws Exception {
-    assertThat(TEST_STATISTICS.getEdgeCountByTarget("Tag", "hasTag"), is(4L));
-    assertThat(TEST_STATISTICS.getEdgeCountByTarget("Tag", "hasInterest"), is(4L));
-    assertThat(TEST_STATISTICS.getEdgeCountByTarget("Person", "knows"), is(10L));
-    assertThat(TEST_STATISTICS.getEdgeCountByTarget("Person", "hasMember"), is(4L));
-    assertThat(TEST_STATISTICS.getEdgeCountByTarget("Person", "hasModerator"), is(2L));
+    assertEquals(4L, TEST_STATISTICS.getEdgeCountByTarget("Tag", "hasTag"));
+    assertEquals(4L, TEST_STATISTICS.getEdgeCountByTarget("Tag", "hasInterest"));
+    assertEquals(10L, TEST_STATISTICS.getEdgeCountByTarget("Person", "knows"));
+    assertEquals(4L, TEST_STATISTICS.getEdgeCountByTarget("Person", "hasMember"));
+    assertEquals(2L, TEST_STATISTICS.getEdgeCountByTarget("Person", "hasModerator"));
     // nonexistent edge label
-    assertThat(TEST_STATISTICS.getEdgeCountByTarget("Tag", "foo"), is(0L));
+    assertEquals(0L, TEST_STATISTICS.getEdgeCountByTarget("Tag", "foo"));
     // nonexistent vertex label
-    assertThat(TEST_STATISTICS.getEdgeCountByTarget("Foo", "hasTag"), is(0L));
+    assertEquals(0L, TEST_STATISTICS.getEdgeCountByTarget("Foo", "hasTag"));
   }
 
   @Test
   public void testGetDistinctSourceVertexCount() throws Exception {
-    assertThat(TEST_STATISTICS.getDistinctSourceVertexCount(), is(8L));
+    assertEquals(8L, TEST_STATISTICS.getDistinctSourceVertexCount());
   }
 
   @Test
   public void testGetDistinctTargetVertexCount() throws Exception {
-    assertThat(TEST_STATISTICS.getDistinctTargetVertexCount(), is(7L));
+    assertEquals(7L, TEST_STATISTICS.getDistinctTargetVertexCount());
   }
 
   @Test
   public void testGetDistinctSourceVertexCountByEdgeLabel() throws Exception {
-    assertThat(TEST_STATISTICS.getDistinctSourceVertexCount("hasInterest"), is(4L));
-    assertThat(TEST_STATISTICS.getDistinctSourceVertexCount("hasModerator"), is(2L));
-    assertThat(TEST_STATISTICS.getDistinctSourceVertexCount("knows"), is(6L));
-    assertThat(TEST_STATISTICS.getDistinctSourceVertexCount("hasTag"), is(2L));
-    assertThat(TEST_STATISTICS.getDistinctSourceVertexCount("hasMember"), is(2L));
+    assertEquals(4L, TEST_STATISTICS.getDistinctSourceVertexCount("hasInterest"));
+    assertEquals(2L, TEST_STATISTICS.getDistinctSourceVertexCount("hasModerator"));
+    assertEquals(6L, TEST_STATISTICS.getDistinctSourceVertexCount("knows"));
+    assertEquals(2L, TEST_STATISTICS.getDistinctSourceVertexCount("hasTag"));
+    assertEquals(2L, TEST_STATISTICS.getDistinctSourceVertexCount("hasMember"));
     // nonexistent edge label
-    assertThat(TEST_STATISTICS.getDistinctSourceVertexCount("foo"), is(0L));
+    assertEquals(0L, TEST_STATISTICS.getDistinctSourceVertexCount("foo"));
   }
 
   @Test
   public void testDistinctTargetVertexCountByEdgeLabel() throws Exception {
-    assertThat(TEST_STATISTICS.getDistinctTargetVertexCount("hasInterest"), is(2L));
-    assertThat(TEST_STATISTICS.getDistinctTargetVertexCount("hasModerator"), is(2L));
-    assertThat(TEST_STATISTICS.getDistinctTargetVertexCount("knows"), is(4L));
-    assertThat(TEST_STATISTICS.getDistinctTargetVertexCount("hasMember"), is(4L));
-    assertThat(TEST_STATISTICS.getDistinctTargetVertexCount("hasTag"), is(3L));
+    assertEquals(2L, TEST_STATISTICS.getDistinctTargetVertexCount("hasInterest"));
+    assertEquals(2L, TEST_STATISTICS.getDistinctTargetVertexCount("hasModerator"));
+    assertEquals(4L, TEST_STATISTICS.getDistinctTargetVertexCount("knows"));
+    assertEquals(4L, TEST_STATISTICS.getDistinctTargetVertexCount("hasMember"));
+    assertEquals(3L, TEST_STATISTICS.getDistinctTargetVertexCount("hasTag"));
     // nonexistent edge label
-    assertThat(TEST_STATISTICS.getDistinctTargetVertexCount("foo"), is(0L));
+    assertEquals(0L, TEST_STATISTICS.getDistinctTargetVertexCount("foo"));
   }
 
   @Test
   public void testDistinctPropertyValuesByEdgeLabelAndPropertyName() throws Exception {
-    assertThat(
-      TEST_STATISTICS.getDistinctEdgeProperties("knows", "since"),
-      is(6L));
-    assertThat(
-      TEST_STATISTICS.getDistinctEdgeProperties("hasModerator", "since"),
-      is(3L));
+    assertEquals(6L, TEST_STATISTICS.getDistinctEdgeProperties("knows", "since"));
+    assertEquals(3L, TEST_STATISTICS.getDistinctEdgeProperties("hasModerator", "since"));
     // nonexistent edge label
-    assertThat(
-      TEST_STATISTICS.getDistinctEdgeProperties("foo", "bar"),
-      is(0L));
+    assertEquals(0L, TEST_STATISTICS.getDistinctEdgeProperties("foo", "bar"));
   }
 
   @Test
   public void testDistinctPropertyValuesByVertexLabelAndPropertyName() throws Exception {
-    assertThat(
-      TEST_STATISTICS.getDistinctVertexProperties("Person", "name"),
-      is(6L));
-    assertThat(
-      TEST_STATISTICS.getDistinctVertexProperties("Person", "gender"),
-      is(2L));
-    assertThat(
-      TEST_STATISTICS.getDistinctVertexProperties("Person", "city"),
-      is(3L));
-    assertThat(
-      TEST_STATISTICS.getDistinctVertexProperties("Person", "age"),
-      is(4L));
-    assertThat(
-      TEST_STATISTICS.getDistinctVertexProperties("Person", "speaks"),
-      is(1L));
-    assertThat(
-      TEST_STATISTICS.getDistinctVertexProperties("Person", "locIP"),
-      is(1L));
-    assertThat(
-      TEST_STATISTICS.getDistinctVertexProperties("Tag", "name"),
-      is(3L));
-    assertThat(
-      TEST_STATISTICS.getDistinctVertexProperties("Forum", "title"),
-      is(2L));
+    assertEquals(6L,
+            TEST_STATISTICS.getDistinctVertexProperties("Person", "name"));
+    assertEquals(2L,
+            TEST_STATISTICS.getDistinctVertexProperties("Person", "gender"));
+    assertEquals(3L,
+            TEST_STATISTICS.getDistinctVertexProperties("Person", "city"));
+    assertEquals(4L,
+            TEST_STATISTICS.getDistinctVertexProperties("Person", "age"));
+    assertEquals(1L,
+            TEST_STATISTICS.getDistinctVertexProperties("Person", "speaks"));
+    assertEquals(1L,
+            TEST_STATISTICS.getDistinctVertexProperties("Person", "locIP"));
+    assertEquals(3L,
+            TEST_STATISTICS.getDistinctVertexProperties("Tag", "name"));
+    assertEquals(2L,
+            TEST_STATISTICS.getDistinctVertexProperties("Forum", "title"));
     // nonexistent edge label
-    assertThat(
-      TEST_STATISTICS.getDistinctVertexProperties("foo", "bar"),
-      is(0L));
+    assertEquals(0L,
+            TEST_STATISTICS.getDistinctVertexProperties("foo", "bar"));
   }
 
   @Test
   public void testDistinctEdgePropertyValuesByPropertyName() throws Exception {
-    assertThat(TEST_STATISTICS.getDistinctEdgeProperties("since"),
-      is(9L));
+    assertEquals(9L,
+            TEST_STATISTICS.getDistinctEdgeProperties("since"));
     // nonexistent edge label
-    assertThat(
-      TEST_STATISTICS.getDistinctEdgeProperties("bar"),
-      is(0L));
+    assertEquals(0L,
+            TEST_STATISTICS.getDistinctEdgeProperties("bar"));
   }
 
   @Test
   public void testDistinctVertexPropertyValuesByPropertyName() throws Exception {
-    assertThat(
-      TEST_STATISTICS.getDistinctVertexProperties("name"),
-      is(9L));
-    assertThat(
-      TEST_STATISTICS.getDistinctVertexProperties("gender"),
-      is(2L));
-    assertThat(
-      TEST_STATISTICS.getDistinctVertexProperties("city"),
-      is(3L));
-    assertThat(
-      TEST_STATISTICS.getDistinctVertexProperties("age"),
-      is(4L));
-    assertThat(
-      TEST_STATISTICS.getDistinctVertexProperties("speaks"),
-      is(1L));
-    assertThat(
-      TEST_STATISTICS.getDistinctVertexProperties("locIP"),
-      is(1L));
-    assertThat(
-      TEST_STATISTICS.getDistinctVertexProperties("title"),
-      is(2L));
+    assertEquals(9L,
+            TEST_STATISTICS.getDistinctVertexProperties("name"));
+    assertEquals(2L,
+            TEST_STATISTICS.getDistinctVertexProperties("gender"));
+    assertEquals(3L,
+            TEST_STATISTICS.getDistinctVertexProperties("city"));
+    assertEquals(4L,
+            TEST_STATISTICS.getDistinctVertexProperties("age"));
+    assertEquals(1L,
+            TEST_STATISTICS.getDistinctVertexProperties("speaks"));
+    assertEquals(1L,
+            TEST_STATISTICS.getDistinctVertexProperties("locIP"));
+    assertEquals(2L,
+            TEST_STATISTICS.getDistinctVertexProperties("title"));
     // nonexistent edge label
-    assertThat(
-      TEST_STATISTICS.getDistinctVertexProperties("bar"),
-      is(0L));
+    assertEquals(0L,
+            TEST_STATISTICS.getDistinctVertexProperties("bar"));
   }
 
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/QueryEngineITTests.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/QueryEngineITTests.java
@@ -29,8 +29,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 
 public class QueryEngineITTests extends GradoopFlinkTestBase {
 
@@ -93,8 +92,8 @@ public class QueryEngineITTests extends GradoopFlinkTestBase {
       MatchStrategy.ISOMORPHISM, MatchStrategy.ISOMORPHISM);
 
     PlanTableEntry planTableEntry = planner.plan();
-    assertThat(planTableEntry.getEstimatedCardinality(), is(estimatedCardinality));
+    assertEquals(estimatedCardinality, planTableEntry.getEstimatedCardinality());
     List<Embedding> result = planTableEntry.getQueryPlan().execute().collect();
-    assertThat(result.size(), is(exactCardinality));
+    assertEquals(exactCardinality, result.size());
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/common/pojos/EmbeddingMetaDataTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/common/pojos/EmbeddingMetaDataTest.java
@@ -301,11 +301,11 @@ public class EmbeddingMetaDataTest {
     metaData3.setEntryColumn("b", EntryType.VERTEX, 0);
     metaData3.setPropertyColumn("b", "age", 0);
 
-    assertTrue(metaData1.equals(metaData1));
-    assertTrue(metaData1.equals(metaData2));
-    assertTrue(metaData2.equals(metaData1));
-    assertFalse(metaData2.equals(metaData3));
-    assertFalse(metaData3.equals(metaData2));
+    assertEquals(metaData1, metaData1);
+    assertEquals(metaData1, metaData2);
+    assertEquals(metaData2, metaData1);
+    assertNotEquals(metaData2, metaData3);
+    assertNotEquals(metaData3, metaData2);
   }
 
   @Test

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/common/pojos/EmbeddingMetaDataTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/common/pojos/EmbeddingMetaDataTest.java
@@ -30,10 +30,7 @@ import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class EmbeddingMetaDataTest {
 
@@ -54,20 +51,20 @@ public class EmbeddingMetaDataTest {
 
     EmbeddingMetaData metaData = new EmbeddingMetaData(entryMap, propertyMap, directionMap);
 
-    assertThat(metaData.getEntryCount(), is(3));
-    assertThat(metaData.getEntryColumn("a"), is(0));
-    assertThat(metaData.getEntryColumn("b"), is(1));
-    assertThat(metaData.getEntryColumn("c"), is(2));
-    assertThat(metaData.getEntryType("a"), is(EntryType.VERTEX));
-    assertThat(metaData.getEntryType("b"), is(EntryType.VERTEX));
-    assertThat(metaData.getEntryType("c"), is(EntryType.EDGE));
+    assertEquals(3, metaData.getEntryCount());
+    assertEquals(0, metaData.getEntryColumn("a"));
+    assertEquals(1, metaData.getEntryColumn("b"));
+    assertEquals(2, metaData.getEntryColumn("c"));
+    assertEquals(EntryType.VERTEX, metaData.getEntryType("a"));
+    assertEquals(EntryType.VERTEX, metaData.getEntryType("b"));
+    assertEquals(EntryType.EDGE, metaData.getEntryType("c"));
 
-    assertThat(metaData.getPropertyCount(), is(3));
-    assertThat(metaData.getPropertyColumn("a", "age"), is(0));
-    assertThat(metaData.getPropertyColumn("b", "age"), is(1));
-    assertThat(metaData.getPropertyColumn("c", "since"), is(2));
+    assertEquals(3, metaData.getPropertyCount());
+    assertEquals(0, metaData.getPropertyColumn("a", "age"));
+    assertEquals(1, metaData.getPropertyColumn("b", "age"));
+    assertEquals(2, metaData.getPropertyColumn("c", "since"));
 
-    assertThat(metaData.getDirection("b"), is(ExpandDirection.OUT));
+    assertEquals(ExpandDirection.OUT, metaData.getDirection("b"));
   }
 
   @Test
@@ -83,62 +80,62 @@ public class EmbeddingMetaDataTest {
 
 
     EmbeddingMetaData copy = new EmbeddingMetaData(metaData);
-    assertThat(copy.getEntryColumn("a"), is(0));
-    assertThat(copy.getEntryColumn("e"), is(1));
-    assertThat(copy.getEntryColumn("b"), is(2));
-    assertThat(copy.getEntryColumn("f"), is(3));
-    assertThat(copy.getPropertyColumn("a", "age"), is(0));
-    assertThat(copy.getDirection("f"), is(ExpandDirection.OUT));
+    assertEquals(0, copy.getEntryColumn("a"));
+    assertEquals(1, copy.getEntryColumn("e"));
+    assertEquals(2, copy.getEntryColumn("b"));
+    assertEquals(3, copy.getEntryColumn("f"));
+    assertEquals(0, copy.getPropertyColumn("a", "age"));
+    assertEquals(ExpandDirection.OUT, copy.getDirection("f"));
 
     copy.setEntryColumn("c", EntryType.VERTEX, 4);
-    assertThat(copy.getEntryCount(), is(5));
-    assertThat(metaData.getEntryCount(), is(4));
+    assertEquals(5, copy.getEntryCount());
+    assertEquals(4, metaData.getEntryCount());
 
     copy.setEntryColumn("a", EntryType.VERTEX, 5);
-    assertThat(copy.getEntryColumn("a"), is(5));
-    assertThat(metaData.getEntryColumn("a"), is(0));
+    assertEquals(5, copy.getEntryColumn("a"));
+    assertEquals(0, metaData.getEntryColumn("a"));
 
     copy.setDirection("f", ExpandDirection.IN);
-    assertThat(copy.getDirection("f"), is(ExpandDirection.IN));
-    assertThat(metaData.getDirection("f"), is(ExpandDirection.OUT));
+    assertEquals(ExpandDirection.IN, copy.getDirection("f"));
+    assertEquals(ExpandDirection.OUT, metaData.getDirection("f"));
   }
 
   @Test
   public void testGetEntryCount() throws Exception {
     EmbeddingMetaData metaData = new EmbeddingMetaData();
-    assertThat(metaData.getEntryCount(), is(0));
+    assertEquals(0, metaData.getEntryCount());
     metaData.setEntryColumn("a", EntryType.VERTEX, 0);
-    assertThat(metaData.getEntryCount(), is(1));
+    assertEquals(1, metaData.getEntryCount());
     metaData.setEntryColumn("a", EntryType.VERTEX, 0);
-    assertThat(metaData.getEntryCount(), is(1));
+    assertEquals(1, metaData.getEntryCount());
     metaData.setEntryColumn("b", EntryType.VERTEX, 1);
-    assertThat(metaData.getEntryCount(), is(2));
+    assertEquals(2, metaData.getEntryCount());
   }
 
   @Test
   public void testGetPropertyCount() throws Exception {
     EmbeddingMetaData metaData = new EmbeddingMetaData();
-    assertThat(metaData.getPropertyCount(), is(0));
+    assertEquals(0, metaData.getPropertyCount());
     metaData.setPropertyColumn("a", "age", 0);
-    assertThat(metaData.getPropertyCount(), is(1));
+    assertEquals(1, metaData.getPropertyCount());
     metaData.setPropertyColumn("a", "age", 0);
-    assertThat(metaData.getPropertyCount(), is(1));
+    assertEquals(1, metaData.getPropertyCount());
     metaData.setPropertyColumn("a", "since", 1);
-    assertThat(metaData.getPropertyCount(), is(2));
+    assertEquals(2, metaData.getPropertyCount());
   }
 
   @Test
   public void testSetEntryColumn() throws Exception {
     EmbeddingMetaData metaData = new EmbeddingMetaData();
     metaData.setEntryColumn("a", EntryType.VERTEX, 0);
-    assertThat(metaData.getEntryColumn("a"), is(0));
+    assertEquals(0, metaData.getEntryColumn("a"));
   }
 
   @Test
   public void testGetEntryColumn() throws Exception {
     EmbeddingMetaData metaData = new EmbeddingMetaData();
     metaData.setEntryColumn("a", EntryType.VERTEX, 0);
-    assertThat(metaData.getEntryColumn("a"), is(0));
+    assertEquals(0, metaData.getEntryColumn("a"));
   }
 
   @Test
@@ -165,9 +162,9 @@ public class EmbeddingMetaDataTest {
     metaData.setEntryColumn("a", EntryType.VERTEX, 0);
     metaData.setEntryColumn("b", EntryType.EDGE, 1);
     metaData.setEntryColumn("c", EntryType.PATH, 2);
-    assertThat(metaData.getEntryType("a"), is(EntryType.VERTEX));
-    assertThat(metaData.getEntryType("b"), is(EntryType.EDGE));
-    assertThat(metaData.getEntryType("c"), is(EntryType.PATH));
+    assertEquals(EntryType.VERTEX, metaData.getEntryType("a"));
+    assertEquals(EntryType.EDGE, metaData.getEntryType("b"));
+    assertEquals(EntryType.PATH, metaData.getEntryType("c"));
   }
 
   @Test(expected = NoSuchElementException.class)
@@ -180,14 +177,14 @@ public class EmbeddingMetaDataTest {
   public void testSetPropertyColumn() throws Exception {
     EmbeddingMetaData metaData = new EmbeddingMetaData();
     metaData.setPropertyColumn("a", "age", 0);
-    assertThat(metaData.getPropertyColumn("a", "age"), is(0));
+    assertEquals(0, metaData.getPropertyColumn("a", "age"));
   }
 
   @Test
   public void testGetPropertyColumn() throws Exception {
     EmbeddingMetaData metaData = new EmbeddingMetaData();
     metaData.setPropertyColumn("a", "age", 0);
-    assertThat(metaData.getPropertyColumn("a", "age"), is(0));
+    assertEquals(0, metaData.getPropertyColumn("a", "age"));
   }
 
   @Test(expected = NoSuchElementException.class)
@@ -200,7 +197,7 @@ public class EmbeddingMetaDataTest {
   public void testGetDirection() throws Exception {
     EmbeddingMetaData metaData = new EmbeddingMetaData();
     metaData.setDirection("a", ExpandDirection.OUT);
-    assertThat(metaData.getDirection("a"), is(ExpandDirection.OUT));
+    assertEquals(ExpandDirection.OUT, metaData.getDirection("a"));
   }
 
   @Test(expected = NoSuchElementException.class)
@@ -216,7 +213,7 @@ public class EmbeddingMetaDataTest {
     IntStream.range(0, expectedVariables.size())
       .forEach(i -> metaData.setEntryColumn(expectedVariables.get(i), EntryType.EDGE, i));
 
-    assertThat(metaData.getVariables(), is(expectedVariables));
+    assertEquals(expectedVariables, metaData.getVariables());
   }
 
   @Test
@@ -229,7 +226,7 @@ public class EmbeddingMetaDataTest {
     metaData.setPropertyColumn("a", "name", 1);
     metaData.setPropertyColumn("c", "age", 2);
 
-    assertThat(metaData.getVariablesWithProperties(), is(Arrays.asList("a", "c")));
+    assertEquals(Arrays.asList("a", "c"), metaData.getVariablesWithProperties());
   }
 
   @Test
@@ -244,7 +241,7 @@ public class EmbeddingMetaDataTest {
       .filter(var -> inputVariables.indexOf(var) % 2 == 0)
       .collect(Collectors.toList());
 
-    assertThat(metaData.getVertexVariables(), is(expectedVariables));
+    assertEquals(expectedVariables, metaData.getVertexVariables());
   }
 
   @Test
@@ -259,7 +256,7 @@ public class EmbeddingMetaDataTest {
       .filter(var -> inputVariables.indexOf(var) % 2 == 1)
       .collect(Collectors.toList());
 
-    assertThat(metaData.getEdgeVariables(), is(expectedVariables));
+    assertEquals(expectedVariables, metaData.getEdgeVariables());
   }
 
   @Test
@@ -274,7 +271,7 @@ public class EmbeddingMetaDataTest {
       .filter(var -> inputVariables.indexOf(var) % 2 == 1)
       .collect(Collectors.toList());
 
-    assertThat(metaData.getPathVariables(), is(expectedVariables));
+    assertEquals(expectedVariables, metaData.getPathVariables());
   }
 
   @Test
@@ -285,9 +282,9 @@ public class EmbeddingMetaDataTest {
     metaData.setPropertyColumn("a", "type", 2);
     metaData.setPropertyColumn("b", "age", 3);
 
-    assertThat(metaData.getPropertyKeys("a"), is(Arrays.asList("age", "name", "type")));
-    assertThat(metaData.getPropertyKeys("b"), is(Collections.singletonList("age")));
-    assertThat(metaData.getPropertyKeys("c"), is(Collections.emptyList()));
+    assertEquals(Arrays.asList("age", "name", "type"), metaData.getPropertyKeys("a"));
+    assertEquals(Collections.singletonList("age"), metaData.getPropertyKeys("b"));
+    assertEquals(Collections.emptyList(), metaData.getPropertyKeys("c"));
   }
 
   @Test

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/common/pojos/EmbeddingTestUtils.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/common/pojos/EmbeddingTestUtils.java
@@ -30,8 +30,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class EmbeddingTestUtils {
@@ -47,9 +46,9 @@ public class EmbeddingTestUtils {
   public static void assertEmbedding(Embedding embedding,
     List<GradoopId> expectedEntries, List<PropertyValue> expectedProperties) {
     expectedEntries.forEach(entry ->
-      assertThat(embedding.getId(expectedEntries.indexOf(entry)), is(entry)));
+      assertEquals(entry, embedding.getId(expectedEntries.indexOf(entry))));
     expectedProperties.forEach(value ->
-      assertThat(embedding.getProperty(expectedProperties.indexOf(value)), is(value)));
+      assertEquals(value, embedding.getProperty(expectedProperties.indexOf(value))));
   }
 
   /**

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/estimation/FilterEstimatorTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/estimation/FilterEstimatorTest.java
@@ -37,7 +37,7 @@ public class FilterEstimatorTest extends EstimatorTestBase {
     elementEstimator.visit(node);
 
     assertEquals(11L, elementEstimator.getCardinality());
-    assertEquals(1d, elementEstimator.getSelectivity());
+    assertEquals(1d, elementEstimator.getSelectivity(), 0);
   }
 
   @Test
@@ -52,7 +52,7 @@ public class FilterEstimatorTest extends EstimatorTestBase {
     elementEstimator.visit(node);
 
     assertEquals(3L, elementEstimator.getCardinality());
-    assertEquals(1d, elementEstimator.getSelectivity());
+    assertEquals(1d, elementEstimator.getSelectivity(), 0);
   }
 
   @Test
@@ -68,7 +68,7 @@ public class FilterEstimatorTest extends EstimatorTestBase {
     elementEstimator.visit(node);
 
     assertEquals(24L, elementEstimator.getCardinality());
-    assertEquals(1d, elementEstimator.getSelectivity());
+    assertEquals(1d, elementEstimator.getSelectivity(), 0);
   }
 
   @Test
@@ -84,6 +84,6 @@ public class FilterEstimatorTest extends EstimatorTestBase {
     elementEstimator.visit(node);
 
     assertEquals(10L, elementEstimator.getCardinality());
-    assertEquals(1d, elementEstimator.getSelectivity());
+    assertEquals(1d, elementEstimator.getSelectivity(), 0);
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/estimation/FilterEstimatorTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/estimation/FilterEstimatorTest.java
@@ -21,8 +21,7 @@ import org.gradoop.flink.model.impl.operators.matching.single.cypher.planning.qu
 import org.gradoop.flink.model.impl.operators.matching.single.cypher.planning.queryplan.leaf.FilterAndProjectVerticesNode;
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 
 public class FilterEstimatorTest extends EstimatorTestBase {
 
@@ -37,8 +36,8 @@ public class FilterEstimatorTest extends EstimatorTestBase {
     FilterEstimator elementEstimator = new FilterEstimator(queryHandler, STATS);
     elementEstimator.visit(node);
 
-    assertThat(elementEstimator.getCardinality(), is(11L));
-    assertThat(elementEstimator.getSelectivity(), is(1d));
+    assertEquals(11L, elementEstimator.getCardinality());
+    assertEquals(1d, elementEstimator.getSelectivity());
   }
 
   @Test
@@ -52,8 +51,8 @@ public class FilterEstimatorTest extends EstimatorTestBase {
     FilterEstimator elementEstimator = new FilterEstimator(queryHandler, STATS);
     elementEstimator.visit(node);
 
-    assertThat(elementEstimator.getCardinality(), is(3L));
-    assertThat(elementEstimator.getSelectivity(), is(1d));
+    assertEquals(3L, elementEstimator.getCardinality());
+    assertEquals(1d, elementEstimator.getSelectivity());
   }
 
   @Test
@@ -68,8 +67,8 @@ public class FilterEstimatorTest extends EstimatorTestBase {
     FilterEstimator elementEstimator = new FilterEstimator(queryHandler, STATS);
     elementEstimator.visit(node);
 
-    assertThat(elementEstimator.getCardinality(), is(24L));
-    assertThat(elementEstimator.getSelectivity(), is(1d));
+    assertEquals(24L, elementEstimator.getCardinality());
+    assertEquals(1d, elementEstimator.getSelectivity());
   }
 
   @Test
@@ -84,7 +83,7 @@ public class FilterEstimatorTest extends EstimatorTestBase {
     FilterEstimator elementEstimator = new FilterEstimator(queryHandler, STATS);
     elementEstimator.visit(node);
 
-    assertThat(elementEstimator.getCardinality(), is(10L));
-    assertThat(elementEstimator.getSelectivity(), is(1d));
+    assertEquals(10L, elementEstimator.getCardinality());
+    assertEquals(1d, elementEstimator.getSelectivity());
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/estimation/JoinEstimatorTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/estimation/JoinEstimatorTest.java
@@ -28,8 +28,7 @@ import org.gradoop.flink.model.impl.operators.matching.single.cypher.planning.qu
 
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 
 public class JoinEstimatorTest extends EstimatorTestBase {
 
@@ -56,7 +55,7 @@ public class JoinEstimatorTest extends EstimatorTestBase {
     estimator.visit(neJoin);
     estimator.visit(nemJoin);
 
-    assertThat(estimator.getCardinality(), is(24L));
+    assertEquals(24L, estimator.getCardinality());
   }
 
   @Test
@@ -82,7 +81,7 @@ public class JoinEstimatorTest extends EstimatorTestBase {
     estimator.visit(neJoin);
     estimator.visit(nemJoin);
 
-    assertThat(estimator.getCardinality(), is(3L));
+    assertEquals(3L, estimator.getCardinality());
   }
 
   @Test
@@ -108,7 +107,7 @@ public class JoinEstimatorTest extends EstimatorTestBase {
     estimator.visit(neJoin);
     estimator.visit(nemJoin);
 
-    assertThat(estimator.getCardinality(), is(10L));
+    assertEquals(10L, estimator.getCardinality());
   }
 
   @Test
@@ -132,9 +131,9 @@ public class JoinEstimatorTest extends EstimatorTestBase {
 
     JoinEstimator estimator = new JoinEstimator(queryHandler, STATS);
     estimator.visit(neJoin);
-    assertThat(estimator.getCardinality(), is(10L));
+    assertEquals(10L, estimator.getCardinality());
     estimator.visit(nemJoin);
-    assertThat(estimator.getCardinality(), is(10L));
+    assertEquals(10L, estimator.getCardinality());
   }
 
   @Test
@@ -158,9 +157,9 @@ public class JoinEstimatorTest extends EstimatorTestBase {
 
     JoinEstimator estimator = new JoinEstimator(queryHandler, STATS);
     estimator.visit(neJoin);
-    assertThat(estimator.getCardinality(), is(10L));
+    assertEquals(10L, estimator.getCardinality());
     estimator.visit(nemJoin);
-    assertThat(estimator.getCardinality(), is(10L));
+    assertEquals(10L, estimator.getCardinality());
   }
 
   @Test
@@ -186,7 +185,7 @@ public class JoinEstimatorTest extends EstimatorTestBase {
     estimator.visit(neJoin);
     estimator.visit(nemJoin);
     // 24 1-edge paths + 10 2-edge paths
-    assertThat(estimator.getCardinality(), is(34L));
+    assertEquals(34L, estimator.getCardinality());
   }
 
   @Test
@@ -212,7 +211,7 @@ public class JoinEstimatorTest extends EstimatorTestBase {
     estimator.visit(neJoin);
     estimator.visit(nemJoin);
 
-    assertThat(estimator.getCardinality(), is(10L));
+    assertEquals(10L, estimator.getCardinality());
   }
 
   @Test
@@ -249,6 +248,6 @@ public class JoinEstimatorTest extends EstimatorTestBase {
     estimator.visit(ne1mJoin);
     estimator.visit(ne1Join);
 
-    assertThat(estimator.getCardinality(), is(30L));
+    assertEquals(30L, estimator.getCardinality());
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/estimation/QueryPlanEstimatorTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/estimation/QueryPlanEstimatorTest.java
@@ -30,8 +30,7 @@ import org.gradoop.flink.model.impl.operators.matching.single.cypher.planning.qu
 import org.gradoop.flink.model.impl.operators.matching.single.cypher.planning.queryplan.leaf.FilterAndProjectVerticesNode;
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 
 public class QueryPlanEstimatorTest extends EstimatorTestBase  {
 
@@ -48,11 +47,11 @@ public class QueryPlanEstimatorTest extends EstimatorTestBase  {
 
     QueryPlan queryPlan = new QueryPlan(nNode);
     QueryPlanEstimator estimator = new QueryPlanEstimator(queryPlan, queryHandler, STATS);
-    assertThat(estimator.getCardinality(), is(11L));
+    assertEquals(11L, estimator.getCardinality());
 
     queryPlan = new QueryPlan(mNode);
     estimator = new QueryPlanEstimator(queryPlan, queryHandler, STATS);
-    assertThat(estimator.getCardinality(), is(6L));
+    assertEquals(6L, estimator.getCardinality());
   }
 
   @Test
@@ -70,11 +69,11 @@ public class QueryPlanEstimatorTest extends EstimatorTestBase  {
 
     QueryPlan queryPlan = new QueryPlan(eNode);
     QueryPlanEstimator estimator = new QueryPlanEstimator(queryPlan, queryHandler, STATS);
-    assertThat(estimator.getCardinality(), is(24L));
+    assertEquals(24L, estimator.getCardinality());
 
     queryPlan = new QueryPlan(fNode);
     estimator = new QueryPlanEstimator(queryPlan, queryHandler, STATS);
-    assertThat(estimator.getCardinality(), is(10L));
+    assertEquals(10L, estimator.getCardinality());
   }
 
   @Test
@@ -102,7 +101,7 @@ public class QueryPlanEstimatorTest extends EstimatorTestBase  {
     QueryPlan plan = new QueryPlan(neJoin);
     QueryPlanEstimator estimator = new QueryPlanEstimator(plan, queryHandler, STATS);
 
-    assertThat(estimator.getCardinality(), is(24L));
+    assertEquals(24L, estimator.getCardinality());
 
     // (n)-[e]->(m)
     JoinEmbeddingsNode nemJoin = new JoinEmbeddingsNode(neJoin, mNode, Lists.newArrayList("m"),
@@ -111,7 +110,7 @@ public class QueryPlanEstimatorTest extends EstimatorTestBase  {
     plan = new QueryPlan(nemJoin);
     estimator = new QueryPlanEstimator(plan, queryHandler, STATS);
 
-    assertThat(estimator.getCardinality(), is(24L));
+    assertEquals(24L, estimator.getCardinality());
 
     // (n)-[e]->(m)-[f]->
     JoinEmbeddingsNode nemfJoin = new JoinEmbeddingsNode(nemJoin, fNode, Lists.newArrayList("m"),
@@ -120,7 +119,7 @@ public class QueryPlanEstimatorTest extends EstimatorTestBase  {
     plan = new QueryPlan(nemfJoin);
     estimator = new QueryPlanEstimator(plan, queryHandler, STATS);
 
-    assertThat(estimator.getCardinality(), is(72L));
+    assertEquals(72L, estimator.getCardinality());
 
     // (n)-[e]->(m)-[f]->(o)
     JoinEmbeddingsNode nemfoJoin = new JoinEmbeddingsNode(nemfJoin, oNode, Lists.newArrayList("o"),
@@ -129,7 +128,7 @@ public class QueryPlanEstimatorTest extends EstimatorTestBase  {
     plan = new QueryPlan(nemfoJoin);
     estimator = new QueryPlanEstimator(plan, queryHandler, STATS);
 
-    assertThat(estimator.getCardinality(), is(72L));
+    assertEquals(72L, estimator.getCardinality());
   }
 
   @Test
@@ -164,7 +163,7 @@ public class QueryPlanEstimatorTest extends EstimatorTestBase  {
 
     QueryPlanEstimator estimator = new QueryPlanEstimator(queryPlan, queryHandler, STATS);
 
-    assertThat(estimator.getCardinality(), is(42L));
+    assertEquals(42L, estimator.getCardinality());
   }
 
   @Test
@@ -183,7 +182,7 @@ public class QueryPlanEstimatorTest extends EstimatorTestBase  {
 
     QueryPlanEstimator estimator = new QueryPlanEstimator(queryPlan, queryHandler, STATS);
 
-    assertThat(estimator.getCardinality(), is(STATS.getVertexCount() * STATS.getVertexCount()));
+    assertEquals(STATS.getVertexCount() * STATS.getVertexCount(), estimator.getCardinality());
   }
 
 
@@ -226,8 +225,7 @@ public class QueryPlanEstimatorTest extends EstimatorTestBase  {
     QueryPlanEstimator ce2dEstimator = new QueryPlanEstimator(ce2dPlan, queryHandler, STATS);
     QueryPlanEstimator crossEstimator = new QueryPlanEstimator(crossPlan, queryHandler, STATS);
 
-    assertThat(crossEstimator.getCardinality(), is(ae1bEstimator.getCardinality() *
-      ce2dEstimator.getCardinality()));
+    assertEquals(ae1bEstimator.getCardinality() * ce2dEstimator.getCardinality(), crossEstimator.getCardinality());
   }
 
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/binary/CartesianProductNodeTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/binary/CartesianProductNodeTest.java
@@ -34,8 +34,7 @@ import static org.gradoop.common.GradoopTestUtils.call;
 
 import static org.gradoop.flink.model.impl.operators.matching.single.cypher.common.pojos.EmbeddingTestUtils.assertEmbeddingExists;
 import static org.gradoop.flink.model.impl.operators.matching.single.cypher.common.pojos.EmbeddingTestUtils.createEmbedding;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 public class CartesianProductNodeTest extends GradoopFlinkTestBase {
 
@@ -64,20 +63,20 @@ public class CartesianProductNodeTest extends GradoopFlinkTestBase {
 
     EmbeddingMetaData outputMetaData = node.getEmbeddingMetaData();
 
-    assertThat(outputMetaData.getEntryCount(), is(6));
-    assertThat(outputMetaData.getEntryColumn("v1"), is(0));
-    assertThat(outputMetaData.getEntryColumn("e1"), is(1));
-    assertThat(outputMetaData.getEntryColumn("v2"), is(2));
-    assertThat(outputMetaData.getEntryColumn("v3"), is(3));
-    assertThat(outputMetaData.getEntryColumn("e2"), is(4));
-    assertThat(outputMetaData.getEntryColumn("v4"), is(5));
+    assertEquals(6, outputMetaData.getEntryCount());
+    assertEquals(0, outputMetaData.getEntryColumn("v1"));
+    assertEquals(1, outputMetaData.getEntryColumn("e1"));
+    assertEquals(2, outputMetaData.getEntryColumn("v2"));
+    assertEquals(3, outputMetaData.getEntryColumn("v3"));
+    assertEquals(4, outputMetaData.getEntryColumn("e2"));
+    assertEquals(5, outputMetaData.getEntryColumn("v4"));
 
-    assertThat(outputMetaData.getPropertyCount(), is(5));
-    assertThat(outputMetaData.getPropertyColumn("v1", "age"), is(0));
-    assertThat(outputMetaData.getPropertyColumn("e1", "since"), is(1));
-    assertThat(outputMetaData.getPropertyColumn("v3", "age"), is(2));
-    assertThat(outputMetaData.getPropertyColumn("e2", "since"), is(3));
-    assertThat(outputMetaData.getPropertyColumn("v4", "age"), is(4));
+    assertEquals(5, outputMetaData.getPropertyCount());
+    assertEquals(0, outputMetaData.getPropertyColumn("v1", "age"));
+    assertEquals(1, outputMetaData.getPropertyColumn("e1", "since"));
+    assertEquals(2, outputMetaData.getPropertyColumn("v3", "age"));
+    assertEquals(3, outputMetaData.getPropertyColumn("e2", "since"));
+    assertEquals(4, outputMetaData.getPropertyColumn("v4", "age"));
   }
 
   @Test
@@ -102,10 +101,10 @@ public class CartesianProductNodeTest extends GradoopFlinkTestBase {
     CartesianProductNode node = new CartesianProductNode(leftChild, rightChild,
       MatchStrategy.ISOMORPHISM, MatchStrategy.ISOMORPHISM);
 
-    assertThat(call(CartesianProductNode.class, node, "getDistinctVertexColumnsLeft"), is(asList(0, 2, 4)));
-    assertThat(call(CartesianProductNode.class, node, "getDistinctVertexColumnsRight"), is(asList(0, 2, 4)));
-    assertThat(call(CartesianProductNode.class, node, "getDistinctEdgeColumnsLeft"), is(asList(1, 3)));
-    assertThat(call(CartesianProductNode.class, node, "getDistinctEdgeColumnsRight"), is(asList(1, 3)));
+    assertEquals(asList(0, 2, 4), call(CartesianProductNode.class, node, "getDistinctVertexColumnsLeft"));
+    assertEquals(asList(0, 2, 4), call(CartesianProductNode.class, node, "getDistinctVertexColumnsRight"));
+    assertEquals(asList(1, 3), call(CartesianProductNode.class, node, "getDistinctEdgeColumnsLeft"));
+    assertEquals(asList(1, 3), call(CartesianProductNode.class, node, "getDistinctEdgeColumnsRight"));
   }
 
   @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
@@ -131,10 +130,10 @@ public class CartesianProductNodeTest extends GradoopFlinkTestBase {
     CartesianProductNode node = new CartesianProductNode(leftChild, rightChild,
       MatchStrategy.HOMOMORPHISM, MatchStrategy.HOMOMORPHISM);
 
-    assertThat(call(CartesianProductNode.class, node, "getDistinctVertexColumnsLeft"), is(asList()));
-    assertThat(call(CartesianProductNode.class, node, "getDistinctVertexColumnsRight"), is(asList()));
-    assertThat(call(CartesianProductNode.class, node, "getDistinctEdgeColumnsLeft"), is(asList()));
-    assertThat(call(CartesianProductNode.class, node, "getDistinctEdgeColumnsRight"), is(asList()));
+    assertEquals(asList(), call(CartesianProductNode.class, node, "getDistinctVertexColumnsLeft"));
+    assertEquals(asList(), call(CartesianProductNode.class, node, "getDistinctVertexColumnsRight"));
+    assertEquals(asList(), call(CartesianProductNode.class, node, "getDistinctEdgeColumnsLeft"));
+    assertEquals(asList(), call(CartesianProductNode.class, node, "getDistinctEdgeColumnsRight"));
   }
 
   @Test
@@ -195,7 +194,7 @@ public class CartesianProductNodeTest extends GradoopFlinkTestBase {
 
     DataSet<Embedding> result = node.execute();
 
-    assertThat(result.count(), is(4L));
+    assertEquals(4L, result.count());
 
     assertEmbeddingExists(result, a, f, g, h);
     assertEmbeddingExists(result, b, f, g, h);

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/binary/ExpandEmbeddingsNodeTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/binary/ExpandEmbeddingsNodeTest.java
@@ -32,8 +32,7 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static org.gradoop.common.GradoopTestUtils.call;
 import static org.gradoop.flink.model.impl.operators.matching.single.cypher.common.pojos.EmbeddingTestUtils.*;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 public class ExpandEmbeddingsNodeTest extends GradoopFlinkTestBase {
 
@@ -58,14 +57,14 @@ public class ExpandEmbeddingsNodeTest extends GradoopFlinkTestBase {
 
     EmbeddingMetaData outputMetaData = node.getEmbeddingMetaData();
 
-    assertThat(outputMetaData.getEntryCount(), is(3));
-    assertThat(outputMetaData.getEntryColumn("v1"), is(0));
-    assertThat(outputMetaData.getEntryColumn("e1"), is(1));
-    assertThat(outputMetaData.getEntryColumn("v2"), is(2));
-    assertThat(outputMetaData.getEntryType("v1"), is(EntryType.VERTEX));
-    assertThat(outputMetaData.getEntryType("e1"), is(EntryType.PATH));
-    assertThat(outputMetaData.getEntryType("v2"), is(EntryType.VERTEX));
-    assertThat(outputMetaData.getDirection("e1"), is(ExpandDirection.OUT));
+    assertEquals(3, outputMetaData.getEntryCount());
+    assertEquals(0, outputMetaData.getEntryColumn("v1"));
+    assertEquals(1, outputMetaData.getEntryColumn("e1"));
+    assertEquals(2, outputMetaData.getEntryColumn("v2"));
+    assertEquals(EntryType.VERTEX, outputMetaData.getEntryType("v1"));
+    assertEquals(EntryType.PATH, outputMetaData.getEntryType("e1"));
+    assertEquals(EntryType.VERTEX, outputMetaData.getEntryType("v2"));
+    assertEquals(ExpandDirection.OUT, outputMetaData.getDirection("e1"));
   }
 
   @Test
@@ -91,12 +90,10 @@ public class ExpandEmbeddingsNodeTest extends GradoopFlinkTestBase {
       0, 10, ExpandDirection.OUT,
       MatchStrategy.ISOMORPHISM, MatchStrategy.ISOMORPHISM);
 
-    assertThat(call(ExpandEmbeddingsNode.class, node, "getDistinctVertexColumns",
-      new Class<?>[] {EmbeddingMetaData.class}, new Object[]{leftInputMetaData}),
-      is(asList(0, 2, 4)));
-    assertThat(call(ExpandEmbeddingsNode.class, node, "getDistinctEdgeColumns",
-      new Class<?>[] {EmbeddingMetaData.class}, new Object[]{leftInputMetaData}),
-      is(asList(1, 3)));
+    assertEquals(asList(0, 2, 4), call(ExpandEmbeddingsNode.class, node, "getDistinctVertexColumns",
+      new Class<?>[] {EmbeddingMetaData.class}, new Object[]{leftInputMetaData}));
+    assertEquals(asList(1, 3), call(ExpandEmbeddingsNode.class, node, "getDistinctEdgeColumns",
+      new Class<?>[] {EmbeddingMetaData.class}, new Object[]{leftInputMetaData}));
   }
 
   @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
@@ -123,12 +120,10 @@ public class ExpandEmbeddingsNodeTest extends GradoopFlinkTestBase {
       0, 10, ExpandDirection.OUT,
       MatchStrategy.HOMOMORPHISM, MatchStrategy.HOMOMORPHISM);
 
-    assertThat(call(ExpandEmbeddingsNode.class, node, "getDistinctVertexColumns",
-      new Class<?>[] {EmbeddingMetaData.class}, new Object[]{leftInputMetaData}),
-      is(asList()));
-    assertThat(call(ExpandEmbeddingsNode.class, node, "getDistinctEdgeColumns",
-      new Class<?>[] {EmbeddingMetaData.class}, new Object[]{leftInputMetaData}),
-      is(asList()));
+    assertEquals(asList(), call(ExpandEmbeddingsNode.class, node, "getDistinctVertexColumns",
+      new Class<?>[] {EmbeddingMetaData.class}, new Object[]{leftInputMetaData}));
+    assertEquals(asList(), call(ExpandEmbeddingsNode.class, node, "getDistinctEdgeColumns",
+      new Class<?>[] {EmbeddingMetaData.class}, new Object[]{leftInputMetaData}));
   }
 
   @Test
@@ -185,15 +180,15 @@ public class ExpandEmbeddingsNodeTest extends GradoopFlinkTestBase {
      * ---------------------------------------------------
      */
     List<Embedding> result = node.execute().collect();
-    assertThat(result.size(), is(1));
+    assertEquals(1, result.size());
     Embedding embedding = result.get(0);
-    assertThat(embedding.getId(0), is(a));
-    assertThat(embedding.getIdList(1).size(), is(5));
-    assertThat(embedding.getIdList(1).get(0), is(b));
-    assertThat(embedding.getIdList(1).get(1), is(c));
-    assertThat(embedding.getIdList(1).get(2), is(d));
-    assertThat(embedding.getIdList(1).get(3), is(e));
-    assertThat(embedding.getIdList(1).get(4), is(f));
-    assertThat(embedding.getId(2), is(g));
+    assertEquals(a, embedding.getId(0));
+    assertEquals(5, embedding.getIdList(1).size());
+    assertEquals(b, embedding.getIdList(1).get(0));
+    assertEquals(c, embedding.getIdList(1).get(1));
+    assertEquals(d, embedding.getIdList(1).get(2));
+    assertEquals(e, embedding.getIdList(1).get(3));
+    assertEquals(f, embedding.getIdList(1).get(4));
+    assertEquals(g, embedding.getId(2));
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/binary/JoinEmbeddingsNodeTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/binary/JoinEmbeddingsNodeTest.java
@@ -37,8 +37,7 @@ import static java.util.Collections.singletonList;
 import static org.gradoop.common.GradoopTestUtils.call;
 import static org.gradoop.flink.model.impl.operators.matching.single.cypher.common.pojos.EmbeddingTestUtils.assertEmbedding;
 import static org.gradoop.flink.model.impl.operators.matching.single.cypher.common.pojos.EmbeddingTestUtils.createEmbedding;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 public class JoinEmbeddingsNodeTest extends GradoopFlinkTestBase {
 
@@ -68,19 +67,19 @@ public class JoinEmbeddingsNodeTest extends GradoopFlinkTestBase {
 
     EmbeddingMetaData outputMetaData = node.getEmbeddingMetaData();
 
-    assertThat(outputMetaData.getEntryCount(), is(5));
-    assertThat(outputMetaData.getEntryColumn("v1"), is(0));
-    assertThat(outputMetaData.getEntryColumn("e1"), is(1));
-    assertThat(outputMetaData.getEntryColumn("v2"), is(2));
-    assertThat(outputMetaData.getEntryColumn("e2"), is(3));
-    assertThat(outputMetaData.getEntryColumn("v3"), is(4));
+    assertEquals(5, outputMetaData.getEntryCount());
+    assertEquals(0, outputMetaData.getEntryColumn("v1"));
+    assertEquals(1, outputMetaData.getEntryColumn("e1"));
+    assertEquals(2, outputMetaData.getEntryColumn("v2"));
+    assertEquals(3, outputMetaData.getEntryColumn("e2"));
+    assertEquals(4, outputMetaData.getEntryColumn("v3"));
 
-    assertThat(outputMetaData.getPropertyCount(), is(5));
-    assertThat(outputMetaData.getPropertyColumn("v1", "age"), is(0));
-    assertThat(outputMetaData.getPropertyColumn("e1", "since"), is(1));
-    assertThat(outputMetaData.getPropertyColumn("v2", "age"), is(2));
-    assertThat(outputMetaData.getPropertyColumn("e2", "since"), is(3));
-    assertThat(outputMetaData.getPropertyColumn("v3", "age"), is(4));
+    assertEquals(5, outputMetaData.getPropertyCount());
+    assertEquals(0, outputMetaData.getPropertyColumn("v1", "age"));
+    assertEquals(1, outputMetaData.getPropertyColumn("e1", "since"));
+    assertEquals(2, outputMetaData.getPropertyColumn("v2", "age"));
+    assertEquals(3, outputMetaData.getPropertyColumn("e2", "since"));
+    assertEquals(4, outputMetaData.getPropertyColumn("v3", "age"));
   }
 
   @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
@@ -103,8 +102,8 @@ public class JoinEmbeddingsNodeTest extends GradoopFlinkTestBase {
       singletonList("v2"),
       MatchStrategy.ISOMORPHISM, MatchStrategy.ISOMORPHISM);
 
-    assertThat(call(JoinEmbeddingsNode.class, node, "getJoinColumnsLeft"), is(asList(2)));
-    assertThat(call(JoinEmbeddingsNode.class, node, "getJoinColumnsRight"), is(asList(0)));
+    assertEquals(asList(2), call(JoinEmbeddingsNode.class, node, "getJoinColumnsLeft"));
+    assertEquals(asList(0), call(JoinEmbeddingsNode.class, node, "getJoinColumnsRight"));
   }
 
   @Test
@@ -130,10 +129,10 @@ public class JoinEmbeddingsNodeTest extends GradoopFlinkTestBase {
       singletonList("v3"),
       MatchStrategy.ISOMORPHISM, MatchStrategy.ISOMORPHISM);
 
-    assertThat(call(JoinEmbeddingsNode.class, node, "getDistinctVertexColumnsLeft"), is(asList(0, 2, 4)));
-    assertThat(call(JoinEmbeddingsNode.class, node, "getDistinctVertexColumnsRight"), is(asList(2, 4)));
-    assertThat(call(JoinEmbeddingsNode.class, node, "getDistinctEdgeColumnsLeft"), is(asList(1, 3)));
-    assertThat(call(JoinEmbeddingsNode.class, node, "getDistinctEdgeColumnsRight"), is(asList(1, 3)));
+    assertEquals(asList(0, 2, 4), call(JoinEmbeddingsNode.class, node, "getDistinctVertexColumnsLeft"));
+    assertEquals(asList(2, 4), call(JoinEmbeddingsNode.class, node, "getDistinctVertexColumnsRight"));
+    assertEquals(asList(1, 3), call(JoinEmbeddingsNode.class, node, "getDistinctEdgeColumnsLeft"));
+    assertEquals(asList(1, 3), call(JoinEmbeddingsNode.class, node, "getDistinctEdgeColumnsRight"));
   }
 
   @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
@@ -160,10 +159,10 @@ public class JoinEmbeddingsNodeTest extends GradoopFlinkTestBase {
       singletonList("v3"),
       MatchStrategy.HOMOMORPHISM, MatchStrategy.HOMOMORPHISM);
 
-    assertThat(call(JoinEmbeddingsNode.class, node, "getDistinctVertexColumnsLeft"), is(asList()));
-    assertThat(call(JoinEmbeddingsNode.class, node, "getDistinctVertexColumnsRight"), is(asList()));
-    assertThat(call(JoinEmbeddingsNode.class, node, "getDistinctEdgeColumnsLeft"), is(asList()));
-    assertThat(call(JoinEmbeddingsNode.class, node, "getDistinctEdgeColumnsRight"), is(asList()));
+    assertEquals(asList(), call(JoinEmbeddingsNode.class, node, "getDistinctVertexColumnsLeft"));
+    assertEquals(asList(), call(JoinEmbeddingsNode.class, node, "getDistinctVertexColumnsRight"));
+    assertEquals(asList(), call(JoinEmbeddingsNode.class, node, "getDistinctEdgeColumnsLeft"));
+    assertEquals(asList(), call(JoinEmbeddingsNode.class, node, "getDistinctEdgeColumnsRight"));
   }
 
   @Test
@@ -223,7 +222,7 @@ public class JoinEmbeddingsNodeTest extends GradoopFlinkTestBase {
     List<Embedding> result = node.execute().collect();
     result.sort(Comparator.comparing(o -> o.getProperty(0))); // sort by property value in column 0
 
-    assertThat(result.size(), is(2));
+    assertEquals(2, result.size());
 
     assertEmbedding(result.get(0), asList(b, d, f), asList(PropertyValue.create(23), PropertyValue.create(77)));
     assertEmbedding(result.get(1), asList(a, c, e), asList(PropertyValue.create(42), PropertyValue.create(84)));

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/binary/ValueJoinNodeTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/binary/ValueJoinNodeTest.java
@@ -38,8 +38,7 @@ import static java.util.Collections.singletonList;
 import static org.gradoop.common.GradoopTestUtils.call;
 import static org.gradoop.flink.model.impl.operators.matching.single.cypher.common.pojos.EmbeddingTestUtils.assertEmbedding;
 import static org.gradoop.flink.model.impl.operators.matching.single.cypher.common.pojos.EmbeddingTestUtils.createEmbedding;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 public class ValueJoinNodeTest extends GradoopFlinkTestBase {
 
@@ -69,20 +68,20 @@ public class ValueJoinNodeTest extends GradoopFlinkTestBase {
 
     EmbeddingMetaData outputMetaData = node.getEmbeddingMetaData();
 
-    assertThat(outputMetaData.getEntryCount(), is(6));
-    assertThat(outputMetaData.getEntryColumn("v1"), is(0));
-    assertThat(outputMetaData.getEntryColumn("e1"), is(1));
-    assertThat(outputMetaData.getEntryColumn("v2"), is(2));
-    assertThat(outputMetaData.getEntryColumn("v3"), is(3));
-    assertThat(outputMetaData.getEntryColumn("e2"), is(4));
-    assertThat(outputMetaData.getEntryColumn("v4"), is(5));
+    assertEquals(6, outputMetaData.getEntryCount());
+    assertEquals(0, outputMetaData.getEntryColumn("v1"));
+    assertEquals(1, outputMetaData.getEntryColumn("e1"));
+    assertEquals(2, outputMetaData.getEntryColumn("v2"));
+    assertEquals(3, outputMetaData.getEntryColumn("v3"));
+    assertEquals(4, outputMetaData.getEntryColumn("e2"));
+    assertEquals(5, outputMetaData.getEntryColumn("v4"));
 
-    assertThat(outputMetaData.getPropertyCount(), is(5));
-    assertThat(outputMetaData.getPropertyColumn("v1", "age"), is(0));
-    assertThat(outputMetaData.getPropertyColumn("e1", "since"), is(1));
-    assertThat(outputMetaData.getPropertyColumn("v3", "age"), is(2));
-    assertThat(outputMetaData.getPropertyColumn("e2", "since"), is(3));
-    assertThat(outputMetaData.getPropertyColumn("v4", "age"), is(4));
+    assertEquals(5, outputMetaData.getPropertyCount());
+    assertEquals(0, outputMetaData.getPropertyColumn("v1", "age"));
+    assertEquals(1, outputMetaData.getPropertyColumn("e1", "since"));
+    assertEquals(2, outputMetaData.getPropertyColumn("v3", "age"));
+    assertEquals(3, outputMetaData.getPropertyColumn("e2", "since"));
+    assertEquals(4, outputMetaData.getPropertyColumn("v4", "age"));
   }
 
   @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
@@ -110,8 +109,8 @@ public class ValueJoinNodeTest extends GradoopFlinkTestBase {
       singletonList(Pair.of("v1", "age")), singletonList(Pair.of("v4", "age")),
       MatchStrategy.ISOMORPHISM, MatchStrategy.ISOMORPHISM);
 
-    assertThat(call(ValueJoinNode.class, node, "getJoinPropertiesLeft"), is(asList(0)));
-    assertThat(call(ValueJoinNode.class, node, "getJoinPropertiesRight"), is(asList(2)));
+    assertEquals(asList(0), call(ValueJoinNode.class, node, "getJoinPropertiesLeft"));
+    assertEquals(asList(2), call(ValueJoinNode.class, node, "getJoinPropertiesRight"));
   }
 
   @Test
@@ -137,10 +136,10 @@ public class ValueJoinNodeTest extends GradoopFlinkTestBase {
       Lists.newArrayList(), Lists.newArrayList(),
       MatchStrategy.ISOMORPHISM, MatchStrategy.ISOMORPHISM);
 
-    assertThat(call(ValueJoinNode.class, node, "getDistinctVertexColumnsLeft"), is(asList(0, 2, 4)));
-    assertThat(call(ValueJoinNode.class, node, "getDistinctVertexColumnsRight"), is(asList(0, 2, 4)));
-    assertThat(call(ValueJoinNode.class, node, "getDistinctEdgeColumnsLeft"), is(asList(1, 3)));
-    assertThat(call(ValueJoinNode.class, node, "getDistinctEdgeColumnsRight"), is(asList(1, 3)));
+    assertEquals(asList(0, 2, 4), call(ValueJoinNode.class, node, "getDistinctVertexColumnsLeft"));
+    assertEquals(asList(0, 2, 4), call(ValueJoinNode.class, node, "getDistinctVertexColumnsRight"));
+    assertEquals(asList(1, 3), call(ValueJoinNode.class, node, "getDistinctEdgeColumnsLeft"));
+    assertEquals(asList(1, 3), call(ValueJoinNode.class, node, "getDistinctEdgeColumnsRight"));
   }
 
   @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
@@ -167,10 +166,10 @@ public class ValueJoinNodeTest extends GradoopFlinkTestBase {
       Lists.newArrayList(), Lists.newArrayList(),
       MatchStrategy.HOMOMORPHISM, MatchStrategy.HOMOMORPHISM);
 
-    assertThat(call(ValueJoinNode.class, node, "getDistinctVertexColumnsLeft"), is(asList()));
-    assertThat(call(ValueJoinNode.class, node, "getDistinctVertexColumnsRight"), is(asList()));
-    assertThat(call(ValueJoinNode.class, node, "getDistinctEdgeColumnsLeft"), is(asList()));
-    assertThat(call(ValueJoinNode.class, node, "getDistinctEdgeColumnsRight"), is(asList()));
+    assertEquals(asList(), call(ValueJoinNode.class, node, "getDistinctVertexColumnsLeft"));
+    assertEquals(asList(), call(ValueJoinNode.class, node, "getDistinctVertexColumnsRight"));
+    assertEquals(asList(), call(ValueJoinNode.class, node, "getDistinctEdgeColumnsLeft"));
+    assertEquals(asList(), call(ValueJoinNode.class, node, "getDistinctEdgeColumnsRight"));
   }
 
   @Test
@@ -233,7 +232,7 @@ public class ValueJoinNodeTest extends GradoopFlinkTestBase {
     List<Embedding> result = node.execute().collect();
     result.sort(Comparator.comparing(o -> o.getProperty(0))); // sort by property value in column 0
 
-    assertThat(result.size(), is(2));
+    assertEquals(2, result.size());
 
     assertEmbedding(result.get(0), asList(b, f, g, h), asList(PropertyValue.create(21), PropertyValue.create(21)));
     assertEmbedding(result.get(1), asList(a, c, d, e), asList(PropertyValue.create(42), PropertyValue.create(42)));

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectEdgesNodeTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectEdgesNodeTest.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class FilterAndProjectEdgesNodeTest extends GradoopFlinkTestBase {
 
@@ -98,8 +99,8 @@ public class FilterAndProjectEdgesNodeTest extends GradoopFlinkTestBase {
     List<Embedding> filteredEdges = node.execute().collect();
 
     assertEquals(1, filteredEdges.size());
-    assertEquals(true, filteredEdges.get(0).getId(0).equals(sourceId));
-    assertEquals(true, filteredEdges.get(0).getId(1).equals(edge1Id));
-    assertEquals(true, filteredEdges.get(0).getId(2).equals(targetId));
+    assertTrue(filteredEdges.get(0).getId(0).equals(sourceId));
+    assertTrue(filteredEdges.get(0).getId(1).equals(edge1Id));
+    assertTrue(filteredEdges.get(0).getId(2).equals(targetId));
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectEdgesNodeTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectEdgesNodeTest.java
@@ -34,8 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 
 public class FilterAndProjectEdgesNodeTest extends GradoopFlinkTestBase {
 
@@ -48,10 +47,10 @@ public class FilterAndProjectEdgesNodeTest extends GradoopFlinkTestBase {
       null, sourceVariable, edgeVariable, targetVariable, new CNF(), new HashSet<>(), false);
 
     EmbeddingMetaData embeddingMetaData = node.getEmbeddingMetaData();
-    assertThat(embeddingMetaData.getEntryColumn(sourceVariable), is(0));
-    assertThat(embeddingMetaData.getEntryColumn(edgeVariable), is(1));
-    assertThat(embeddingMetaData.getEntryColumn(targetVariable), is(2));
-    assertThat(embeddingMetaData.getPropertyKeys(edgeVariable).size(), is(0));
+    assertEquals(0, embeddingMetaData.getEntryColumn(sourceVariable));
+    assertEquals(1, embeddingMetaData.getEntryColumn(edgeVariable));
+    assertEquals(2, embeddingMetaData.getEntryColumn(targetVariable));
+    assertEquals(0, embeddingMetaData.getPropertyKeys(edgeVariable).size());
   }
 
   @Test
@@ -63,10 +62,10 @@ public class FilterAndProjectEdgesNodeTest extends GradoopFlinkTestBase {
       null, sourceVariable, edgeVariable, targetVariable, new CNF(), new HashSet<>(), false);
 
     EmbeddingMetaData embeddingMetaData = node.getEmbeddingMetaData();
-    assertThat(embeddingMetaData.getEntryColumn(sourceVariable), is(0));
-    assertThat(embeddingMetaData.getEntryColumn(edgeVariable), is(1));
-    assertThat(embeddingMetaData.getEntryColumn(targetVariable), is(0));
-    assertThat(embeddingMetaData.getPropertyKeys(edgeVariable).size(), is(0));
+    assertEquals(0, embeddingMetaData.getEntryColumn(sourceVariable));
+    assertEquals(1, embeddingMetaData.getEntryColumn(edgeVariable));
+    assertEquals(0, embeddingMetaData.getEntryColumn(targetVariable));
+    assertEquals(0, embeddingMetaData.getPropertyKeys(edgeVariable).size());
   }
 
   @Test
@@ -98,9 +97,9 @@ public class FilterAndProjectEdgesNodeTest extends GradoopFlinkTestBase {
 
     List<Embedding> filteredEdges = node.execute().collect();
 
-    assertThat(filteredEdges.size(), is(1));
-    assertThat(filteredEdges.get(0).getId(0).equals(sourceId), is(true));
-    assertThat(filteredEdges.get(0).getId(1).equals(edge1Id), is(true));
-    assertThat(filteredEdges.get(0).getId(2).equals(targetId), is(true));
+    assertEquals(1, filteredEdges.size());
+    assertEquals(true, filteredEdges.get(0).getId(0).equals(sourceId));
+    assertEquals(true, filteredEdges.get(0).getId(1).equals(edge1Id));
+    assertEquals(true, filteredEdges.get(0).getId(2).equals(targetId));
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectEdgesNodeTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectEdgesNodeTest.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class FilterAndProjectEdgesNodeTest extends GradoopFlinkTestBase {
 
@@ -99,8 +98,8 @@ public class FilterAndProjectEdgesNodeTest extends GradoopFlinkTestBase {
     List<Embedding> filteredEdges = node.execute().collect();
 
     assertEquals(1, filteredEdges.size());
-    assertTrue(filteredEdges.get(0).getId(0).equals(sourceId));
-    assertTrue(filteredEdges.get(0).getId(1).equals(edge1Id));
-    assertTrue(filteredEdges.get(0).getId(2).equals(targetId));
+    assertEquals(sourceId, filteredEdges.get(0).getId(0));
+    assertEquals(edge1Id, filteredEdges.get(0).getId(1));
+    assertEquals(targetId, filteredEdges.get(0).getId(2));
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectVerticesNodeTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectVerticesNodeTest.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class FilterAndProjectVerticesNodeTest extends GradoopFlinkTestBase {
 
@@ -76,6 +75,6 @@ public class FilterAndProjectVerticesNodeTest extends GradoopFlinkTestBase {
     List<Embedding> filteredVertices = node.execute().collect();
 
     assertEquals(1, filteredVertices.size());
-    assertTrue(filteredVertices.get(0).getId(0).equals(vertex1Id));
+    assertEquals(vertex1Id, filteredVertices.get(0).getId(0));
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectVerticesNodeTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectVerticesNodeTest.java
@@ -33,8 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 
 public class FilterAndProjectVerticesNodeTest extends GradoopFlinkTestBase {
 
@@ -45,8 +44,8 @@ public class FilterAndProjectVerticesNodeTest extends GradoopFlinkTestBase {
       null, variable, new CNF(), Sets.newHashSet());
 
     EmbeddingMetaData embeddingMetaData = node.getEmbeddingMetaData();
-    assertThat(embeddingMetaData.getEntryColumn(variable), is(0));
-    assertThat(node.getEmbeddingMetaData().getPropertyKeys(variable).size(), is(0));
+    assertEquals(0, embeddingMetaData.getEntryColumn(variable));
+    assertEquals(0, node.getEmbeddingMetaData().getPropertyKeys(variable).size());
   }
 
   @Test
@@ -75,7 +74,7 @@ public class FilterAndProjectVerticesNodeTest extends GradoopFlinkTestBase {
       vertices, "n", filterPredicate, projectionKeys);
     List<Embedding> filteredVertices = node.execute().collect();
 
-    assertThat(filteredVertices.size(), is(1));
-    assertThat(filteredVertices.get(0).getId(0).equals(vertex1Id), is(true));
+    assertEquals(1, filteredVertices.size());
+    assertEquals(true, filteredVertices.get(0).getId(0).equals(vertex1Id));
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectVerticesNodeTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/leaf/FilterAndProjectVerticesNodeTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class FilterAndProjectVerticesNodeTest extends GradoopFlinkTestBase {
 
@@ -75,6 +76,6 @@ public class FilterAndProjectVerticesNodeTest extends GradoopFlinkTestBase {
     List<Embedding> filteredVertices = node.execute().collect();
 
     assertEquals(1, filteredVertices.size());
-    assertEquals(true, filteredVertices.get(0).getId(0).equals(vertex1Id));
+    assertTrue(filteredVertices.get(0).getId(0).equals(vertex1Id));
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/unary/FilterEmbeddingsNodeTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/unary/FilterEmbeddingsNodeTest.java
@@ -44,7 +44,7 @@ public class FilterEmbeddingsNodeTest extends GradoopFlinkTestBase {
 
     FilterEmbeddingsNode node = new FilterEmbeddingsNode(mockNode, new CNF());
 
-    assertTrue(mockNode.getEmbeddingMetaData().equals(node.getEmbeddingMetaData()));
+    assertEquals(node.getEmbeddingMetaData(), mockNode.getEmbeddingMetaData());
   }
 
   @Test
@@ -77,9 +77,9 @@ public class FilterEmbeddingsNodeTest extends GradoopFlinkTestBase {
     List<Embedding> result = new FilterEmbeddingsNode(mockChild, filterPredicate).execute().collect();
 
     assertEquals(1, result.size());
-    assertTrue(result.get(0).getId(0).equals(vertexAId));
-    assertTrue(result.get(0).getId(1).equals(vertexBId));
-    assertTrue(result.get(0).getProperty(0).equals(PropertyValue.create(42)));
-    assertTrue(result.get(0).getProperty(1).equals(PropertyValue.create(23)));
+    assertEquals(vertexAId, result.get(0).getId(0));
+    assertEquals(vertexBId, result.get(0).getId(1));
+    assertEquals(PropertyValue.create(42), result.get(0).getProperty(0));
+    assertEquals(PropertyValue.create(23), result.get(0).getProperty(1));
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/unary/FilterEmbeddingsNodeTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/unary/FilterEmbeddingsNodeTest.java
@@ -31,9 +31,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class FilterEmbeddingsNodeTest extends GradoopFlinkTestBase {
 
@@ -78,7 +76,7 @@ public class FilterEmbeddingsNodeTest extends GradoopFlinkTestBase {
 
     List<Embedding> result = new FilterEmbeddingsNode(mockChild, filterPredicate).execute().collect();
 
-    assertThat(result.size(), is(1));
+    assertEquals(1, result.size());
     assertTrue(result.get(0).getId(0).equals(vertexAId));
     assertTrue(result.get(0).getId(1).equals(vertexBId));
     assertTrue(result.get(0).getProperty(0).equals(PropertyValue.create(42)));

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/unary/ProjectEmbeddingsNodeTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/matching/single/cypher/planning/queryplan/unary/ProjectEmbeddingsNodeTest.java
@@ -25,15 +25,11 @@ import org.gradoop.flink.model.impl.operators.matching.single.cypher.planning.qu
 import org.gradoop.flink.model.impl.operators.matching.single.cypher.pojos.Embedding;
 import org.gradoop.flink.model.impl.operators.matching.single.cypher.pojos.EmbeddingMetaData;
 import org.gradoop.flink.model.impl.operators.matching.single.cypher.pojos.EmbeddingMetaData.EntryType;
-import org.hamcrest.core.Is;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class ProjectEmbeddingsNodeTest extends GradoopFlinkTestBase {
@@ -52,11 +48,11 @@ public class ProjectEmbeddingsNodeTest extends GradoopFlinkTestBase {
 
     ProjectEmbeddingsNode node = new ProjectEmbeddingsNode(mockNode, projectedKeys);
     EmbeddingMetaData outputMetaData = node.getEmbeddingMetaData();
-    assertThat(outputMetaData.getEntryCount(), is(2));
-    assertThat(outputMetaData.getEntryColumn("a"), is(0));
-    assertThat(outputMetaData.getEntryColumn("b"), is(1));
-    assertThat(outputMetaData.getPropertyCount(), is(1));
-    assertThat(outputMetaData.getPropertyColumn("a", "age"), is(0));
+    assertEquals(2, outputMetaData.getEntryCount());
+    assertEquals(0, outputMetaData.getEntryColumn("a"));
+    assertEquals(1, outputMetaData.getEntryColumn("b"));
+    assertEquals(1, outputMetaData.getPropertyCount());
+    assertEquals(0, outputMetaData.getPropertyColumn("a", "age"));
   }
 
   @Test
@@ -82,10 +78,10 @@ public class ProjectEmbeddingsNodeTest extends GradoopFlinkTestBase {
 
     List<Embedding> result = new ProjectEmbeddingsNode(mockChild, projectedKeys).execute().collect();
 
-    Assert.assertThat(result.size(), Is.is(1));
+    assertEquals(1, result.size());
     assertEquals(result.get(0).getId(0), vertexAId);
     assertEquals(result.get(0).getId(1), vertexBId);
-    assertThat(result.get(0).getProperties().size(), is(1));
+    assertEquals(1, result.get(0).getProperties().size());
     assertEquals(result.get(0).getProperty(0), PropertyValue.create(42));
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/statistics/StatisticsTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/statistics/StatisticsTest.java
@@ -110,10 +110,10 @@ public class StatisticsTest extends GradoopFlinkTestBase {
     result.forEach(e -> dist.put(e.getCount(), dist.getOrDefault(e.getCount(), 0) + 1));
 
     assertEquals(4, dist.size());
-    assertEquals(1, (int)dist.get(2L));
-    assertEquals(4, (int)dist.get(3L));
-    assertEquals(2, (int)dist.get(5L));
-    assertEquals(4, (int)dist.get(6L));
+    assertEquals(1, (int) dist.get(2L));
+    assertEquals(4, (int) dist.get(3L));
+    assertEquals(2, (int) dist.get(5L));
+    assertEquals(4, (int) dist.get(6L));
   }
 
   @Test
@@ -131,10 +131,10 @@ public class StatisticsTest extends GradoopFlinkTestBase {
     result.forEach(e -> dist.put(e.getCount(), dist.getOrDefault(e.getCount(), 0) + 1));
 
     assertEquals(4, dist.size());
-    assertEquals(3, (int)dist.get(0L));
-    assertEquals(4, (int)dist.get(2L));
-    assertEquals(2, (int)dist.get(3L));
-    assertEquals(2, (int)dist.get(5L));
+    assertEquals(3, (int) dist.get(0L));
+    assertEquals(4, (int) dist.get(2L));
+    assertEquals(2, (int) dist.get(3L));
+    assertEquals(2, (int) dist.get(5L));
   }
 
   @Test
@@ -152,10 +152,10 @@ public class StatisticsTest extends GradoopFlinkTestBase {
     result.forEach(e -> dist.put(e.getCount(), dist.getOrDefault(e.getCount(), 0) + 1));
 
     assertEquals(4, dist.size());
-    assertEquals(4, (int)dist.get(0L));
-    assertEquals(1, (int)dist.get(2L));
-    assertEquals(2, (int)dist.get(3L));
-    assertEquals(4, (int)dist.get(4L));
+    assertEquals(4, (int) dist.get(0L));
+    assertEquals(1, (int) dist.get(2L));
+    assertEquals(2, (int) dist.get(3L));
+    assertEquals(4, (int) dist.get(4L));
   }
 
   @Test
@@ -321,7 +321,7 @@ public class StatisticsTest extends GradoopFlinkTestBase {
 
     assertEquals(4L, (long) cache.get(Tuple2.of("Tag", "hasTag")));
     assertEquals(4L, (long) cache.get(Tuple2.of("Tag", "hasInterest")));
-    assertEquals(10L,(long) cache.get(Tuple2.of("Person", "knows")));
+    assertEquals(10L, (long) cache.get(Tuple2.of("Person", "knows")));
     assertEquals(2L, (long) cache.get(Tuple2.of("Person", "hasModerator")));
     assertEquals(4L, (long) cache.get(Tuple2.of("Person", "hasMember")));
   }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/statistics/StatisticsTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/statistics/StatisticsTest.java
@@ -27,9 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class StatisticsTest extends GradoopFlinkTestBase {
 
@@ -42,7 +40,7 @@ public class StatisticsTest extends GradoopFlinkTestBase {
       .collect()
       .get(0);
 
-    assertThat(vertexCount, is(11L));
+    assertEquals(11L, (long)vertexCount);
   }
 
   @Test
@@ -54,7 +52,7 @@ public class StatisticsTest extends GradoopFlinkTestBase {
       .collect()
       .get(0);
 
-    assertThat(edgeCount, is(24L));
+    assertEquals(24L, (long)edgeCount);
   }
 
   @Test
@@ -71,9 +69,9 @@ public class StatisticsTest extends GradoopFlinkTestBase {
 
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertThat(cache.get("Tag"), is(3L));
-    assertThat(cache.get("Forum"), is(2L));
-    assertThat(cache.get("Person"), is(6L));
+    assertEquals(3L, (long)cache.get("Tag"));
+    assertEquals(2L, (long)cache.get("Forum"));
+    assertEquals(6L, (long)cache.get("Person"));
   }
 
   @Test
@@ -84,17 +82,17 @@ public class StatisticsTest extends GradoopFlinkTestBase {
       .execute(db)
       .collect();
 
-    assertThat(result.size(), is(5));
+    assertEquals(5, result.size());
 
     Map<String, Long> cache = new HashMap<>(5);
 
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertThat(cache.get("hasTag"), is(4L));
-    assertThat(cache.get("hasInterest"), is(4L));
-    assertThat(cache.get("hasModerator"), is(2L));
-    assertThat(cache.get("hasMember"), is(4L));
-    assertThat(cache.get("knows"), is(10L));
+    assertEquals(4L, (long)cache.get("hasTag"));
+    assertEquals(4L, (long)cache.get("hasInterest"));
+    assertEquals(2L, (long)cache.get("hasModerator"));
+    assertEquals(4L, (long)cache.get("hasMember"));
+    assertEquals(10L, (long)cache.get("knows"));
   }
 
   @Test
@@ -105,17 +103,17 @@ public class StatisticsTest extends GradoopFlinkTestBase {
       .execute(db)
       .collect();
 
-    assertThat(result.size(), is(11));
+    assertEquals(11, result.size());
 
     Map<Long, Integer> dist = new HashMap<>(4);
 
     result.forEach(e -> dist.put(e.getCount(), dist.getOrDefault(e.getCount(), 0) + 1));
 
-    assertThat(dist.size(), is(4));
-    assertThat(dist.get(2L), is(1));
-    assertThat(dist.get(3L), is(4));
-    assertThat(dist.get(5L), is(2));
-    assertThat(dist.get(6L), is(4));
+    assertEquals(4, dist.size());
+    assertEquals(1, (int)dist.get(2L));
+    assertEquals(4, (int)dist.get(3L));
+    assertEquals(2, (int)dist.get(5L));
+    assertEquals(4, (int)dist.get(6L));
   }
 
   @Test
@@ -126,17 +124,17 @@ public class StatisticsTest extends GradoopFlinkTestBase {
       .execute(db)
       .collect();
 
-    assertThat(result.size(), is(11));
+    assertEquals(11, result.size());
 
     Map<Long, Integer> dist = new HashMap<>(4);
 
     result.forEach(e -> dist.put(e.getCount(), dist.getOrDefault(e.getCount(), 0) + 1));
 
-    assertThat(dist.size(), is(4));
-    assertThat(dist.get(0L), is(3));
-    assertThat(dist.get(2L), is(4));
-    assertThat(dist.get(3L), is(2));
-    assertThat(dist.get(5L), is(2));
+    assertEquals(4, dist.size());
+    assertEquals(3, (int)dist.get(0L));
+    assertEquals(4, (int)dist.get(2L));
+    assertEquals(2, (int)dist.get(3L));
+    assertEquals(2, (int)dist.get(5L));
   }
 
   @Test
@@ -147,17 +145,17 @@ public class StatisticsTest extends GradoopFlinkTestBase {
       .execute(db)
       .collect();
 
-    assertThat(result.size(), is(11));
+    assertEquals(11, result.size());
 
     Map<Long, Integer> dist = new HashMap<>(4);
 
     result.forEach(e -> dist.put(e.getCount(), dist.getOrDefault(e.getCount(), 0) + 1));
 
-    assertThat(dist.size(), is(4));
-    assertThat(dist.get(0L), is(4));
-    assertThat(dist.get(2L), is(1));
-    assertThat(dist.get(3L), is(2));
-    assertThat(dist.get(4L), is(4));
+    assertEquals(4, dist.size());
+    assertEquals(4, (int)dist.get(0L));
+    assertEquals(1, (int)dist.get(2L));
+    assertEquals(2, (int)dist.get(3L));
+    assertEquals(4, (int)dist.get(4L));
   }
 
   @Test
@@ -168,16 +166,16 @@ public class StatisticsTest extends GradoopFlinkTestBase {
       .execute(db)
       .collect();
 
-    assertThat(result.size(), is(4));
+    assertEquals(4, result.size());
 
     Map<Long, Long> cache = new HashMap<>(4);
 
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertThat(cache.get(2L), is(1L));
-    assertThat(cache.get(3L), is(4L));
-    assertThat(cache.get(5L), is(2L));
-    assertThat(cache.get(6L), is(4L));
+    assertEquals(1L, (long)cache.get(2L));
+    assertEquals(4L, (long)cache.get(3L));
+    assertEquals(2L, (long)cache.get(5L));
+    assertEquals(4L, (long)cache.get(6L));
   }
 
   @Test
@@ -188,16 +186,16 @@ public class StatisticsTest extends GradoopFlinkTestBase {
       .execute(db)
       .collect();
 
-    assertThat(result.size(), is(4));
+    assertEquals(4, result.size());
 
     Map<Long, Long> cache = new HashMap<>(4);
 
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertThat(cache.get(0L), is(3L));
-    assertThat(cache.get(2L), is(4L));
-    assertThat(cache.get(3L), is(2L));
-    assertThat(cache.get(5L), is(2L));
+    assertEquals(3L, (long)cache.get(0L));
+    assertEquals(4L, (long)cache.get(2L));
+    assertEquals(2L, (long)cache.get(3L));
+    assertEquals(2L, (long)cache.get(5L));
   }
 
   @Test
@@ -208,16 +206,16 @@ public class StatisticsTest extends GradoopFlinkTestBase {
       .execute(db)
       .collect();
 
-    assertThat(result.size(), is(4));
+    assertEquals(4, result.size());
 
     Map<Long, Long> cache = new HashMap<>(4);
 
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertThat(cache.get(0L), is(4L));
-    assertThat(cache.get(2L), is(1L));
-    assertThat(cache.get(3L), is(2L));
-    assertThat(cache.get(4L), is(4L));
+    assertEquals(4L, (long)cache.get(0L));
+    assertEquals(1L, (long)cache.get(2L));
+    assertEquals(2L, (long)cache.get(3L));
+    assertEquals(4L, (long)cache.get(4L));
   }
 
   @Test
@@ -229,7 +227,7 @@ public class StatisticsTest extends GradoopFlinkTestBase {
       .collect()
       .get(0);
 
-    assertThat(result, is(8L));
+    assertEquals(8L, (long)result);
   }
 
   @Test
@@ -241,7 +239,7 @@ public class StatisticsTest extends GradoopFlinkTestBase {
       .collect()
       .get(0);
 
-    assertThat(result, is(7L));
+    assertEquals(7L, (long)result);
   }
 
   @Test
@@ -252,17 +250,17 @@ public class StatisticsTest extends GradoopFlinkTestBase {
       .execute(db)
       .collect();
 
-    assertThat(result.size(), is(5));
+    assertEquals(5, result.size());
 
     Map<String, Long> cache = new HashMap<>(5);
 
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertThat(cache.get("hasInterest"), is(4L));
-    assertThat(cache.get("hasModerator"), is(2L));
-    assertThat(cache.get("knows"), is(6L));
-    assertThat(cache.get("hasTag"), is(2L));
-    assertThat(cache.get("hasMember"), is(2L));
+    assertEquals(4L, (long)cache.get("hasInterest"));
+    assertEquals(2L, (long)cache.get("hasModerator"));
+    assertEquals(6L, (long)cache.get("knows"));
+    assertEquals(2L, (long)cache.get("hasTag"));
+    assertEquals(2L, (long)cache.get("hasMember"));
   }
 
   @Test
@@ -273,17 +271,17 @@ public class StatisticsTest extends GradoopFlinkTestBase {
       .execute(db)
       .collect();
 
-    assertThat(result.size(), is(5));
+    assertEquals(5, result.size());
 
     Map<String, Long> cache = new HashMap<>(5);
 
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertThat(cache.get("hasInterest"), is(2L));
-    assertThat(cache.get("hasModerator"), is(2L));
-    assertThat(cache.get("knows"), is(4L));
-    assertThat(cache.get("hasTag"), is(3L));
-    assertThat(cache.get("hasMember"), is(4L));
+    assertEquals(2L, (long)cache.get("hasInterest"));
+    assertEquals(2L, (long)cache.get("hasModerator"));
+    assertEquals(4L, (long)cache.get("knows"));
+    assertEquals(3L, (long)cache.get("hasTag"));
+    assertEquals(4L, (long)cache.get("hasMember"));
   }
 
   @Test
@@ -294,17 +292,17 @@ public class StatisticsTest extends GradoopFlinkTestBase {
       .execute(db)
       .collect();
 
-    assertThat(result.size(), is(5));
+    assertEquals(5, result.size());
 
     Map<Tuple2<String, String>, Long> cache = new HashMap<>(5);
 
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertThat(cache.get(Tuple2.of("Forum", "hasModerator")), is(2L));
-    assertThat(cache.get(Tuple2.of("Forum", "hasTag")), is(4L));
-    assertThat(cache.get(Tuple2.of("Person", "hasInterest")), is(4L));
-    assertThat(cache.get(Tuple2.of("Person", "knows")), is(10L));
-    assertThat(cache.get(Tuple2.of("Forum", "hasMember")), is(4L));
+    assertEquals(2L, (long)cache.get(Tuple2.of("Forum", "hasModerator")));
+    assertEquals(4L, (long)cache.get(Tuple2.of("Forum", "hasTag")));
+    assertEquals(4L, (long)cache.get(Tuple2.of("Person", "hasInterest")));
+    assertEquals(10L, (long) cache.get(Tuple2.of("Person", "knows")));
+    assertEquals(4L, (long)cache.get(Tuple2.of("Forum", "hasMember")));
   }
 
   @Test
@@ -315,17 +313,17 @@ public class StatisticsTest extends GradoopFlinkTestBase {
       .execute(db)
       .collect();
 
-    assertThat(result.size(), is(5));
+    assertEquals(5, result.size());
 
     Map<Tuple2<String, String>, Long> cache = new HashMap<>(5);
 
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertThat(cache.get(Tuple2.of("Tag", "hasTag")), is(4L));
-    assertThat(cache.get(Tuple2.of("Tag", "hasInterest")), is(4L));
-    assertThat(cache.get(Tuple2.of("Person", "knows")), is(10L));
-    assertThat(cache.get(Tuple2.of("Person", "hasModerator")), is(2L));
-    assertThat(cache.get(Tuple2.of("Person", "hasMember")), is(4L));
+    assertEquals(4L, (long)cache.get(Tuple2.of("Tag", "hasTag")));
+    assertEquals(4L, (long)cache.get(Tuple2.of("Tag", "hasInterest")));
+    assertEquals(10L,(long) cache.get(Tuple2.of("Person", "knows")));
+    assertEquals(2L, (long)cache.get(Tuple2.of("Person", "hasModerator")));
+    assertEquals(4L, (long)cache.get(Tuple2.of("Person", "hasMember")));
   }
 
 
@@ -341,9 +339,9 @@ public class StatisticsTest extends GradoopFlinkTestBase {
     Map<Tuple, Long> cache = new HashMap<>(5);
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertThat(result.size(), is(2));
-    assertThat(cache.get(Tuple2.of("knows", "since")), is(3L));
-    assertThat(cache.get(Tuple2.of("hasModerator", "since")), is(1L));
+    assertEquals(2, result.size());
+    assertEquals(3L, (long)cache.get(Tuple2.of("knows", "since")));
+    assertEquals(1L, (long)cache.get(Tuple2.of("hasModerator", "since")));
   }
 
   @Test
@@ -358,16 +356,16 @@ public class StatisticsTest extends GradoopFlinkTestBase {
     Map<Tuple, Long> cache = new HashMap<>(5);
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertThat(result.size(), is(8));
+    assertEquals(8, result.size());
 
-    assertThat(cache.get(Tuple2.of("Person", "name")), is(6L));
-    assertThat(cache.get(Tuple2.of("Person", "gender")), is(2L));
-    assertThat(cache.get(Tuple2.of("Person", "city")), is(3L));
-    assertThat(cache.get(Tuple2.of("Person", "age")), is(4L));
-    assertThat(cache.get(Tuple2.of("Person", "speaks")), is(1L));
-    assertThat(cache.get(Tuple2.of("Person", "locIP")), is(1L));
-    assertThat(cache.get(Tuple2.of("Tag", "name")), is(3L));
-    assertThat(cache.get(Tuple2.of("Forum", "title")), is(2L));
+    assertEquals(6L, (long)cache.get(Tuple2.of("Person", "name")));
+    assertEquals(2L, (long)cache.get(Tuple2.of("Person", "gender")));
+    assertEquals(3L, (long)cache.get(Tuple2.of("Person", "city")));
+    assertEquals(4L, (long)cache.get(Tuple2.of("Person", "age")));
+    assertEquals(1L, (long)cache.get(Tuple2.of("Person", "speaks")));
+    assertEquals(1L, (long)cache.get(Tuple2.of("Person", "locIP")));
+    assertEquals(3L, (long)cache.get(Tuple2.of("Tag", "name")));
+    assertEquals(2L, (long)cache.get(Tuple2.of("Forum", "title")));
   }
 
   @Test
@@ -382,8 +380,8 @@ public class StatisticsTest extends GradoopFlinkTestBase {
     Map<String, Long> cache = new HashMap<>(5);
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertThat(result.size(), is(1));
-    assertThat(cache.get("since"), is(3L));
+    assertEquals(1, result.size());
+    assertEquals(3L, (long)cache.get("since"));
   }
 
   @Test
@@ -398,14 +396,14 @@ public class StatisticsTest extends GradoopFlinkTestBase {
     Map<String, Long> cache = new HashMap<>(5);
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertThat(result.size(), is(7));
+    assertEquals(7, result.size());
 
-    assertThat(cache.get("name"), is(9L));
-    assertThat(cache.get("gender"), is(2L));
-    assertThat(cache.get("city"), is(3L));
-    assertThat(cache.get("age"), is(4L));
-    assertThat(cache.get("speaks"), is(1L));
-    assertThat(cache.get("locIP"), is(1L));
-    assertThat(cache.get("title"), is(2L));
+    assertEquals(9L, (long)cache.get("name"));
+    assertEquals(2L, (long)cache.get("gender"));
+    assertEquals(3L, (long)cache.get("city"));
+    assertEquals(4L, (long)cache.get("age"));
+    assertEquals(1L, (long)cache.get("speaks"));
+    assertEquals(1L, (long)cache.get("locIP"));
+    assertEquals(2L, (long)cache.get("title"));
   }
 }

--- a/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/statistics/StatisticsTest.java
+++ b/gradoop-flink/src/test/java/org/gradoop/flink/model/impl/operators/statistics/StatisticsTest.java
@@ -40,7 +40,7 @@ public class StatisticsTest extends GradoopFlinkTestBase {
       .collect()
       .get(0);
 
-    assertEquals(11L, (long)vertexCount);
+    assertEquals(11L, (long) vertexCount);
   }
 
   @Test
@@ -52,7 +52,7 @@ public class StatisticsTest extends GradoopFlinkTestBase {
       .collect()
       .get(0);
 
-    assertEquals(24L, (long)edgeCount);
+    assertEquals(24L, (long) edgeCount);
   }
 
   @Test
@@ -69,9 +69,9 @@ public class StatisticsTest extends GradoopFlinkTestBase {
 
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertEquals(3L, (long)cache.get("Tag"));
-    assertEquals(2L, (long)cache.get("Forum"));
-    assertEquals(6L, (long)cache.get("Person"));
+    assertEquals(3L, (long) cache.get("Tag"));
+    assertEquals(2L, (long) cache.get("Forum"));
+    assertEquals(6L, (long) cache.get("Person"));
   }
 
   @Test
@@ -88,11 +88,11 @@ public class StatisticsTest extends GradoopFlinkTestBase {
 
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertEquals(4L, (long)cache.get("hasTag"));
-    assertEquals(4L, (long)cache.get("hasInterest"));
-    assertEquals(2L, (long)cache.get("hasModerator"));
-    assertEquals(4L, (long)cache.get("hasMember"));
-    assertEquals(10L, (long)cache.get("knows"));
+    assertEquals(4L, (long) cache.get("hasTag"));
+    assertEquals(4L, (long) cache.get("hasInterest"));
+    assertEquals(2L, (long) cache.get("hasModerator"));
+    assertEquals(4L, (long) cache.get("hasMember"));
+    assertEquals(10L, (long) cache.get("knows"));
   }
 
   @Test
@@ -172,10 +172,10 @@ public class StatisticsTest extends GradoopFlinkTestBase {
 
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertEquals(1L, (long)cache.get(2L));
-    assertEquals(4L, (long)cache.get(3L));
-    assertEquals(2L, (long)cache.get(5L));
-    assertEquals(4L, (long)cache.get(6L));
+    assertEquals(1L, (long) cache.get(2L));
+    assertEquals(4L, (long) cache.get(3L));
+    assertEquals(2L, (long) cache.get(5L));
+    assertEquals(4L, (long) cache.get(6L));
   }
 
   @Test
@@ -192,10 +192,10 @@ public class StatisticsTest extends GradoopFlinkTestBase {
 
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertEquals(3L, (long)cache.get(0L));
-    assertEquals(4L, (long)cache.get(2L));
-    assertEquals(2L, (long)cache.get(3L));
-    assertEquals(2L, (long)cache.get(5L));
+    assertEquals(3L, (long) cache.get(0L));
+    assertEquals(4L, (long) cache.get(2L));
+    assertEquals(2L, (long) cache.get(3L));
+    assertEquals(2L, (long) cache.get(5L));
   }
 
   @Test
@@ -212,10 +212,10 @@ public class StatisticsTest extends GradoopFlinkTestBase {
 
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertEquals(4L, (long)cache.get(0L));
-    assertEquals(1L, (long)cache.get(2L));
-    assertEquals(2L, (long)cache.get(3L));
-    assertEquals(4L, (long)cache.get(4L));
+    assertEquals(4L, (long) cache.get(0L));
+    assertEquals(1L, (long) cache.get(2L));
+    assertEquals(2L, (long) cache.get(3L));
+    assertEquals(4L, (long) cache.get(4L));
   }
 
   @Test
@@ -227,7 +227,7 @@ public class StatisticsTest extends GradoopFlinkTestBase {
       .collect()
       .get(0);
 
-    assertEquals(8L, (long)result);
+    assertEquals(8L, (long) result);
   }
 
   @Test
@@ -239,7 +239,7 @@ public class StatisticsTest extends GradoopFlinkTestBase {
       .collect()
       .get(0);
 
-    assertEquals(7L, (long)result);
+    assertEquals(7L, (long) result);
   }
 
   @Test
@@ -256,11 +256,11 @@ public class StatisticsTest extends GradoopFlinkTestBase {
 
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertEquals(4L, (long)cache.get("hasInterest"));
-    assertEquals(2L, (long)cache.get("hasModerator"));
-    assertEquals(6L, (long)cache.get("knows"));
-    assertEquals(2L, (long)cache.get("hasTag"));
-    assertEquals(2L, (long)cache.get("hasMember"));
+    assertEquals(4L, (long) cache.get("hasInterest"));
+    assertEquals(2L, (long) cache.get("hasModerator"));
+    assertEquals(6L, (long) cache.get("knows"));
+    assertEquals(2L, (long) cache.get("hasTag"));
+    assertEquals(2L, (long) cache.get("hasMember"));
   }
 
   @Test
@@ -277,11 +277,11 @@ public class StatisticsTest extends GradoopFlinkTestBase {
 
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertEquals(2L, (long)cache.get("hasInterest"));
-    assertEquals(2L, (long)cache.get("hasModerator"));
-    assertEquals(4L, (long)cache.get("knows"));
-    assertEquals(3L, (long)cache.get("hasTag"));
-    assertEquals(4L, (long)cache.get("hasMember"));
+    assertEquals(2L, (long) cache.get("hasInterest"));
+    assertEquals(2L, (long) cache.get("hasModerator"));
+    assertEquals(4L, (long) cache.get("knows"));
+    assertEquals(3L, (long) cache.get("hasTag"));
+    assertEquals(4L, (long) cache.get("hasMember"));
   }
 
   @Test
@@ -298,11 +298,11 @@ public class StatisticsTest extends GradoopFlinkTestBase {
 
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertEquals(2L, (long)cache.get(Tuple2.of("Forum", "hasModerator")));
-    assertEquals(4L, (long)cache.get(Tuple2.of("Forum", "hasTag")));
-    assertEquals(4L, (long)cache.get(Tuple2.of("Person", "hasInterest")));
+    assertEquals(2L, (long) cache.get(Tuple2.of("Forum", "hasModerator")));
+    assertEquals(4L, (long) cache.get(Tuple2.of("Forum", "hasTag")));
+    assertEquals(4L, (long) cache.get(Tuple2.of("Person", "hasInterest")));
     assertEquals(10L, (long) cache.get(Tuple2.of("Person", "knows")));
-    assertEquals(4L, (long)cache.get(Tuple2.of("Forum", "hasMember")));
+    assertEquals(4L, (long) cache.get(Tuple2.of("Forum", "hasMember")));
   }
 
   @Test
@@ -319,11 +319,11 @@ public class StatisticsTest extends GradoopFlinkTestBase {
 
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
-    assertEquals(4L, (long)cache.get(Tuple2.of("Tag", "hasTag")));
-    assertEquals(4L, (long)cache.get(Tuple2.of("Tag", "hasInterest")));
+    assertEquals(4L, (long) cache.get(Tuple2.of("Tag", "hasTag")));
+    assertEquals(4L, (long) cache.get(Tuple2.of("Tag", "hasInterest")));
     assertEquals(10L,(long) cache.get(Tuple2.of("Person", "knows")));
-    assertEquals(2L, (long)cache.get(Tuple2.of("Person", "hasModerator")));
-    assertEquals(4L, (long)cache.get(Tuple2.of("Person", "hasMember")));
+    assertEquals(2L, (long) cache.get(Tuple2.of("Person", "hasModerator")));
+    assertEquals(4L, (long) cache.get(Tuple2.of("Person", "hasMember")));
   }
 
 
@@ -340,8 +340,8 @@ public class StatisticsTest extends GradoopFlinkTestBase {
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
     assertEquals(2, result.size());
-    assertEquals(3L, (long)cache.get(Tuple2.of("knows", "since")));
-    assertEquals(1L, (long)cache.get(Tuple2.of("hasModerator", "since")));
+    assertEquals(3L, (long) cache.get(Tuple2.of("knows", "since")));
+    assertEquals(1L, (long) cache.get(Tuple2.of("hasModerator", "since")));
   }
 
   @Test
@@ -358,14 +358,14 @@ public class StatisticsTest extends GradoopFlinkTestBase {
 
     assertEquals(8, result.size());
 
-    assertEquals(6L, (long)cache.get(Tuple2.of("Person", "name")));
-    assertEquals(2L, (long)cache.get(Tuple2.of("Person", "gender")));
-    assertEquals(3L, (long)cache.get(Tuple2.of("Person", "city")));
-    assertEquals(4L, (long)cache.get(Tuple2.of("Person", "age")));
-    assertEquals(1L, (long)cache.get(Tuple2.of("Person", "speaks")));
-    assertEquals(1L, (long)cache.get(Tuple2.of("Person", "locIP")));
-    assertEquals(3L, (long)cache.get(Tuple2.of("Tag", "name")));
-    assertEquals(2L, (long)cache.get(Tuple2.of("Forum", "title")));
+    assertEquals(6L, (long) cache.get(Tuple2.of("Person", "name")));
+    assertEquals(2L, (long) cache.get(Tuple2.of("Person", "gender")));
+    assertEquals(3L, (long) cache.get(Tuple2.of("Person", "city")));
+    assertEquals(4L, (long) cache.get(Tuple2.of("Person", "age")));
+    assertEquals(1L, (long) cache.get(Tuple2.of("Person", "speaks")));
+    assertEquals(1L, (long) cache.get(Tuple2.of("Person", "locIP")));
+    assertEquals(3L, (long) cache.get(Tuple2.of("Tag", "name")));
+    assertEquals(2L, (long) cache.get(Tuple2.of("Forum", "title")));
   }
 
   @Test
@@ -381,7 +381,7 @@ public class StatisticsTest extends GradoopFlinkTestBase {
     result.forEach(e -> cache.put(e.getObject(), e.getCount()));
 
     assertEquals(1, result.size());
-    assertEquals(3L, (long)cache.get("since"));
+    assertEquals(3L, (long) cache.get("since"));
   }
 
   @Test
@@ -398,12 +398,12 @@ public class StatisticsTest extends GradoopFlinkTestBase {
 
     assertEquals(7, result.size());
 
-    assertEquals(9L, (long)cache.get("name"));
-    assertEquals(2L, (long)cache.get("gender"));
-    assertEquals(3L, (long)cache.get("city"));
-    assertEquals(4L, (long)cache.get("age"));
-    assertEquals(1L, (long)cache.get("speaks"));
-    assertEquals(1L, (long)cache.get("locIP"));
-    assertEquals(2L, (long)cache.get("title"));
+    assertEquals(9L, (long) cache.get("name"));
+    assertEquals(2L, (long) cache.get("gender"));
+    assertEquals(3L, (long) cache.get("city"));
+    assertEquals(4L, (long) cache.get("age"));
+    assertEquals(1L, (long) cache.get("speaks"));
+    assertEquals(1L, (long) cache.get("locIP"));
+    assertEquals(2L, (long) cache.get("title"));
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request removes the hamcrest dependency from relevant unit tests. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This is a fix for issue #1540 . 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I tested my changes by ensuring that all of the existing unit tests pass. 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This fixes issue #1540. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if necessary).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I ran a spell checker.

