### PR TITLE
Bugfix Snapshot Release + Bump deprecated github action versions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,7 +6,7 @@ on:
     - cron: '00 23 * * SUN'
 
 jobs:
-  deploy:
+  deploy-gh-pages:
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,14 +11,14 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: develop
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4.2.1
         with:
-          java-version: 1.8
+          java-version: 8
 
       - name: Build Project
         run: mvn clean install

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-java@v4.2.1
         with:
           java-version: 8
+          distribution: zulu
 
       - name: Build Project
         run: mvn clean install

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Hadoop winutils (Windows)
       if: matrix.os == 'windows-latest'
       run: |
@@ -24,9 +24,9 @@ jobs:
         echo "HADOOP_HOME=C:\winutils\hadoop-3.2.2" >> $env:GITHUB_ENV
         echo "PATH=$env:PATH;$env:HADOOP_HOME\bin" >> $env:GITHUB_ENV
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4.2.1
       with:
-        java-version: 1.8
+        java-version: 8
     - name: Build with Maven
       run: |
         mvn clean install -DskipTests --no-transfer-progress -DtrimStackTrace=false

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Hadoop winutils (Windows)

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,6 +27,7 @@ jobs:
       uses: actions/setup-java@v4.2.1
       with:
         java-version: 8
+        distribution: zulu
     - name: Build with Maven
       run: |
         mvn clean install -DskipTests --no-transfer-progress -DtrimStackTrace=false

--- a/.github/workflows/release-snaphot.yml
+++ b/.github/workflows/release-snaphot.yml
@@ -1,6 +1,6 @@
 name: release-snapshot
 
-on: workflow-dispatch
+on: workflow_dispatch
   # Run weekly on sunday at 22:00 UTC (arbitrary)
 #  schedule:
 #    - cron: '00 22 * * SUN'

--- a/.github/workflows/release-snaphot.yml
+++ b/.github/workflows/release-snaphot.yml
@@ -1,9 +1,9 @@
 name: release-snapshot
 
-on: workflow_dispatch
+on:
   # Run weekly on sunday at 22:00 UTC (arbitrary)
-#  schedule:
-#    - cron: '00 22 * * SUN'
+  schedule:
+    - cron: '00 22 * * SUN'
 
 jobs:
   release:
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: '#1598_github_actions_upgrade'
+          ref: develop
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v4.2.1

--- a/.github/workflows/release-snaphot.yml
+++ b/.github/workflows/release-snaphot.yml
@@ -11,19 +11,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: develop
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4.2.1
         with:
-          java-version: 1.8
+          java-version: 8
 
       - name: Set up Apache Maven Central
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4.2.1
         with: # running setup-java again overwrites the settings.xml
-          java-version: 1.8
+          java-version: 8
           server-id: release_artifacts_gradoop
           server-username: OSSRH_USERNAME
           server-password: OSSRH_PASSWORD

--- a/.github/workflows/release-snaphot.yml
+++ b/.github/workflows/release-snaphot.yml
@@ -19,13 +19,13 @@ jobs:
         uses: actions/setup-java@v4.2.1
         with:
           java-version: 8
-          distribution: oracle
+          distribution: zulu
 
       - name: Set up Apache Maven Central
         uses: actions/setup-java@v4.2.1
         with: # running setup-java again overwrites the settings.xml
           java-version: 8
-          distribution: oracle
+          distribution: zulu
           server-id: release_artifacts_gradoop
           server-username: OSSRH_USERNAME
           server-password: OSSRH_PASSWORD

--- a/.github/workflows/release-snaphot.yml
+++ b/.github/workflows/release-snaphot.yml
@@ -1,9 +1,9 @@
 name: release-snapshot
 
-on:
+on: workflow-dispatch
   # Run weekly on sunday at 22:00 UTC (arbitrary)
-  schedule:
-    - cron: '00 22 * * SUN'
+#  schedule:
+#    - cron: '00 22 * * SUN'
 
 jobs:
   release:

--- a/.github/workflows/release-snaphot.yml
+++ b/.github/workflows/release-snaphot.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: develop
+          ref: '#1598_github_actions_upgrade'
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v4.2.1

--- a/.github/workflows/release-snaphot.yml
+++ b/.github/workflows/release-snaphot.yml
@@ -19,11 +19,13 @@ jobs:
         uses: actions/setup-java@v4.2.1
         with:
           java-version: 8
+          distribution: oracle
 
       - name: Set up Apache Maven Central
         uses: actions/setup-java@v4.2.1
         with: # running setup-java again overwrites the settings.xml
           java-version: 8
+          distribution: oracle
           server-id: release_artifacts_gradoop
           server-username: OSSRH_USERNAME
           server-password: OSSRH_PASSWORD

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,7 @@
         <dep.jsonassert.version>1.2.3</dep.jsonassert.version>
         <dep.kryo.version>4.0.2</dep.kryo.version>
         <dep.flink-shaded.version>2.6.5-9.0</dep.flink-shaded.version>
+        <dep.protoc.version>3.0.0</dep.protoc.version>
         <dep.parquet.version>1.12.0</dep.parquet.version>
         <dep.log4j.version>2.17.1</dep.log4j.version>
         <dep.mockito.version>2.21.0</dep.mockito.version>
@@ -294,7 +295,7 @@
                     <artifactId>protoc-jar-maven-plugin</artifactId>
                     <version>${plugin.maven-protoc.version}</version>
                     <configuration>
-                        <protocVersion>3.0.0</protocVersion>
+                        <protocVersion>${dep.protoc.version}</protocVersion>
                         <inputDirectories>
                             <include>src/main/proto</include>
                         </inputDirectories>

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         </site>
         <snapshotRepository>
             <id>release_artifacts_gradoop</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/org/gradoop</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
             <id>release_artifacts_gradoop</id>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. Snapshot release was creating a group id like `org.gradoop.org.gradoop` because a wrong suffic in the sonatype url in parent pom.xml. I have fixed this.
2. Some of the versions used in github actions were deprecated. I cahnged them to the newest version.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1598 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Now the snapshot release will work properly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
In my local repo with manual triggering the snapshot.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if necessary).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I ran a spell checker.

