### PR TITLE
#1559 min max avg degree evolution

### DIFF
--- a/gradoop-examples/gradoop-examples-temporal/src/main/java/org/gradoop/examples/metric/MaxDegreeEvolutionExample.java
+++ b/gradoop-examples/gradoop-examples-temporal/src/main/java/org/gradoop/examples/metric/MaxDegreeEvolutionExample.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.examples.metric;
+
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.gradoop.flink.model.impl.operators.sampling.functions.VertexDegree;
+import org.gradoop.temporal.io.impl.csv.TemporalCSVDataSource;
+import org.gradoop.temporal.model.api.TimeDimension;
+import org.gradoop.temporal.model.impl.TemporalGraph;
+import org.gradoop.temporal.model.impl.operators.metric.MaxDegreeEvolution;
+import org.gradoop.temporal.util.TemporalGradoopConfig;
+
+import static org.apache.flink.api.java.ExecutionEnvironment.getExecutionEnvironment;
+
+/**
+ * A self contained example on how to use the max degree evolution operator on a graph loaded via path name.
+ */
+
+public class MaxDegreeEvolutionExample {
+
+
+  /**
+   *
+   * Runs the example by creating an execution environment, loading a temporal graph from a csv-file
+   * and then uses the MaxDegreeEvolution operator on the graph
+   *
+   *
+   * @param args Command line input: path to the csv file for the graph
+   * @throws Exception on failure
+   */
+  public static void main(String[] args) throws Exception {
+    ExecutionEnvironment env = getExecutionEnvironment();
+
+    TemporalGraph graph = new TemporalCSVDataSource(args[0], TemporalGradoopConfig.createConfig(env))
+            .getTemporalGraph();
+
+
+
+    final DataSet<Tuple3<Long, Long, Float>> resultDataSet = graph
+            .callForValue(new MaxDegreeEvolution(VertexDegree.IN, TimeDimension.VALID_TIME));
+
+
+    resultDataSet.collect();
+    //resultDataSet.print();
+  }
+}

--- a/gradoop-examples/gradoop-examples-temporal/src/main/java/org/gradoop/examples/metric/package-info.java
+++ b/gradoop-examples/gradoop-examples-temporal/src/main/java/org/gradoop/examples/metric/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Examples related to the temporal degrees metrics.
+ */
+package org.gradoop.examples.metric;

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/AvgDegreeEvolution.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/AvgDegreeEvolution.java
@@ -15,12 +15,14 @@
  */
 package org.gradoop.temporal.model.impl.operators.metric;
 
+import org.apache.flink.api.common.operators.Order;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.gradoop.flink.model.impl.operators.sampling.functions.VertexDegree;
 import org.gradoop.temporal.model.api.TimeDimension;
 import org.gradoop.temporal.model.impl.TemporalGraph;
 import org.gradoop.temporal.model.impl.operators.metric.functions.AggregationType;
+import org.gradoop.temporal.model.impl.operators.metric.functions.MapPartitionCombineDegreeTrees;
 import org.gradoop.temporal.model.impl.operators.metric.functions.GroupDegreeTreesToAggregateDegrees;
 import org.gradoop.temporal.model.impl.operators.metric.functions.MapDegreesToInterval;
 
@@ -53,7 +55,9 @@ public class AvgDegreeEvolution extends BaseAggregateDegreeEvolution {
   @Override
   public DataSet<Tuple3<Long, Long, Float>> execute(TemporalGraph graph) {
     return preProcess(graph)
-                .reduceGroup(new GroupDegreeTreesToAggregateDegrees(AggregationType.AVG))
-                .mapPartition(new MapDegreesToInterval());
+            .mapPartition(new MapPartitionCombineDegreeTrees(AggregationType.AVG))
+            .reduceGroup(new GroupDegreeTreesToAggregateDegrees(AggregationType.AVG))
+            .sortPartition(0, Order.ASCENDING)
+            .mapPartition(new MapDegreesToInterval());
   }
 }

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/AvgDegreeEvolution.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/AvgDegreeEvolution.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.operators.metric;
+
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.gradoop.flink.model.impl.operators.sampling.functions.VertexDegree;
+import org.gradoop.temporal.model.api.TimeDimension;
+import org.gradoop.temporal.model.impl.TemporalGraph;
+import org.gradoop.temporal.model.impl.operators.metric.functions.AggregationType;
+import org.gradoop.temporal.model.impl.operators.metric.functions.GroupDegreeTreesToAggregateDegrees;
+
+/**
+ * Operator that calculates the evolution of the graph's average degree for the whole lifetime of the graph.
+ * The result is a triple dataset {@link DataSet<Tuple3>} in form {@code <Long, Long, Float>}. It
+ * represents a time interval (first and second element) and the aggregated degree value for this interval
+ * (3rd element).
+ */
+public class AvgDegreeEvolution extends BaseAggregateDegreeEvolution {
+    /**
+     * Creates an instance of this average degree evolution operator using {@link TimeDimension#VALID_TIME}
+     * as default time dimension and {@link VertexDegree#BOTH} as default degree type.
+     */
+    public AvgDegreeEvolution() {
+        super();
+    }
+
+    /**
+     * Creates an instance of this average degree evolution operator using the given time dimension and
+     * degree type.
+     *
+     * @param degreeType the degree type (IN, OUT or BOTH)
+     * @param dimension the time dimension to consider (VALID_TIME or TRANSACTION_TIME)
+     */
+    public AvgDegreeEvolution(VertexDegree degreeType, TimeDimension dimension) {
+        super(degreeType, dimension);
+    }
+
+    @Override
+    public DataSet<Tuple3<Long, Long, Float>> execute(TemporalGraph graph) {
+        return preProcess(graph).reduceGroup(new GroupDegreeTreesToAggregateDegrees(AggregationType.AVG));
+    }
+}

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/AvgDegreeEvolution.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/AvgDegreeEvolution.java
@@ -22,6 +22,7 @@ import org.gradoop.temporal.model.api.TimeDimension;
 import org.gradoop.temporal.model.impl.TemporalGraph;
 import org.gradoop.temporal.model.impl.operators.metric.functions.AggregationType;
 import org.gradoop.temporal.model.impl.operators.metric.functions.GroupDegreeTreesToAggregateDegrees;
+import org.gradoop.temporal.model.impl.operators.metric.functions.MapDegreesToInterval;
 
 /**
  * Operator that calculates the evolution of the graph's average degree for the whole lifetime of the graph.
@@ -34,9 +35,9 @@ public class AvgDegreeEvolution extends BaseAggregateDegreeEvolution {
      * Creates an instance of this average degree evolution operator using {@link TimeDimension#VALID_TIME}
      * as default time dimension and {@link VertexDegree#BOTH} as default degree type.
      */
-    public AvgDegreeEvolution() {
+  public AvgDegreeEvolution() {
         super();
-    }
+  }
 
     /**
      * Creates an instance of this average degree evolution operator using the given time dimension and
@@ -45,12 +46,14 @@ public class AvgDegreeEvolution extends BaseAggregateDegreeEvolution {
      * @param degreeType the degree type (IN, OUT or BOTH)
      * @param dimension the time dimension to consider (VALID_TIME or TRANSACTION_TIME)
      */
-    public AvgDegreeEvolution(VertexDegree degreeType, TimeDimension dimension) {
+  public AvgDegreeEvolution(VertexDegree degreeType, TimeDimension dimension) {
         super(degreeType, dimension);
-    }
+  }
 
-    @Override
-    public DataSet<Tuple3<Long, Long, Float>> execute(TemporalGraph graph) {
-        return preProcess(graph).reduceGroup(new GroupDegreeTreesToAggregateDegrees(AggregationType.AVG));
-    }
+  @Override
+  public DataSet<Tuple3<Long, Long, Float>> execute(TemporalGraph graph) {
+    return preProcess(graph)
+                .reduceGroup(new GroupDegreeTreesToAggregateDegrees(AggregationType.AVG))
+                .mapPartition(new MapDegreesToInterval());
+  }
 }

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/BaseAggregateDegreeEvolution.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/BaseAggregateDegreeEvolution.java
@@ -39,19 +39,19 @@ abstract class BaseAggregateDegreeEvolution
     /**
      * The time dimension that will be considered.
      */
-    private TimeDimension dimension = TimeDimension.VALID_TIME;
+  private TimeDimension dimension = TimeDimension.VALID_TIME;
 
     /**
      * The degree type (IN, OUT, BOTH);
      */
-    private VertexDegree degreeType = VertexDegree.BOTH;
+  private VertexDegree degreeType = VertexDegree.BOTH;
 
     /**
      * Default constructor using {@link TimeDimension#VALID_TIME} as default time dimension and
      * {@link VertexDegree#BOTH} as default degree type.
      */
-    protected BaseAggregateDegreeEvolution() {
-    }
+  protected BaseAggregateDegreeEvolution() {
+  }
 
     /**
      * Abstract constructor for the aggregated degree evolution of a graph.
@@ -59,10 +59,10 @@ abstract class BaseAggregateDegreeEvolution
      * @param degreeType the degree type (IN, OUT or BOTH)
      * @param dimension the time dimension to consider (VALID_TIME or TRANSACTION_TIME)
      */
-    protected BaseAggregateDegreeEvolution(VertexDegree degreeType, TimeDimension dimension) {
-        this.degreeType = Objects.requireNonNull(degreeType);
-        this.dimension = Objects.requireNonNull(dimension);
-    }
+  protected BaseAggregateDegreeEvolution(VertexDegree degreeType, TimeDimension dimension) {
+    this.degreeType = Objects.requireNonNull(degreeType);
+    this.dimension = Objects.requireNonNull(dimension);
+  }
 
     /**
      * A pre-process function to prevent duplicate code for min, max and avg aggregation. The result is an
@@ -71,8 +71,8 @@ abstract class BaseAggregateDegreeEvolution
      * @param graph the temporal graph as input
      * @return a dataset containing an absolute degree tree for each vertex identifier
      */
