### PR TITLE
[#1574] Added Deploy of Gradoop-Site and Javadoc to Github Action

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -28,4 +28,7 @@ jobs:
         run: mvn site site:stage -Pjavadoc -DskipTests
 
       - name: Deploy to gh-pages
-        run: mvn scm-publish:publish-scm -Pjavadoc
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/staging

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,10 +1,9 @@
 name: Deploy GitHub Pages
 
 on:
-  workflow_dispatch
-  # Run weekly on sunday at 22:00 UTC (arbitrary)
-  #schedule:
-  #  - cron: '00 22 * * SUN'
+  # Run weekly on sunday at 23:00 UTC (arbitrary)
+  schedule:
+    - cron: '00 23 * * SUN'
 
 jobs:
   deploy:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,4 @@
-name: Deploy Snapshot JavaDoc to GitHub Pages
+name: Deploy GitHub Pages
 
 on:
   workflow_dispatch
@@ -21,8 +21,11 @@ jobs:
         with:
           java-version: 1.8
 
+      - name: Build Project
+        run: mvn clean install
+
       - name: Build JavaDoc
-        run: mvn clean site site:stage -Pjavadoc
+        run: mvn site site:stage -Pjavadoc -DskipTests
 
       - name: Deploy to gh-pages
         run: mvn scm-publish:publish-scm -Pjavadoc

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,28 @@
+name: Deploy Snapshot JavaDoc to GitHub Pages
+
+on:
+  workflow_dispatch
+  # Run weekly on sunday at 22:00 UTC (arbitrary)
+  #schedule:
+  #  - cron: '00 22 * * SUN'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: develop
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Build JavaDoc
+        run: mvn clean site site:stage -Pjavadoc
+
+      - name: Deploy to gh-pages
+        run: mvn scm-publish:publish-scm -Pjavadoc

--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
                         <inherited>false</inherited>
                         <configuration>
                             <serverId>github</serverId>
-                            <pubScmUrl>scm:git:https://github.com/dbs-leipzig/gradoop.git</pubScmUrl>
+                            <pubScmUrl>scm:git:https://github.com/ChrizZz110/gradoop.git</pubScmUrl>
                             <scmBranch>gh-pages</scmBranch>
                             <checkinComment>Updated Site via Maven</checkinComment>
                             <content>${project.build.directory}/staging</content>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         </site>
         <snapshotRepository>
             <id>release_artifacts_gradoop</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/org/gradoop</url>
         </snapshotRepository>
         <repository>
             <id>release_artifacts_gradoop</id>
@@ -189,7 +189,6 @@
         <plugin.maven-gpg.version>1.6</plugin.maven-gpg.version>
         <plugin.maven-nexus-staging.version>1.6.7</plugin.maven-nexus-staging.version>
         <plugin.maven-site.version>3.7.1</plugin.maven-site.version>
-        <plugin.maven-scm-publish.version>3.0.0</plugin.maven-scm-publish.version>
         <plugin.maven-jacoco.version>0.8.1</plugin.maven-jacoco.version>
         <plugin.maven-wagon-ssh.version>3.0.0</plugin.maven-wagon-ssh.version>
     </properties>
@@ -274,28 +273,6 @@
                                 <version>${plugin.maven-wagon-ssh.version}</version>
                             </dependency>
                         </dependencies>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-scm-publish-plugin</artifactId>
-                        <version>${plugin.maven-scm-publish.version}</version>
-                        <inherited>false</inherited>
-                        <configuration>
-                            <serverId>github</serverId>
-                            <pubScmUrl>scm:git:https://github.com/ChrizZz110/gradoop.git</pubScmUrl>
-                            <scmBranch>gh-pages</scmBranch>
-                            <checkinComment>Updated Site via Maven</checkinComment>
-                            <content>${project.build.directory}/staging</content>
-                            <siteOutputEncoding>UTF-8</siteOutputEncoding>
-                            <tryUpdate>true</tryUpdate>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>publish-scm</goal>
-                                </goals>
-                                <phase>site-deploy</phase>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The gradoop project sites were generated by a Jenkins schedule in the past. In this PR, a github action is created which builds the project page + JavaDoc and deploys it to the gh-pages repository.
The scm-publish plugin was removed since it is not needed anymore.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1574 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Weekly deploy of Project summary and JavaDoc.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
In the Fork of @ChrizZz110 .

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if necessary).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I ran a spell checker.