-    public DataSet<Tuple2<GradoopId, TreeMap<Long, Integer>>> preProcess(TemporalGraph graph) {
-        return graph.getEdges()
+  public DataSet<Tuple2<GradoopId, TreeMap<Long, Integer>>> preProcess(TemporalGraph graph) {
+    return graph.getEdges()
                 // 1) Extract vertex id(s) and corresponding time intervals
                 .flatMap(new FlatMapVertexIdEdgeInterval(dimension, degreeType))
                 // 2) Group them by the vertex id
@@ -81,5 +81,5 @@ abstract class BaseAggregateDegreeEvolution
                 .reduceGroup(new BuildTemporalDegreeTree())
                 // 4) Transform each tree to aggregated evolution
                 .map(new TransformDeltaToAbsoluteDegreeTree());
-    }
+  }
 }

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/BaseAggregateDegreeEvolution.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/BaseAggregateDegreeEvolution.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.operators.metric;
+
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.flink.model.api.operators.UnaryBaseGraphToValueOperator;
+import org.gradoop.flink.model.impl.operators.sampling.functions.VertexDegree;
+import org.gradoop.temporal.model.api.TimeDimension;
+import org.gradoop.temporal.model.impl.TemporalGraph;
+import org.gradoop.temporal.model.impl.operators.metric.functions.BuildTemporalDegreeTree;
+import org.gradoop.temporal.model.impl.operators.metric.functions.FlatMapVertexIdEdgeInterval;
+import org.gradoop.temporal.model.impl.operators.metric.functions.TransformDeltaToAbsoluteDegreeTree;
+
+import java.util.Objects;
+import java.util.TreeMap;
+
+/**
+ * Abstract class as parent for aggregated degree evolution operators.
+ */
+abstract class BaseAggregateDegreeEvolution
+        implements UnaryBaseGraphToValueOperator<TemporalGraph, DataSet<Tuple3<Long, Long, Float>>> {
+
+    /**
+     * The time dimension that will be considered.
+     */
+    private TimeDimension dimension = TimeDimension.VALID_TIME;
+
+    /**
+     * The degree type (IN, OUT, BOTH);
+     */
+    private VertexDegree degreeType = VertexDegree.BOTH;
+
+    /**
+     * Default constructor using {@link TimeDimension#VALID_TIME} as default time dimension and
+     * {@link VertexDegree#BOTH} as default degree type.
+     */
+    protected BaseAggregateDegreeEvolution() {
+    }
+
+    /**
+     * Abstract constructor for the aggregated degree evolution of a graph.
+     *
+     * @param degreeType the degree type (IN, OUT or BOTH)
+     * @param dimension the time dimension to consider (VALID_TIME or TRANSACTION_TIME)
+     */
+    protected BaseAggregateDegreeEvolution(VertexDegree degreeType, TimeDimension dimension) {
+        this.degreeType = Objects.requireNonNull(degreeType);
+        this.dimension = Objects.requireNonNull(dimension);
+    }
+
+    /**
+     * A pre-process function to prevent duplicate code for min, max and avg aggregation. The result is an
+     * absolute degree tree for each vertex (id).
+     *
+     * @param graph the temporal graph as input
+     * @return a dataset containing an absolute degree tree for each vertex identifier
+     */
+    public DataSet<Tuple2<GradoopId, TreeMap<Long, Integer>>> preProcess(TemporalGraph graph) {
+        return graph.getEdges()
+                // 1) Extract vertex id(s) and corresponding time intervals
+                .flatMap(new FlatMapVertexIdEdgeInterval(dimension, degreeType))
+                // 2) Group them by the vertex id
+                .groupBy(0)
+                // 3) For each vertex id, build a degree tree data structure
+                .reduceGroup(new BuildTemporalDegreeTree())
+                // 4) Transform each tree to aggregated evolution
+                .map(new TransformDeltaToAbsoluteDegreeTree());
+    }
+}

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/MaxDegreeEvolution.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/MaxDegreeEvolution.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.operators.metric;
+
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.gradoop.flink.model.impl.operators.sampling.functions.VertexDegree;
+import org.gradoop.temporal.model.api.TimeDimension;
+import org.gradoop.temporal.model.impl.TemporalGraph;
+import org.gradoop.temporal.model.impl.operators.metric.functions.AggregationType;
+import org.gradoop.temporal.model.impl.operators.metric.functions.GroupDegreeTreesToAggregateDegrees;
+
+/**
+ * Operator that calculates the evolution of the graph's maximum degree for the whole lifetime of the graph.
+ * The result is a triple dataset {@link DataSet<Tuple3>} in form {@code <Long, Long, Float>}. It
+ * represents a time interval (first and second element) and the aggregated degree value for this interval
+ * (3rd element).
+ */
+public class MaxDegreeEvolution extends BaseAggregateDegreeEvolution {
+    /**
+     * Creates an instance of this maximum degree evolution operator using {@link TimeDimension#VALID_TIME}
+     * as default time dimension and {@link VertexDegree#BOTH} as default degree type.
+     */
+    public MaxDegreeEvolution() {
+        super();
+    }
+
+    /**
+     * Creates an instance of this maximum degree evolution operator using the given time dimension and
+     * degree type.
+     *
+     * @param degreeType the degree type (IN, OUT or BOTH)
+     * @param dimension the time dimension to consider (VALID_TIME or TRANSACTION_TIME)
+     */
+    public MaxDegreeEvolution(VertexDegree degreeType, TimeDimension dimension) {
+        super(degreeType, dimension);
+    }
+
+    @Override
+    public DataSet<Tuple3<Long, Long, Float>> execute(TemporalGraph graph) {
+        return preProcess(graph).reduceGroup(new GroupDegreeTreesToAggregateDegrees(AggregationType.MAX));
+    }
+}

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/MaxDegreeEvolution.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/MaxDegreeEvolution.java
@@ -22,6 +22,7 @@ import org.gradoop.temporal.model.api.TimeDimension;
 import org.gradoop.temporal.model.impl.TemporalGraph;
 import org.gradoop.temporal.model.impl.operators.metric.functions.AggregationType;
 import org.gradoop.temporal.model.impl.operators.metric.functions.GroupDegreeTreesToAggregateDegrees;
+import org.gradoop.temporal.model.impl.operators.metric.functions.MapDegreesToInterval;
 
 /**
  * Operator that calculates the evolution of the graph's maximum degree for the whole lifetime of the graph.
@@ -34,9 +35,9 @@ public class MaxDegreeEvolution extends BaseAggregateDegreeEvolution {
      * Creates an instance of this maximum degree evolution operator using {@link TimeDimension#VALID_TIME}
      * as default time dimension and {@link VertexDegree#BOTH} as default degree type.
      */
-    public MaxDegreeEvolution() {
+  public MaxDegreeEvolution() {
         super();
-    }
+  }
 
     /**
      * Creates an instance of this maximum degree evolution operator using the given time dimension and
@@ -45,12 +46,14 @@ public class MaxDegreeEvolution extends BaseAggregateDegreeEvolution {
      * @param degreeType the degree type (IN, OUT or BOTH)
      * @param dimension the time dimension to consider (VALID_TIME or TRANSACTION_TIME)
      */
-    public MaxDegreeEvolution(VertexDegree degreeType, TimeDimension dimension) {
+  public MaxDegreeEvolution(VertexDegree degreeType, TimeDimension dimension) {
         super(degreeType, dimension);
-    }
+  }
 
-    @Override
-    public DataSet<Tuple3<Long, Long, Float>> execute(TemporalGraph graph) {
-        return preProcess(graph).reduceGroup(new GroupDegreeTreesToAggregateDegrees(AggregationType.MAX));
-    }
+  @Override
+  public DataSet<Tuple3<Long, Long, Float>> execute(TemporalGraph graph) {
+    return preProcess(graph)
+                .reduceGroup(new GroupDegreeTreesToAggregateDegrees(AggregationType.MAX))
+                .mapPartition(new MapDegreesToInterval());
+  }
 }

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/MaxDegreeEvolution.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/MaxDegreeEvolution.java
@@ -15,12 +15,14 @@
  */
 package org.gradoop.temporal.model.impl.operators.metric;
 
+import org.apache.flink.api.common.operators.Order;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.gradoop.flink.model.impl.operators.sampling.functions.VertexDegree;
 import org.gradoop.temporal.model.api.TimeDimension;
 import org.gradoop.temporal.model.impl.TemporalGraph;
 import org.gradoop.temporal.model.impl.operators.metric.functions.AggregationType;
+import org.gradoop.temporal.model.impl.operators.metric.functions.MapPartitionCombineDegreeTrees;
 import org.gradoop.temporal.model.impl.operators.metric.functions.GroupDegreeTreesToAggregateDegrees;
 import org.gradoop.temporal.model.impl.operators.metric.functions.MapDegreesToInterval;
 
@@ -53,7 +55,11 @@ public class MaxDegreeEvolution extends BaseAggregateDegreeEvolution {
   @Override
   public DataSet<Tuple3<Long, Long, Float>> execute(TemporalGraph graph) {
     return preProcess(graph)
-                .reduceGroup(new GroupDegreeTreesToAggregateDegrees(AggregationType.MAX))
-                .mapPartition(new MapDegreesToInterval());
+            .mapPartition(new MapPartitionCombineDegreeTrees(AggregationType.MAX))
+            .reduceGroup(new GroupDegreeTreesToAggregateDegrees(AggregationType.MAX))
+            .sortPartition(0, Order.ASCENDING)
+            .mapPartition(new MapDegreesToInterval());
+                //.reduceGroup(new GroupDegreeTreesToAggregateDegrees(AggregationType.MAX))
+               // .mapPartition(new MapDegreesToInterval());
   }
 }

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/MinDegreeEvolution.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/MinDegreeEvolution.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.operators.metric;
+
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.gradoop.flink.model.impl.operators.sampling.functions.VertexDegree;
+import org.gradoop.temporal.model.api.TimeDimension;
+import org.gradoop.temporal.model.impl.TemporalGraph;
+import org.gradoop.temporal.model.impl.operators.metric.functions.AggregationType;
+import org.gradoop.temporal.model.impl.operators.metric.functions.GroupDegreeTreesToAggregateDegrees;
+
+/**
+ * Operator that calculates the evolution of the graph's minimum degree for the whole lifetime of the graph.
+ * The result is a triple dataset {@link DataSet<Tuple3>} in form {@code <Long, Long, Float>}. It
+ * represents a time interval (first and second element) and the aggregated degree value for this interval
+ * (3rd element).
+ */
+public class MinDegreeEvolution extends BaseAggregateDegreeEvolution {
+
+    /**
+     * Creates an instance of this minimum degree evolution operator using {@link TimeDimension#VALID_TIME}
+     * as default time dimension and {@link VertexDegree#BOTH} as default degree type.
+     */
+    public MinDegreeEvolution() {
+        super();
+    }
+
+    /**
+     * Creates an instance of this minimum degree evolution operator using the given time dimension and
+     * degree type.
+     *
+     * @param degreeType the degree type (IN, OUT or BOTH)
+     * @param dimension the time dimension to consider (VALID_TIME or TRANSACTION_TIME)
+     */
+    public MinDegreeEvolution(VertexDegree degreeType, TimeDimension dimension) {
+        super(degreeType, dimension);
+    }
+
+    @Override
+    public DataSet<Tuple3<Long, Long, Float>> execute(TemporalGraph graph) {
+        return preProcess(graph).reduceGroup(new GroupDegreeTreesToAggregateDegrees(AggregationType.MIN));
+    }
+}

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/MinDegreeEvolution.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/MinDegreeEvolution.java
@@ -15,12 +15,14 @@
  */
 package org.gradoop.temporal.model.impl.operators.metric;
 
+import org.apache.flink.api.common.operators.Order;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.gradoop.flink.model.impl.operators.sampling.functions.VertexDegree;
 import org.gradoop.temporal.model.api.TimeDimension;
 import org.gradoop.temporal.model.impl.TemporalGraph;
 import org.gradoop.temporal.model.impl.operators.metric.functions.AggregationType;
+import org.gradoop.temporal.model.impl.operators.metric.functions.MapPartitionCombineDegreeTrees;
 import org.gradoop.temporal.model.impl.operators.metric.functions.GroupDegreeTreesToAggregateDegrees;
 import org.gradoop.temporal.model.impl.operators.metric.functions.MapDegreesToInterval;
 
@@ -54,7 +56,9 @@ public class MinDegreeEvolution extends BaseAggregateDegreeEvolution {
   @Override
     public DataSet<Tuple3<Long, Long, Float>> execute(TemporalGraph graph) {
     return preProcess(graph)
-                .reduceGroup(new GroupDegreeTreesToAggregateDegrees(AggregationType.MIN))
-                .mapPartition(new MapDegreesToInterval());
+            .mapPartition(new MapPartitionCombineDegreeTrees(AggregationType.MIN))
+            .reduceGroup(new GroupDegreeTreesToAggregateDegrees(AggregationType.MIN))
+            .sortPartition(0, Order.ASCENDING)
+            .mapPartition(new MapDegreesToInterval());
   }
 }

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/MinDegreeEvolution.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/MinDegreeEvolution.java
@@ -22,6 +22,7 @@ import org.gradoop.temporal.model.api.TimeDimension;
 import org.gradoop.temporal.model.impl.TemporalGraph;
 import org.gradoop.temporal.model.impl.operators.metric.functions.AggregationType;
 import org.gradoop.temporal.model.impl.operators.metric.functions.GroupDegreeTreesToAggregateDegrees;
+import org.gradoop.temporal.model.impl.operators.metric.functions.MapDegreesToInterval;
 
 /**
  * Operator that calculates the evolution of the graph's minimum degree for the whole lifetime of the graph.
@@ -35,9 +36,9 @@ public class MinDegreeEvolution extends BaseAggregateDegreeEvolution {
      * Creates an instance of this minimum degree evolution operator using {@link TimeDimension#VALID_TIME}
      * as default time dimension and {@link VertexDegree#BOTH} as default degree type.
      */
-    public MinDegreeEvolution() {
+  public MinDegreeEvolution() {
         super();
-    }
+  }
 
     /**
      * Creates an instance of this minimum degree evolution operator using the given time dimension and
@@ -46,12 +47,14 @@ public class MinDegreeEvolution extends BaseAggregateDegreeEvolution {
      * @param degreeType the degree type (IN, OUT or BOTH)
      * @param dimension the time dimension to consider (VALID_TIME or TRANSACTION_TIME)
      */
-    public MinDegreeEvolution(VertexDegree degreeType, TimeDimension dimension) {
+  public MinDegreeEvolution(VertexDegree degreeType, TimeDimension dimension) {
         super(degreeType, dimension);
-    }
+  }
 
-    @Override
+  @Override
     public DataSet<Tuple3<Long, Long, Float>> execute(TemporalGraph graph) {
-        return preProcess(graph).reduceGroup(new GroupDegreeTreesToAggregateDegrees(AggregationType.MIN));
-    }
+    return preProcess(graph)
+                .reduceGroup(new GroupDegreeTreesToAggregateDegrees(AggregationType.MIN))
+                .mapPartition(new MapDegreesToInterval());
+  }
 }

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/functions/GroupDegreeTreesToAggregateDegrees.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/functions/GroupDegreeTreesToAggregateDegrees.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.operators.metric.functions;
+
+import org.apache.flink.api.common.functions.GroupReduceFunction;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.util.Collector;
+import org.gradoop.common.model.impl.id.GradoopId;
+
+import java.util.TreeSet;
+import java.util.TreeMap;
+import java.util.SortedSet;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A group reduce function that merges all Tuples (vId, degreeTree) to a dataset of tuples (time, aggDegree)
+ * that represents the aggregated degree value for the whole graph at the given time.
+ */
+public class GroupDegreeTreesToAggregateDegrees
+        implements GroupReduceFunction<Tuple2<GradoopId, TreeMap<Long, Integer>>, Tuple3<Long, Long, Float>> {
+
+    /**
+     * The aggregate type to use (min,max,avg).
+     */
+    private final AggregationType aggregateType;
+
+    /**
+     * Creates an instance of this group reduce function.
+     *
+     * @param aggregateType the aggregate type to use (min,max,avg).
+     */
+    public GroupDegreeTreesToAggregateDegrees(AggregationType aggregateType) {
+        this.aggregateType = aggregateType;
+    }
+
+    @Override
+    public void reduce(Iterable<Tuple2<GradoopId, TreeMap<Long, Integer>>> iterable,
+                       Collector<Tuple3<Long, Long, Float>> collector) throws Exception {
+
+        // init necessary maps and set
+        HashMap<GradoopId, TreeMap<Long, Integer>> degreeTrees = new HashMap<>();
+        HashMap<GradoopId, Integer> vertexDegrees = new HashMap<>();
+        SortedSet<Long> timePoints = new TreeSet<>();
+
+        // convert the iterables to a hashmap and remember all possible timestamps
+        for (Tuple2<GradoopId, TreeMap<Long, Integer>> tuple : iterable) {
+            degreeTrees.put(tuple.f0, tuple.f1);
+            timePoints.addAll(tuple.f1.keySet());
+        }
+
+        int numberOfVertices = degreeTrees.size();
+        long lastTimestamp = Long.MIN_VALUE;
+        float degreeValue = 0f;
+
+        // Add default times
+        timePoints.add(Long.MIN_VALUE);
+
+        for (Long timePoint : timePoints) {
+            // Do the collection from the previous loop
+            if (lastTimestamp < timePoint) {
+                collector.collect(new Tuple3<>(lastTimestamp, timePoint, degreeValue));
+            }
+
+            // skip last default time
+            if (Long.MAX_VALUE == timePoint) {
+                continue;
+            }
+
+            // Iterate over all vertices
+            for (Map.Entry<GradoopId, TreeMap<Long, Integer>> entry : degreeTrees.entrySet()) {
+                // Make sure the vertex is registered in the current vertexDegrees capture
+                if (!vertexDegrees.containsKey(entry.getKey())) {
+                    vertexDegrees.put(entry.getKey(), 0);
+                }
+
+                // Check if timestamp is in tree, if not, take the lower key
+                if (entry.getValue().containsKey(timePoint)) {
+                    vertexDegrees.put(entry.getKey(), entry.getValue().get(timePoint));
+                } else {
+                    Long lowerKey = entry.getValue().lowerKey(timePoint);
+                    if (lowerKey != null) {
+                        vertexDegrees.put(entry.getKey(), entry.getValue().get(lowerKey));
+                    }
+                }
+            }
+
+            lastTimestamp = timePoint;
+            // Here, every tree with this time point is iterated. Now we need to aggregate for the current time.
+            switch (aggregateType) {
+                case MIN:
+                    degreeValue = vertexDegrees.values().stream().reduce(Math::min).orElse(0).floatValue();
+                    break;
+                case MAX:
+                    degreeValue = vertexDegrees.values().stream().reduce(Math::max).orElse(0).floatValue();
+                    break;
+                case AVG:
+                    int sum = vertexDegrees.values().stream().reduce(Math::addExact).orElse(0);
+                    degreeValue = (float) sum /  (float) numberOfVertices;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Aggregate type not specified.");
+            }
+            // Collect in next iteration
+        }
+    }
+}

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/functions/GroupDegreeTreesToAggregateDegrees.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/functions/GroupDegreeTreesToAggregateDegrees.java
@@ -17,7 +17,6 @@ package org.gradoop.temporal.model.impl.operators.metric.functions;
 
 import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.util.Collector;
 import org.gradoop.common.model.impl.id.GradoopId;
 
@@ -32,90 +31,85 @@ import java.util.Map;
  * that represents the aggregated degree value for the whole graph at the given time.
  */
 public class GroupDegreeTreesToAggregateDegrees
-        implements GroupReduceFunction<Tuple2<GradoopId, TreeMap<Long, Integer>>, Tuple3<Long, Long, Float>> {
+        implements GroupReduceFunction<Tuple2<GradoopId, TreeMap<Long, Integer>>, Tuple2<Long, Float>> {
 
     /**
      * The aggregate type to use (min,max,avg).
      */
-    private final AggregationType aggregateType;
+  private final AggregationType aggregateType;
 
     /**
      * Creates an instance of this group reduce function.
      *
      * @param aggregateType the aggregate type to use (min,max,avg).
      */
-    public GroupDegreeTreesToAggregateDegrees(AggregationType aggregateType) {
-        this.aggregateType = aggregateType;
-    }
+  public GroupDegreeTreesToAggregateDegrees(AggregationType aggregateType) {
+    this.aggregateType = aggregateType;
+  }
 
-    @Override
+  @Override
     public void reduce(Iterable<Tuple2<GradoopId, TreeMap<Long, Integer>>> iterable,
-                       Collector<Tuple3<Long, Long, Float>> collector) throws Exception {
+                       Collector<Tuple2<Long, Float>> collector) throws Exception {
+
 
         // init necessary maps and set
-        HashMap<GradoopId, TreeMap<Long, Integer>> degreeTrees = new HashMap<>();
-        HashMap<GradoopId, Integer> vertexDegrees = new HashMap<>();
-        SortedSet<Long> timePoints = new TreeSet<>();
+    HashMap<GradoopId, TreeMap<Long, Integer>> degreeTrees = new HashMap<>();
+    HashMap<GradoopId, Integer> vertexDegrees = new HashMap<>();
+    SortedSet<Long> timePoints = new TreeSet<>();
 
-        // convert the iterables to a hashmap and remember all possible timestamps
-        for (Tuple2<GradoopId, TreeMap<Long, Integer>> tuple : iterable) {
-            degreeTrees.put(tuple.f0, tuple.f1);
-            timePoints.addAll(tuple.f1.keySet());
-        }
-
-        int numberOfVertices = degreeTrees.size();
-        long lastTimestamp = Long.MIN_VALUE;
-        float degreeValue = 0f;
-
-        // Add default times
-        timePoints.add(Long.MIN_VALUE);
-
-        for (Long timePoint : timePoints) {
-            // Do the collection from the previous loop
-            if (lastTimestamp < timePoint) {
-                collector.collect(new Tuple3<>(lastTimestamp, timePoint, degreeValue));
-            }
-
-            // skip last default time
-            if (Long.MAX_VALUE == timePoint) {
-                continue;
-            }
-
-            // Iterate over all vertices
-            for (Map.Entry<GradoopId, TreeMap<Long, Integer>> entry : degreeTrees.entrySet()) {
-                // Make sure the vertex is registered in the current vertexDegrees capture
-                if (!vertexDegrees.containsKey(entry.getKey())) {
-                    vertexDegrees.put(entry.getKey(), 0);
-                }
-
-                // Check if timestamp is in tree, if not, take the lower key
-                if (entry.getValue().containsKey(timePoint)) {
-                    vertexDegrees.put(entry.getKey(), entry.getValue().get(timePoint));
-                } else {
-                    Long lowerKey = entry.getValue().lowerKey(timePoint);
-                    if (lowerKey != null) {
-                        vertexDegrees.put(entry.getKey(), entry.getValue().get(lowerKey));
-                    }
-                }
-            }
-
-            lastTimestamp = timePoint;
-            // Here, every tree with this time point is iterated. Now we need to aggregate for the current time.
-            switch (aggregateType) {
-                case MIN:
-                    degreeValue = vertexDegrees.values().stream().reduce(Math::min).orElse(0).floatValue();
-                    break;
-                case MAX:
-                    degreeValue = vertexDegrees.values().stream().reduce(Math::max).orElse(0).floatValue();
-                    break;
-                case AVG:
-                    int sum = vertexDegrees.values().stream().reduce(Math::addExact).orElse(0);
-                    degreeValue = (float) sum /  (float) numberOfVertices;
-                    break;
-                default:
-                    throw new IllegalArgumentException("Aggregate type not specified.");
-            }
-            // Collect in next iteration
-        }
+    // convert the iterables to a hashmap and remember all possible timestamps
+    for (Tuple2<GradoopId, TreeMap<Long, Integer>> tuple : iterable) {
+      degreeTrees.put(tuple.f0, tuple.f1);
+      timePoints.addAll(tuple.f1.keySet());
     }
+
+    int numberOfVertices = degreeTrees.size();
+    long lastTimestamp = Long.MIN_VALUE;
+    float degreeValue = 0f;
+
+    // Add default times
+    timePoints.add(Long.MIN_VALUE);
+
+    for (Long timePoint : timePoints) {
+
+        // Iterate over all vertices
+      for (Map.Entry<GradoopId, TreeMap<Long, Integer>> entry : degreeTrees.entrySet()) {
+        // Make sure the vertex is registered in the current vertexDegrees capture
+        if (!vertexDegrees.containsKey(entry.getKey())) {
+          vertexDegrees.put(entry.getKey(), 0);
+        }
+
+            // Check if timestamp is in tree, if not, take the lower key
+        if (entry.getValue().containsKey(timePoint)) {
+          vertexDegrees.put(entry.getKey(), entry.getValue().get(timePoint));
+        } else {
+          Long lowerKey = entry.getValue().lowerKey(timePoint);
+          if (lowerKey != null) {
+            vertexDegrees.put(entry.getKey(), entry.getValue().get(lowerKey));
+          }
+        }
+      }
+
+      lastTimestamp = timePoint;
+      // Here, every tree with this time point is iterated. Now we need to aggregate for the current time.
+      switch (aggregateType) {
+      case MIN:
+        degreeValue = vertexDegrees.values().stream().reduce(Math::min).orElse(0).floatValue();
+        break;
+      case MAX:
+        degreeValue = vertexDegrees.values().stream().reduce(Math::max).orElse(0).floatValue();
+        break;
+      case AVG:
+        int sum = vertexDegrees.values().stream().reduce(Math::addExact).orElse(0);
+        degreeValue = (float) sum /  (float) numberOfVertices;
+        break;
+      default:
+        throw new IllegalArgumentException("Aggregate type not specified.");
+      }
+
+        //collect the results
+      collector.collect(new Tuple2<>(timePoint, degreeValue));
+
+    }
+  }
 }

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/functions/MapDegreesToInterval.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/functions/MapDegreesToInterval.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.operators.metric.functions;
+
+import org.apache.flink.api.common.functions.MapPartitionFunction;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.util.Collector;
+
+/**
+ * A map partition function that calculates the intervals in which the values stay the same
+ * by checking if the current value is the same as the previous one
+ *
+ */
+
+public class MapDegreesToInterval implements MapPartitionFunction<Tuple2<Long, Float>, Tuple3<Long, Long, Float>> {
+  @Override
+    public void mapPartition(Iterable<Tuple2<Long, Float>> values, Collector<Tuple3<Long, Long, Float>> out) {
+
+        //set starting values to null
+    Long startTimestamp = null;
+    Long endTimestamp = null;
+    Float value = null;
+    Boolean collected = false;
+
+    //loop through each tuple
+    for (Tuple2<Long, Float> tuple : values) {
+      if (startTimestamp == null) {
+        // First element in the group
+        startTimestamp = tuple.f0;
+        endTimestamp = tuple.f0;
+        value = tuple.f1;
+      } else {
+        if (!tuple.f1.equals(value)) {
+          // Value changed, emit the current interval and start a new one
+          out.collect(new Tuple3<>(startTimestamp, tuple.f0, value));
+          startTimestamp = tuple.f0;
+          endTimestamp = tuple.f0;
+          value = tuple.f1;
+          collected = true;
+        } else {
+          // Extend the current interval
+          endTimestamp = tuple.f0;
+          collected = false;
+        }
+      }
+    }
+    //check if the latest interval was collected, if not, collect it
+    //this happens when the last interval has the value 0
+    if (!collected) {
+      out.collect(new Tuple3<>(startTimestamp, endTimestamp, value));
+    }
+  }
+}

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/functions/TransformDeltaToAbsoluteDegreeTree.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/functions/TransformDeltaToAbsoluteDegreeTree.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.operators.metric.functions;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.functions.FunctionAnnotation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.gradoop.common.model.impl.id.GradoopId;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Replaces the degree tree, that just stores the degree changes for each time, with a degree tree that
+ * stores the actual degree of the vertex at that time.
+ */
+@FunctionAnnotation.ForwardedFields("f0")
+public class TransformDeltaToAbsoluteDegreeTree
+        implements MapFunction<Tuple2<GradoopId, TreeMap<Long, Integer>>,
+        Tuple2<GradoopId, TreeMap<Long, Integer>>> {
+
+    /**
+     * To reduce object instantiations.
+     */
+    private TreeMap<Long, Integer> absoluteDegreeTree;
+
+    @Override
+    public Tuple2<GradoopId, TreeMap<Long, Integer>> map(
+            Tuple2<GradoopId, TreeMap<Long, Integer>> vIdTreeMapTuple) throws Exception {
+        // init the degree and the temporal tree
+        int degree = 0;
+        absoluteDegreeTree = new TreeMap<>();
+
+        // aggregate the degrees
+        for (Map.Entry<Long, Integer> entry : vIdTreeMapTuple.f1.entrySet()) {
+            degree += entry.getValue();
+            absoluteDegreeTree.put(entry.getKey(), degree);
+        }
+        vIdTreeMapTuple.f1 = absoluteDegreeTree;
+        return vIdTreeMapTuple;
+    }
+}

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/functions/TransformDeltaToAbsoluteDegreeTree.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/metric/functions/TransformDeltaToAbsoluteDegreeTree.java
@@ -35,21 +35,21 @@ public class TransformDeltaToAbsoluteDegreeTree
     /**
      * To reduce object instantiations.
      */
-    private TreeMap<Long, Integer> absoluteDegreeTree;
+  private TreeMap<Long, Integer> absoluteDegreeTree;
 
-    @Override
+  @Override
     public Tuple2<GradoopId, TreeMap<Long, Integer>> map(
             Tuple2<GradoopId, TreeMap<Long, Integer>> vIdTreeMapTuple) throws Exception {
         // init the degree and the temporal tree
-        int degree = 0;
-        absoluteDegreeTree = new TreeMap<>();
+    int degree = 0;
+    absoluteDegreeTree = new TreeMap<>();
 
-        // aggregate the degrees
-        for (Map.Entry<Long, Integer> entry : vIdTreeMapTuple.f1.entrySet()) {
-            degree += entry.getValue();
-            absoluteDegreeTree.put(entry.getKey(), degree);
-        }
-        vIdTreeMapTuple.f1 = absoluteDegreeTree;
-        return vIdTreeMapTuple;
+    // aggregate the degrees
+    for (Map.Entry<Long, Integer> entry : vIdTreeMapTuple.f1.entrySet()) {
+      degree += entry.getValue();
+      absoluteDegreeTree.put(entry.getKey(), degree);
     }
+    vIdTreeMapTuple.f1 = absoluteDegreeTree;
+    return vIdTreeMapTuple;
+  }
 }

--- a/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/operators/metric/AvgDegreeEvolutionTest.java
+++ b/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/operators/metric/AvgDegreeEvolutionTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.operators.metric;
+
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.flink.model.impl.operators.sampling.functions.VertexDegree;
+import org.gradoop.temporal.model.api.TimeDimension;
+import org.gradoop.temporal.model.impl.TemporalGraph;
+import org.gradoop.temporal.util.TemporalGradoopTestBase;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class AvgDegreeEvolutionTest extends TemporalGradoopTestBase {
+    /**
+     * The expected in-degrees for each vertex label.
+     */
+    private static final List<Tuple3<Long, Long, Float>> EXPECTED_IN_DEGREES = new ArrayList<>();
+    /**
+     * The expected out-degrees for each vertex label.
+     */
+    private static final List<Tuple3<Long, Long, Float>> EXPECTED_OUT_DEGREES = new ArrayList<>();
+    /**
+     * The expected degrees for each vertex label.
+     */
+    private static final List<Tuple3<Long, Long, Float>> EXPECTED_BOTH_DEGREES = new ArrayList<>();
+
+    static {
+        // IN DEGREES
+        EXPECTED_IN_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0.0f));
+        EXPECTED_IN_DEGREES.add(new Tuple3<>(0L, 4L, 0.25f));
+        EXPECTED_IN_DEGREES.add(new Tuple3<>(4L, 5L, 1.0f));
+        EXPECTED_IN_DEGREES.add(new Tuple3<>(5L, 6L, 0.5f));
+        EXPECTED_IN_DEGREES.add(new Tuple3<>(6L, 7L, 0.5f));
+        EXPECTED_IN_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 0.25f));
+
+        // OUT DEGREES
+        EXPECTED_OUT_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0.0f));
+        EXPECTED_OUT_DEGREES.add(new Tuple3<>(0L, 4L, 0.25f));
+        EXPECTED_OUT_DEGREES.add(new Tuple3<>(4L, 5L, 1.0f));
+        EXPECTED_OUT_DEGREES.add(new Tuple3<>(5L, 6L, 0.5f));
+        EXPECTED_OUT_DEGREES.add(new Tuple3<>(6L, 7L, 0.5f));
+        EXPECTED_OUT_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 0.25f));
+
+        // DEGREES
+        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0.0f));
+        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(0L, 4L, 0.4f));
+        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(4L, 5L, 1.6f));
+        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(5L, 6L, 0.8f));
+        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(6L, 7L, 0.8f));
+        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 0.4f));
+    }
+
+    /**
+     * The degree type to test.
+     */
+    @Parameterized.Parameter(0)
+    public VertexDegree degreeType;
+
+    /**
+     * The expected degree evolution for the given type.
+     */
+    @Parameterized.Parameter(1)
+    public List<Tuple3<Long, Long, Float>> expectedDegrees;
+
+    /**
+     * The temporal graph to test the operator.
+     */
+    TemporalGraph testGraph;
+
+    /**
+     * The parameters to test the operator.
+     *
+     * @return three different vertex degree types with its corresponding expected degree evolution.
+     */
+    @Parameterized.Parameters(name = "Test degree type {0}.")
+    public static Iterable<Object[]> parameters() {
+        return Arrays.asList(
+                new Object[]{VertexDegree.IN, EXPECTED_IN_DEGREES},
+                new Object[]{VertexDegree.OUT, EXPECTED_OUT_DEGREES},
+                new Object[]{VertexDegree.BOTH, EXPECTED_BOTH_DEGREES});
+    }
+
+    /**
+     * Set up the test graph and create the id-label mapping.
+     *
+     * @throws Exception in case of an error
+     */
+    @Before
+    public void setUp() throws Exception {
+        testGraph = getTestGraphWithValues();
+        Collection<Tuple2<GradoopId, String>> idLabelCollection = new HashSet<>();
+        testGraph.getVertices().map(v -> new Tuple2<>(v.getId(), v.getLabel()))
+                .returns(new TypeHint<Tuple2<GradoopId, String>>() {
+                }).output(new LocalCollectionOutputFormat<>(idLabelCollection));
+        getExecutionEnvironment().execute();
+    }
+
+    /**
+     * Test the avg degree evolution operator.
+     *
+     * @throws Exception in case of an error.
+     */
+    @Test
+    public void testAvgDegree() throws Exception {
+        Collection<Tuple3<Long, Long, Float>> resultCollection = new ArrayList<>();
+
+        final DataSet<Tuple3<Long, Long, Float>> resultDataSet = testGraph
+                .callForValue(new AvgDegreeEvolution(degreeType, TimeDimension.VALID_TIME));
+
+        resultDataSet.output(new LocalCollectionOutputFormat<>(resultCollection));
+        getExecutionEnvironment().execute();
+
+        assertTrue(resultCollection.containsAll(expectedDegrees));
+        assertTrue(expectedDegrees.containsAll(resultCollection));
+    }
+}

--- a/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/operators/metric/AvgDegreeEvolutionTest.java
+++ b/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/operators/metric/AvgDegreeEvolutionTest.java
@@ -40,106 +40,102 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 public class AvgDegreeEvolutionTest extends TemporalGradoopTestBase {
-    /**
-     * The expected in-degrees for each vertex label.
-     */
-    private static final List<Tuple3<Long, Long, Float>> EXPECTED_IN_DEGREES = new ArrayList<>();
-    /**
-     * The expected out-degrees for each vertex label.
-     */
-    private static final List<Tuple3<Long, Long, Float>> EXPECTED_OUT_DEGREES = new ArrayList<>();
-    /**
-     * The expected degrees for each vertex label.
-     */
-    private static final List<Tuple3<Long, Long, Float>> EXPECTED_BOTH_DEGREES = new ArrayList<>();
+  /**
+   * The expected in-degrees for each vertex label.
+   */
+  private static final List<Tuple3<Long, Long, Float>> EXPECTED_IN_DEGREES = new ArrayList<>();
+  /**
+   * The expected out-degrees for each vertex label.
+   */
+  private static final List<Tuple3<Long, Long, Float>> EXPECTED_OUT_DEGREES = new ArrayList<>();
+  /**
+   * The expected degrees for each vertex label.
+   */
+  private static final List<Tuple3<Long, Long, Float>> EXPECTED_BOTH_DEGREES = new ArrayList<>();
 
-    static {
-        // IN DEGREES
-        EXPECTED_IN_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0.0f));
-        EXPECTED_IN_DEGREES.add(new Tuple3<>(0L, 4L, 0.25f));
-        EXPECTED_IN_DEGREES.add(new Tuple3<>(4L, 5L, 1.0f));
-        EXPECTED_IN_DEGREES.add(new Tuple3<>(5L, 6L, 0.5f));
-        EXPECTED_IN_DEGREES.add(new Tuple3<>(6L, 7L, 0.5f));
-        EXPECTED_IN_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 0.25f));
+  static {
+    // IN DEGREES
+    EXPECTED_IN_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0.0f));
+    EXPECTED_IN_DEGREES.add(new Tuple3<>(0L, 4L, 0.25f));
+    EXPECTED_IN_DEGREES.add(new Tuple3<>(4L, 5L, 1.0f));
+    EXPECTED_IN_DEGREES.add(new Tuple3<>(5L, 7L, 0.5f));
+    EXPECTED_IN_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 0.25f));
 
-        // OUT DEGREES
-        EXPECTED_OUT_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0.0f));
-        EXPECTED_OUT_DEGREES.add(new Tuple3<>(0L, 4L, 0.25f));
-        EXPECTED_OUT_DEGREES.add(new Tuple3<>(4L, 5L, 1.0f));
-        EXPECTED_OUT_DEGREES.add(new Tuple3<>(5L, 6L, 0.5f));
-        EXPECTED_OUT_DEGREES.add(new Tuple3<>(6L, 7L, 0.5f));
-        EXPECTED_OUT_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 0.25f));
+    // OUT DEGREES
+    EXPECTED_OUT_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0.0f));
+    EXPECTED_OUT_DEGREES.add(new Tuple3<>(0L, 4L, 0.25f));
+    EXPECTED_OUT_DEGREES.add(new Tuple3<>(4L, 5L, 1.0f));
+    EXPECTED_OUT_DEGREES.add(new Tuple3<>(5L, 7L, 0.5f));
+    EXPECTED_OUT_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 0.25f));
 
-        // DEGREES
-        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0.0f));
-        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(0L, 4L, 0.4f));
-        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(4L, 5L, 1.6f));
-        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(5L, 6L, 0.8f));
-        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(6L, 7L, 0.8f));
-        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 0.4f));
-    }
+    // DEGREES
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0.0f));
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(0L, 4L, 0.4f));
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(4L, 5L, 1.6f));
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(5L, 7L, 0.8f));
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 0.4f));
+  }
 
     /**
      * The degree type to test.
      */
-    @Parameterized.Parameter(0)
-    public VertexDegree degreeType;
+  @Parameterized.Parameter(0)
+  public VertexDegree degreeType;
 
     /**
      * The expected degree evolution for the given type.
      */
-    @Parameterized.Parameter(1)
-    public List<Tuple3<Long, Long, Float>> expectedDegrees;
+  @Parameterized.Parameter(1)
+  public List<Tuple3<Long, Long, Float>> expectedDegrees;
 
     /**
      * The temporal graph to test the operator.
      */
-    TemporalGraph testGraph;
+  TemporalGraph testGraph;
 
     /**
      * The parameters to test the operator.
      *
      * @return three different vertex degree types with its corresponding expected degree evolution.
      */
-    @Parameterized.Parameters(name = "Test degree type {0}.")
-    public static Iterable<Object[]> parameters() {
-        return Arrays.asList(
-                new Object[]{VertexDegree.IN, EXPECTED_IN_DEGREES},
-                new Object[]{VertexDegree.OUT, EXPECTED_OUT_DEGREES},
-                new Object[]{VertexDegree.BOTH, EXPECTED_BOTH_DEGREES});
-    }
+  @Parameterized.Parameters(name = "Test degree type {0}.")
+  public static Iterable<Object[]> parameters() {
+    return Arrays.asList(
+            new Object[]{VertexDegree.IN, EXPECTED_IN_DEGREES},
+            new Object[]{VertexDegree.OUT, EXPECTED_OUT_DEGREES},
+            new Object[]{VertexDegree.BOTH, EXPECTED_BOTH_DEGREES});
+  }
 
-    /**
-     * Set up the test graph and create the id-label mapping.
-     *
-     * @throws Exception in case of an error
-     */
-    @Before
-    public void setUp() throws Exception {
-        testGraph = getTestGraphWithValues();
-        Collection<Tuple2<GradoopId, String>> idLabelCollection = new HashSet<>();
-        testGraph.getVertices().map(v -> new Tuple2<>(v.getId(), v.getLabel()))
-                .returns(new TypeHint<Tuple2<GradoopId, String>>() {
-                }).output(new LocalCollectionOutputFormat<>(idLabelCollection));
-        getExecutionEnvironment().execute();
-    }
+  /**
+   * Set up the test graph and create the id-label mapping.
+   *
+   * @throws Exception in case of an error
+   */
+  @Before
+  public void setUp() throws Exception {
+    testGraph = getTestGraphWithValues();
+    Collection<Tuple2<GradoopId, String>> idLabelCollection = new HashSet<>();
+    testGraph.getVertices().map(v -> new Tuple2<>(v.getId(), v.getLabel()))
+            .returns(new TypeHint<Tuple2<GradoopId, String>>() {
+            }).output(new LocalCollectionOutputFormat<>(idLabelCollection));
+    getExecutionEnvironment().execute();
+  }
 
-    /**
-     * Test the avg degree evolution operator.
-     *
-     * @throws Exception in case of an error.
-     */
-    @Test
-    public void testAvgDegree() throws Exception {
-        Collection<Tuple3<Long, Long, Float>> resultCollection = new ArrayList<>();
+  /**
+   * Test the avg degree evolution operator.
+   *
+   * @throws Exception in case of an error.
+   */
+  @Test
+  public void testAvgDegree() throws Exception {
+    Collection<Tuple3<Long, Long, Float>> resultCollection = new ArrayList<>();
+    final DataSet<Tuple3<Long, Long, Float>> resultDataSet = testGraph
+            .callForValue(new AvgDegreeEvolution(degreeType, TimeDimension.VALID_TIME));
 
-        final DataSet<Tuple3<Long, Long, Float>> resultDataSet = testGraph
-                .callForValue(new AvgDegreeEvolution(degreeType, TimeDimension.VALID_TIME));
+    resultDataSet.output(new LocalCollectionOutputFormat<>(resultCollection));
+    getExecutionEnvironment().execute();
 
-        resultDataSet.output(new LocalCollectionOutputFormat<>(resultCollection));
-        getExecutionEnvironment().execute();
-
-        assertTrue(resultCollection.containsAll(expectedDegrees));
-        assertTrue(expectedDegrees.containsAll(resultCollection));
-    }
+    assertTrue(resultCollection.containsAll(expectedDegrees));
+    assertTrue(expectedDegrees.containsAll(resultCollection));
+  }
 }

--- a/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/operators/metric/MaxDegreeEvolutionTest.java
+++ b/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/operators/metric/MaxDegreeEvolutionTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.operators.metric;
+
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.flink.model.impl.operators.sampling.functions.VertexDegree;
+import org.gradoop.temporal.model.api.TimeDimension;
+import org.gradoop.temporal.model.impl.TemporalGraph;
+import org.gradoop.temporal.util.TemporalGradoopTestBase;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class MaxDegreeEvolutionTest extends TemporalGradoopTestBase {
+    /**
+     * The expected in-degrees for each vertex label.
+     */
+    private static final List<Tuple3<Long, Long, Float>> EXPECTED_IN_DEGREES = new ArrayList<>();
+    /**
+     * The expected out-degrees for each vertex label.
+     */
+    private static final List<Tuple3<Long, Long, Float>> EXPECTED_OUT_DEGREES = new ArrayList<>();
+    /**
+     * The expected degrees for each vertex label.
+     */
+    private static final List<Tuple3<Long, Long, Float>> EXPECTED_BOTH_DEGREES = new ArrayList<>();
+
+    static {
+        // IN DEGREES
+        EXPECTED_IN_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0f));
+        EXPECTED_IN_DEGREES.add(new Tuple3<>(0L, 4L, 1f));
+        EXPECTED_IN_DEGREES.add(new Tuple3<>(4L, 5L, 2f));
+        EXPECTED_IN_DEGREES.add(new Tuple3<>(5L, 6L, 1f));
+        EXPECTED_IN_DEGREES.add(new Tuple3<>(6L, 7L, 1f));
+        EXPECTED_IN_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 1f));
+
+        // OUT DEGREES
+        EXPECTED_OUT_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0f));
+        EXPECTED_OUT_DEGREES.add(new Tuple3<>(0L, 4L, 1f));
+        EXPECTED_OUT_DEGREES.add(new Tuple3<>(4L, 5L, 2f));
+        EXPECTED_OUT_DEGREES.add(new Tuple3<>(5L, 6L, 1f));
+        EXPECTED_OUT_DEGREES.add(new Tuple3<>(6L, 7L, 1f));
+        EXPECTED_OUT_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 1f));
+
+        // DEGREES
+        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0f));
+        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(0L, 4L, 1f));
+        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(4L, 5L, 3f));
+        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(5L, 6L, 1f));
+        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(6L, 7L, 2f));
+        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 1f));
+    }
+
+    /**
+     * The degree type to test.
+     */
+    @Parameterized.Parameter(0)
+    public VertexDegree degreeType;
+
+    /**
+     * The expected degree evolution for the given type.
+     */
+    @Parameterized.Parameter(1)
+    public List<Tuple3<Long, Long, Float>> expectedDegrees;
+
+    /**
+     * The temporal graph to test the operator.
+     */
+    TemporalGraph testGraph;
+
+    /**
+     * The parameters to test the operator.
+     *
+     * @return three different vertex degree types with its corresponding expected degree evolution.
+     */
+    @Parameterized.Parameters(name = "Test degree type {0}.")
+    public static Iterable<Object[]> parameters() {
+        return Arrays.asList(
+                new Object[]{VertexDegree.IN, EXPECTED_IN_DEGREES},
+                new Object[]{VertexDegree.OUT, EXPECTED_OUT_DEGREES},
+                new Object[]{VertexDegree.BOTH, EXPECTED_BOTH_DEGREES});
+    }
+
+    /**
+     * Set up the test graph and create the id-label mapping.
+     *
+     * @throws Exception in case of an error
+     */
+    @Before
+    public void setUp() throws Exception {
+        testGraph = getTestGraphWithValues();
+        Collection<Tuple2<GradoopId, String>> idLabelCollection = new HashSet<>();
+        testGraph.getVertices().map(v -> new Tuple2<>(v.getId(), v.getLabel()))
+                .returns(new TypeHint<Tuple2<GradoopId, String>>() {
+                }).output(new LocalCollectionOutputFormat<>(idLabelCollection));
+        getExecutionEnvironment().execute();
+    }
+
+    /**
+     * Test the max degree evolution operator.
+     *
+     * @throws Exception in case of an error.
+     */
+    @Test
+    public void testMaxDegree() throws Exception {
+        Collection<Tuple3<Long, Long, Float>> resultCollection = new ArrayList<>();
+
+        final DataSet<Tuple3<Long, Long, Float>> resultDataSet = testGraph
+                .callForValue(new MaxDegreeEvolution(degreeType, TimeDimension.VALID_TIME));
+
+        resultDataSet.output(new LocalCollectionOutputFormat<>(resultCollection));
+        getExecutionEnvironment().execute();
+
+        assertTrue(resultCollection.containsAll(expectedDegrees));
+        assertTrue(expectedDegrees.containsAll(resultCollection));
+    }
+}

--- a/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/operators/metric/MaxDegreeEvolutionTest.java
+++ b/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/operators/metric/MaxDegreeEvolutionTest.java
@@ -43,103 +43,99 @@ public class MaxDegreeEvolutionTest extends TemporalGradoopTestBase {
     /**
      * The expected in-degrees for each vertex label.
      */
-    private static final List<Tuple3<Long, Long, Float>> EXPECTED_IN_DEGREES = new ArrayList<>();
+  private static final List<Tuple3<Long, Long, Float>> EXPECTED_IN_DEGREES = new ArrayList<>();
     /**
      * The expected out-degrees for each vertex label.
      */
-    private static final List<Tuple3<Long, Long, Float>> EXPECTED_OUT_DEGREES = new ArrayList<>();
+  private static final List<Tuple3<Long, Long, Float>> EXPECTED_OUT_DEGREES = new ArrayList<>();
     /**
      * The expected degrees for each vertex label.
      */
-    private static final List<Tuple3<Long, Long, Float>> EXPECTED_BOTH_DEGREES = new ArrayList<>();
+  private static final List<Tuple3<Long, Long, Float>> EXPECTED_BOTH_DEGREES = new ArrayList<>();
 
-    static {
-        // IN DEGREES
-        EXPECTED_IN_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0f));
-        EXPECTED_IN_DEGREES.add(new Tuple3<>(0L, 4L, 1f));
-        EXPECTED_IN_DEGREES.add(new Tuple3<>(4L, 5L, 2f));
-        EXPECTED_IN_DEGREES.add(new Tuple3<>(5L, 6L, 1f));
-        EXPECTED_IN_DEGREES.add(new Tuple3<>(6L, 7L, 1f));
-        EXPECTED_IN_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 1f));
+  static {
+    // IN DEGREES
+    EXPECTED_IN_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0f));
+    EXPECTED_IN_DEGREES.add(new Tuple3<>(0L, 4L, 1f));
+    EXPECTED_IN_DEGREES.add(new Tuple3<>(4L, 5L, 2f));
+    EXPECTED_IN_DEGREES.add(new Tuple3<>(5L, Long.MAX_VALUE, 1f));
 
-        // OUT DEGREES
-        EXPECTED_OUT_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0f));
-        EXPECTED_OUT_DEGREES.add(new Tuple3<>(0L, 4L, 1f));
-        EXPECTED_OUT_DEGREES.add(new Tuple3<>(4L, 5L, 2f));
-        EXPECTED_OUT_DEGREES.add(new Tuple3<>(5L, 6L, 1f));
-        EXPECTED_OUT_DEGREES.add(new Tuple3<>(6L, 7L, 1f));
-        EXPECTED_OUT_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 1f));
+    // OUT DEGREES
+    EXPECTED_OUT_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0f));
+    EXPECTED_OUT_DEGREES.add(new Tuple3<>(0L, 4L, 1f));
+    EXPECTED_OUT_DEGREES.add(new Tuple3<>(4L, 5L, 2f));
+    EXPECTED_OUT_DEGREES.add(new Tuple3<>(5L, Long.MAX_VALUE, 1f));
 
-        // DEGREES
-        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0f));
-        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(0L, 4L, 1f));
-        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(4L, 5L, 3f));
-        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(5L, 6L, 1f));
-        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(6L, 7L, 2f));
-        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 1f));
-    }
+    // DEGREES
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0f));
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(0L, 4L, 1f));
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(4L, 5L, 3f));
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(5L, 6L, 1f));
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(6L, 7L, 2f));
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 1f));
+  }
 
     /**
      * The degree type to test.
      */
-    @Parameterized.Parameter(0)
+  @Parameterized.Parameter(0)
     public VertexDegree degreeType;
 
     /**
      * The expected degree evolution for the given type.
      */
-    @Parameterized.Parameter(1)
+  @Parameterized.Parameter(1)
     public List<Tuple3<Long, Long, Float>> expectedDegrees;
 
     /**
      * The temporal graph to test the operator.
      */
-    TemporalGraph testGraph;
+  TemporalGraph testGraph;
 
     /**
      * The parameters to test the operator.
      *
      * @return three different vertex degree types with its corresponding expected degree evolution.
      */
-    @Parameterized.Parameters(name = "Test degree type {0}.")
+  @Parameterized.Parameters(name = "Test degree type {0}.")
     public static Iterable<Object[]> parameters() {
-        return Arrays.asList(
+    return Arrays.asList(
                 new Object[]{VertexDegree.IN, EXPECTED_IN_DEGREES},
                 new Object[]{VertexDegree.OUT, EXPECTED_OUT_DEGREES},
                 new Object[]{VertexDegree.BOTH, EXPECTED_BOTH_DEGREES});
-    }
+  }
 
     /**
      * Set up the test graph and create the id-label mapping.
      *
      * @throws Exception in case of an error
      */
-    @Before
+  @Before
     public void setUp() throws Exception {
-        testGraph = getTestGraphWithValues();
-        Collection<Tuple2<GradoopId, String>> idLabelCollection = new HashSet<>();
-        testGraph.getVertices().map(v -> new Tuple2<>(v.getId(), v.getLabel()))
-                .returns(new TypeHint<Tuple2<GradoopId, String>>() {
-                }).output(new LocalCollectionOutputFormat<>(idLabelCollection));
-        getExecutionEnvironment().execute();
-    }
+    testGraph = getTestGraphWithValues();
+    Collection<Tuple2<GradoopId, String>> idLabelCollection = new HashSet<>();
+    testGraph.getVertices().map(v -> new Tuple2<>(v.getId(), v.getLabel()))
+            .returns(new TypeHint<Tuple2<GradoopId, String>>() {
+            }).output(new LocalCollectionOutputFormat<>(idLabelCollection));
+    getExecutionEnvironment().execute();
+  }
 
     /**
      * Test the max degree evolution operator.
      *
      * @throws Exception in case of an error.
      */
-    @Test
-    public void testMaxDegree() throws Exception {
-        Collection<Tuple3<Long, Long, Float>> resultCollection = new ArrayList<>();
+  @Test
+  public void testMaxDegree() throws Exception {
+    Collection<Tuple3<Long, Long, Float>> resultCollection = new ArrayList<>();
 
-        final DataSet<Tuple3<Long, Long, Float>> resultDataSet = testGraph
-                .callForValue(new MaxDegreeEvolution(degreeType, TimeDimension.VALID_TIME));
+    final DataSet<Tuple3<Long, Long, Float>> resultDataSet = testGraph
+            .callForValue(new MaxDegreeEvolution(degreeType, TimeDimension.VALID_TIME));
 
-        resultDataSet.output(new LocalCollectionOutputFormat<>(resultCollection));
-        getExecutionEnvironment().execute();
+    resultDataSet.output(new LocalCollectionOutputFormat<>(resultCollection));
+    getExecutionEnvironment().execute();
 
-        assertTrue(resultCollection.containsAll(expectedDegrees));
-        assertTrue(expectedDegrees.containsAll(resultCollection));
-    }
+    assertTrue(resultCollection.containsAll(expectedDegrees));
+    assertTrue(expectedDegrees.containsAll(resultCollection));
+  }
 }

--- a/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/operators/metric/MinDegreeEvolutionTest.java
+++ b/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/operators/metric/MinDegreeEvolutionTest.java
@@ -40,106 +40,120 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 public class MinDegreeEvolutionTest extends TemporalGradoopTestBase {
-    /**
-     * The expected in-degrees for each vertex label.
-     */
-    private static final List<Tuple3<Long, Long, Float>> EXPECTED_IN_DEGREES = new ArrayList<>();
-    /**
-     * The expected out-degrees for each vertex label.
-     */
-    private static final List<Tuple3<Long, Long, Float>> EXPECTED_OUT_DEGREES = new ArrayList<>();
-    /**
-     * The expected degrees for each vertex label.
-     */
-    private static final List<Tuple3<Long, Long, Float>> EXPECTED_BOTH_DEGREES = new ArrayList<>();
+  /**
+   * The expected in-degrees for each vertex label.
+   */
+  private static final List<Tuple3<Long, Long, Float>> EXPECTED_IN_DEGREES = new ArrayList<>();
+  /**
+   * The expected out-degrees for each vertex label.
+   */
+  private static final List<Tuple3<Long, Long, Float>> EXPECTED_OUT_DEGREES = new ArrayList<>();
+  /**
+   * The expected degrees for each vertex label.
+   */
+  private static final List<Tuple3<Long, Long, Float>> EXPECTED_BOTH_DEGREES = new ArrayList<>();
 
-    static {
-        // IN DEGREES
-        EXPECTED_IN_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0f));
-        EXPECTED_IN_DEGREES.add(new Tuple3<>(0L, 4L, 0f));
-        EXPECTED_IN_DEGREES.add(new Tuple3<>(4L, 5L, 0f));
-        EXPECTED_IN_DEGREES.add(new Tuple3<>(5L, 6L, 0f));
-        EXPECTED_IN_DEGREES.add(new Tuple3<>(6L, 7L, 0f));
-        EXPECTED_IN_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 0f));
+  static {
+    // IN DEGREES
+    EXPECTED_IN_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, Long.MAX_VALUE, 0f));
 
-        // OUT DEGREES
-        EXPECTED_OUT_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0f));
-        EXPECTED_OUT_DEGREES.add(new Tuple3<>(0L, 4L, 0f));
-        EXPECTED_OUT_DEGREES.add(new Tuple3<>(4L, 5L, 0f));
-        EXPECTED_OUT_DEGREES.add(new Tuple3<>(5L, 6L, 0f));
-        EXPECTED_OUT_DEGREES.add(new Tuple3<>(6L, 7L, 0f));
-        EXPECTED_OUT_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 0f));
+    // OUT DEGREES
 
-        // DEGREES
-        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0f));
-        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(0L, 4L, 0f));
-        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(4L, 5L, 1f));
-        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(5L, 6L, 0f));
-        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(6L, 7L, 0f));
-        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 0f));
-    }
+    EXPECTED_OUT_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, Long.MAX_VALUE, 0f));
+
+
+    // DEGREES
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 4L, 0f));
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(4L, 5L, 1f));
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(5L, Long.MAX_VALUE, 0f));
+    /*
+    EXPECTED_IN_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0f));
+    EXPECTED_IN_DEGREES.add(new Tuple3<>(0L, 4L, 0f));
+    EXPECTED_IN_DEGREES.add(new Tuple3<>(4L, 5L, 0f));
+    EXPECTED_IN_DEGREES.add(new Tuple3<>(5L, 6L, 0f));
+    EXPECTED_IN_DEGREES.add(new Tuple3<>(6L, 7L, 0f));
+    EXPECTED_IN_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 0f));
+
+    // OUT DEGREES
+    EXPECTED_OUT_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0f));
+    EXPECTED_OUT_DEGREES.add(new Tuple3<>(0L, 4L, 0f));
+    EXPECTED_OUT_DEGREES.add(new Tuple3<>(4L, 5L, 0f));
+    EXPECTED_OUT_DEGREES.add(new Tuple3<>(5L, 6L, 0f));
+    EXPECTED_OUT_DEGREES.add(new Tuple3<>(6L, 7L, 0f));
+    EXPECTED_OUT_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 0f));
+
+    // DEGREES
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0f));
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(0L, 4L, 0f));
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(4L, 5L, 1f));
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(5L, 6L, 0f));
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(6L, 7L, 0f));
+    EXPECTED_BOTH_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 0f));
+    */
+
+  }
 
     /**
      * The degree type to test.
      */
-    @Parameterized.Parameter(0)
+  @Parameterized.Parameter(0)
     public VertexDegree degreeType;
 
     /**
      * The expected degree evolution for the given type.
      */
-    @Parameterized.Parameter(1)
+  @Parameterized.Parameter(1)
     public List<Tuple3<Long, Long, Float>> expectedDegrees;
 
     /**
      * The temporal graph to test the operator.
      */
-    TemporalGraph testGraph;
+  TemporalGraph testGraph;
 
     /**
      * The parameters to test the operator.
      *
      * @return three different vertex degree types with its corresponding expected degree evolution.
      */
-    @Parameterized.Parameters(name = "Test degree type {0}.")
-    public static Iterable<Object[]> parameters() {
-        return Arrays.asList(
+  @Parameterized.Parameters(name = "Test degree type {0}.")
+  public static Iterable<Object[]> parameters() {
+    return Arrays.asList(
                 new Object[]{VertexDegree.IN, EXPECTED_IN_DEGREES},
                 new Object[]{VertexDegree.OUT, EXPECTED_OUT_DEGREES},
                 new Object[]{VertexDegree.BOTH, EXPECTED_BOTH_DEGREES});
-    }
+  }
 
     /**
      * Set up the test graph and create the id-label mapping.
      *
      * @throws Exception in case of an error
      */
-    @Before
-    public void setUp() throws Exception {
-        testGraph = getTestGraphWithValues();
-        Collection<Tuple2<GradoopId, String>> idLabelCollection = new HashSet<>();
-        testGraph.getVertices().map(v -> new Tuple2<>(v.getId(), v.getLabel()))
-                .returns(new TypeHint<Tuple2<GradoopId, String>>() {
-                }).output(new LocalCollectionOutputFormat<>(idLabelCollection));
-        getExecutionEnvironment().execute();
-    }
+  @Before
+  public void setUp() throws Exception {
+    testGraph = getTestGraphWithValues();
+    Collection<Tuple2<GradoopId, String>> idLabelCollection = new HashSet<>();
+    testGraph.getVertices().map(v -> new Tuple2<>(v.getId(), v.getLabel()))
+            .returns(new TypeHint<Tuple2<GradoopId, String>>() {
+            }).output(new LocalCollectionOutputFormat<>(idLabelCollection));
+    getExecutionEnvironment().execute();
+  }
 
     /**
      * Test the min degree evolution operator.
      *
      * @throws Exception in case of an error.
      */
-    @Test
-    public void testMinDegree() throws Exception {
-        Collection<Tuple3<Long, Long, Float>> resultCollection = new ArrayList<>();
+  @Test
+  public void testMinDegree() throws Exception {
+    Collection<Tuple3<Long, Long, Float>> resultCollection = new ArrayList<>();
 
-        final DataSet<Tuple3<Long, Long, Float>> resultDataSet = testGraph
-                .callForValue(new MinDegreeEvolution(degreeType, TimeDimension.VALID_TIME));
+    final DataSet<Tuple3<Long, Long, Float>> resultDataSet = testGraph
+            .callForValue(new MinDegreeEvolution(degreeType, TimeDimension.VALID_TIME));
 
-        resultDataSet.output(new LocalCollectionOutputFormat<>(resultCollection));
-        getExecutionEnvironment().execute();
+    resultDataSet.output(new LocalCollectionOutputFormat<>(resultCollection));
+    getExecutionEnvironment().execute();
 
-        assertTrue(resultCollection.containsAll(expectedDegrees));
-        assertTrue(expectedDegrees.containsAll(resultCollection));
-    }
+    assertTrue(resultCollection.containsAll(expectedDegrees));
+    assertTrue(expectedDegrees.containsAll(resultCollection));
+  }
 }

--- a/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/operators/metric/MinDegreeEvolutionTest.java
+++ b/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/operators/metric/MinDegreeEvolutionTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.operators.metric;
+
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.flink.model.impl.operators.sampling.functions.VertexDegree;
+import org.gradoop.temporal.model.api.TimeDimension;
+import org.gradoop.temporal.model.impl.TemporalGraph;
+import org.gradoop.temporal.util.TemporalGradoopTestBase;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class MinDegreeEvolutionTest extends TemporalGradoopTestBase {
+    /**
+     * The expected in-degrees for each vertex label.
+     */
+    private static final List<Tuple3<Long, Long, Float>> EXPECTED_IN_DEGREES = new ArrayList<>();
+    /**
+     * The expected out-degrees for each vertex label.
+     */
+    private static final List<Tuple3<Long, Long, Float>> EXPECTED_OUT_DEGREES = new ArrayList<>();
+    /**
+     * The expected degrees for each vertex label.
+     */
+    private static final List<Tuple3<Long, Long, Float>> EXPECTED_BOTH_DEGREES = new ArrayList<>();
+
+    static {
+        // IN DEGREES
+        EXPECTED_IN_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0f));
+        EXPECTED_IN_DEGREES.add(new Tuple3<>(0L, 4L, 0f));
+        EXPECTED_IN_DEGREES.add(new Tuple3<>(4L, 5L, 0f));
+        EXPECTED_IN_DEGREES.add(new Tuple3<>(5L, 6L, 0f));
+        EXPECTED_IN_DEGREES.add(new Tuple3<>(6L, 7L, 0f));
+        EXPECTED_IN_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 0f));
+
+        // OUT DEGREES
+        EXPECTED_OUT_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0f));
+        EXPECTED_OUT_DEGREES.add(new Tuple3<>(0L, 4L, 0f));
+        EXPECTED_OUT_DEGREES.add(new Tuple3<>(4L, 5L, 0f));
+        EXPECTED_OUT_DEGREES.add(new Tuple3<>(5L, 6L, 0f));
+        EXPECTED_OUT_DEGREES.add(new Tuple3<>(6L, 7L, 0f));
+        EXPECTED_OUT_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 0f));
+
+        // DEGREES
+        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(Long.MIN_VALUE, 0L, 0f));
+        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(0L, 4L, 0f));
+        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(4L, 5L, 1f));
+        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(5L, 6L, 0f));
+        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(6L, 7L, 0f));
+        EXPECTED_BOTH_DEGREES.add(new Tuple3<>(7L, Long.MAX_VALUE, 0f));
+    }
+
+    /**
+     * The degree type to test.
+     */
+    @Parameterized.Parameter(0)
+    public VertexDegree degreeType;
+
+    /**
+     * The expected degree evolution for the given type.
+     */
+    @Parameterized.Parameter(1)
+    public List<Tuple3<Long, Long, Float>> expectedDegrees;
+
+    /**
+     * The temporal graph to test the operator.
+     */
+    TemporalGraph testGraph;
+
+    /**
+     * The parameters to test the operator.
+     *
+     * @return three different vertex degree types with its corresponding expected degree evolution.
+     */
+    @Parameterized.Parameters(name = "Test degree type {0}.")
+    public static Iterable<Object[]> parameters() {
+        return Arrays.asList(
+                new Object[]{VertexDegree.IN, EXPECTED_IN_DEGREES},
+                new Object[]{VertexDegree.OUT, EXPECTED_OUT_DEGREES},
+                new Object[]{VertexDegree.BOTH, EXPECTED_BOTH_DEGREES});
+    }
+
+    /**
+     * Set up the test graph and create the id-label mapping.
+     *
+     * @throws Exception in case of an error
+     */
+    @Before
+    public void setUp() throws Exception {
+        testGraph = getTestGraphWithValues();
+        Collection<Tuple2<GradoopId, String>> idLabelCollection = new HashSet<>();
+        testGraph.getVertices().map(v -> new Tuple2<>(v.getId(), v.getLabel()))
+                .returns(new TypeHint<Tuple2<GradoopId, String>>() {
+                }).output(new LocalCollectionOutputFormat<>(idLabelCollection));
+        getExecutionEnvironment().execute();
+    }
+
+    /**
+     * Test the min degree evolution operator.
+     *
+     * @throws Exception in case of an error.
+     */
+    @Test
+    public void testMinDegree() throws Exception {
+        Collection<Tuple3<Long, Long, Float>> resultCollection = new ArrayList<>();
+
+        final DataSet<Tuple3<Long, Long, Float>> resultDataSet = testGraph
+                .callForValue(new MinDegreeEvolution(degreeType, TimeDimension.VALID_TIME));
+
+        resultDataSet.output(new LocalCollectionOutputFormat<>(resultCollection));
+        getExecutionEnvironment().execute();
+
+        assertTrue(resultCollection.containsAll(expectedDegrees));
+        assertTrue(expectedDegrees.containsAll(resultCollection));
+    }
+}


### PR DESCRIPTION
Added the operators to calculate the min/max/avg degree evolution for a temporal graph. 

## Description
A graph to value operator that calculates the min/max/avg degree of all vertices of a temporal graph. The result is a dataset of Tuple3<Long,Long,Float> where the tuple positions represent the following:
  1. the interval start
  2.   the interval end
  3.  the aggregated value for that interval


## Related Issue
#1559

## How Has This Been Tested?
Unit Tests with a test graph

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if necessary).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I ran a spell checker.

