### PR TITLE
#1601 Add Single Source Earliest Arrival Operator

### DIFF
--- a/gradoop-checkstyle/src/main/resources/gradoop/checkstyle-suppressions.xml
+++ b/gradoop-checkstyle/src/main/resources/gradoop/checkstyle-suppressions.xml
@@ -17,6 +17,9 @@
   <suppress checks="IllegalCatch"
             files="PrintTableSink"
             lines="90-100"/>
+  <suppress checks="IllegalCatch"
+            files="TemporalGellyAlgorithm.java"
+            lines="85-90"/>
   <suppress checks="IllegalImport"
             files="Bytes.java"
             lines="20"/>

--- a/gradoop-examples/gradoop-examples-temporal/src/main/java/org/gradoop/examples/singleSourceEarliestArrival/SingleSourceEarliestArrivalExample.java
+++ b/gradoop-examples/gradoop-examples-temporal/src/main/java/org/gradoop/examples/singleSourceEarliestArrival/SingleSourceEarliestArrivalExample.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.examples.singleSourceEarliestArrival;
+
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.gradoop.flink.util.GradoopFlinkConfig;
+import org.gradoop.temporal.model.impl.TemporalGraph;
+
+/**
+ * Single Source Earliest Arrival Example
+ */
+public class SingleSourceEarliestArrivalExample {
+
+  /**
+   * Method to run Single Source Earliest Arrival Example
+   * @param args Input arguments
+   * @throws Exception Exception
+   */
+  public static void main(String[] args) throws Exception {
+    ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+    TemporalGraph in = TemporalSSEAExampleGraph.getTemporalGraph(GradoopFlinkConfig.createConfig(env));
+
+    TemporalGraph out = in.singleSourceEarliestArrival(
+            TemporalSSEAExampleGraph.getSrcVertexId(), 100, "SSEA",
+            true, 0L, true);
+
+    System.out.println("Output");
+
+    out.print();
+
+
+
+
+
+  }
+}

--- a/gradoop-examples/gradoop-examples-temporal/src/main/java/org/gradoop/examples/singleSourceEarliestArrival/TemporalSSEAExampleGraph.java
+++ b/gradoop-examples/gradoop-examples-temporal/src/main/java/org/gradoop/examples/singleSourceEarliestArrival/TemporalSSEAExampleGraph.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.examples.singleSourceEarliestArrival;
+
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
+import org.gradoop.flink.model.impl.epgm.LogicalGraph;
+import org.gradoop.flink.util.FlinkAsciiGraphLoader;
+import org.gradoop.flink.util.GradoopFlinkConfig;
+import org.gradoop.temporal.model.impl.TemporalGraph;
+import org.gradoop.temporal.model.impl.pojo.TemporalEdge;
+
+/**
+ * Class to provide an example graph representing a dump from the citibike rentals of NYC.
+ *
+ * @see <a href="https://www.citibikenyc.com/system-data">https://www.citibikenyc.com/system-data</a>
+ */
+public class TemporalSSEAExampleGraph {
+
+  /**
+   * ID of the source vertex
+   */
+  private static GradoopId SRC_VERTEX_ID;
+
+  /**
+   * No need for an object of this class.
+   */
+  private TemporalSSEAExampleGraph() {
+  }
+
+  /**
+   * Returns the temporal graph instance.
+   *
+   * @param config the gradoop flink config
+   * @return the temporal graph that represents the bike rental example
+   */
+  public static TemporalGraph getTemporalGraph(GradoopFlinkConfig config) {
+    // create loader
+    FlinkAsciiGraphLoader loader = new FlinkAsciiGraphLoader(config);
+
+    String graph = "input:test[" +
+            "(v1 {id:1})" +
+            "(v2 {id:2})" +
+            "(v3 {id:3})" +
+            "(v4 {id:4})" +
+            "(v5 {id:5})" +
+            "(v1)-[e1 {starttime: 0L, endtime: 3L}]->(v2)" +
+            "(v2)-[e2 {starttime: 2L, endtime: 7L}]->(v4)" +
+            "(v2)-[e3 {starttime: 4L, endtime: 5L}]->(v3)" +
+            "(v3)-[e4 {starttime: 6L, endtime: 8L}]->(v4)" +
+            "(v4)-[e5 {starttime: 8L, endtime: 10L}]->(v5)" +
+            "(v3)-[e6 {starttime: 7L, endtime: 12L}]->(v5)" +
+            "]";
+
+    loader.initDatabaseFromString(graph);
+
+    // get LogicalGraph representation of the social network graph
+    LogicalGraph networkGraph = loader.getLogicalGraph();
+    EPGMVertex srcVertexDouble = loader.getVertexByVariable("v1");
+    SRC_VERTEX_ID = srcVertexDouble.getId();
+
+    // transform to temporal graph by extracting time intervals from vertices
+    return TemporalGraph.fromGraph(networkGraph)
+            .transformEdges(TemporalSSEAExampleGraph::extractTripPeriod);
+  }
+
+  public static GradoopId getSrcVertexId() {
+    return SRC_VERTEX_ID;
+  }
+
+  /**
+   * Function to extract the trip period from properties of a vertex. The names of the properties have to be
+   * {@code starttime} and {@code stoptime} and their type has to be a String.
+   *
+   * @param current The current vertex to transform.
+   * @param transformed A copy of the current vertex used to create the resulting one.
+   * @return The resulting temporal vertex with assigned valid times.
+   */
+  private static TemporalEdge extractTripPeriod(TemporalEdge current, TemporalEdge transformed) {
+    transformed.setLabel(current.getLabel());
+    transformed.setProperties(current.getProperties());
+    //SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    String startTime = "starttime";
+    if (current.hasProperty(startTime)) {
+      transformed.setValidFrom(current.getPropertyValue("starttime").getLong());
+      transformed.removeProperty(startTime);
+      String stopTime = "endtime";
+      if (current.hasProperty(stopTime)) {
+        transformed.setValidTo(current.getPropertyValue("endtime").getLong());
+        transformed.removeProperty(stopTime);
+      }
+    }
+    return transformed;
+  }
+}

--- a/gradoop-examples/gradoop-examples-temporal/src/main/java/org/gradoop/examples/singleSourceEarliestArrival/package-info.java
+++ b/gradoop-examples/gradoop-examples-temporal/src/main/java/org/gradoop/examples/singleSourceEarliestArrival/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Examples related to single source earliest arrival
+ */
+package org.gradoop.examples.singleSourceEarliestArrival;

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/api/TemporalGraphOperators.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/api/TemporalGraphOperators.java
@@ -15,6 +15,7 @@
  */
 package org.gradoop.temporal.model.api;
 
+import org.gradoop.common.model.impl.id.GradoopId;
 import org.gradoop.flink.model.api.epgm.BaseGraphOperators;
 import org.gradoop.flink.model.api.functions.AggregateFunction;
 import org.gradoop.flink.model.api.functions.KeyFunction;
@@ -36,6 +37,7 @@ import org.gradoop.temporal.model.impl.operators.aggregation.functions.MaxVertex
 import org.gradoop.temporal.model.impl.operators.aggregation.functions.MinEdgeTime;
 import org.gradoop.temporal.model.impl.operators.aggregation.functions.MinVertexTime;
 import org.gradoop.temporal.model.impl.operators.diff.Diff;
+import org.gradoop.temporal.model.impl.operators.gelly.earliestArrival.SingleSourceEarliestArrival;
 import org.gradoop.temporal.model.impl.operators.matching.common.query.postprocessing.CNFPostProcessing;
 import org.gradoop.temporal.model.impl.operators.matching.common.statistics.TemporalGraphStatistics;
 import org.gradoop.temporal.model.impl.operators.matching.common.statistics.dummy.DummyTemporalGraphStatistics;
@@ -404,6 +406,24 @@ public interface TemporalGraphOperators extends BaseGraphOperators<TemporalGraph
 
     return callForGraph(new KeyedGrouping<>(vertexGroupingKeys, tempVertexAgg, edgeGroupingKeys,
       tempEdgeAgg));
+  }
+
+  /**
+   * determines the single source earliest arrival time to all nodes starting from a start node
+   *
+   * @param srcID           Gradoop ID of the source vertex
+   * @param maxIterations   maximum number of iterations
+   * @param vertexProperty  vertex property to store SSEA time
+   * @param interval        edge valid time is interval (true) or timestamp (false)
+   * @param starttime       start time on source vertex
+   * @param overlap         valid time can overlap (true) or not (false)
+   * @return Graph with the earliest arrival times
+   */
+  default TemporalGraph singleSourceEarliestArrival(
+          GradoopId srcID, int maxIterations, String vertexProperty, boolean interval, Long starttime,
+          boolean overlap) {
+    return callForGraph(new SingleSourceEarliestArrival<>(
+            srcID, maxIterations, vertexProperty, interval, starttime, overlap));
   }
 
   //----------------------------------------------------------------------------

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/functions/gelly/TemporalGellyAlgorithm.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/functions/gelly/TemporalGellyAlgorithm.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.functions.gelly;
+
+
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.graph.Graph;
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.flink.model.api.operators.UnaryBaseGraphToBaseGraphOperator;
+import org.gradoop.temporal.model.impl.TemporalGraph;
+import org.gradoop.temporal.model.impl.TemporalGraphCollection;
+import org.gradoop.temporal.model.impl.functions.gelly.functions.TemporalEdgeToGellyEdge;
+import org.gradoop.temporal.model.impl.functions.gelly.functions.TemporalVertexToGellyVertex;
+import org.gradoop.temporal.model.impl.pojo.TemporalEdge;
+import org.gradoop.temporal.model.impl.pojo.TemporalGraphHead;
+import org.gradoop.temporal.model.impl.pojo.TemporalVertex;
+
+/**
+ *  Base class for Algorithms executed in Flink Gelly that returns a {@link TemporalGraph}.
+ *
+ * @param <G>  Gradoop graph head type.
+ * @param <V>  Gradoop vertex type.
+ * @param <E>  Gradoop edge type.
+ * @param <LG> Gradoop type of the graph.
+ * @param <GC> Gradoop type of the graph collection.
+ * @param <VV> Value type for gelly vertices.
+ * @param <EV> Value type for gelly edges.
+ */
+
+public abstract class TemporalGellyAlgorithm<
+        G extends TemporalGraphHead,
+        V extends TemporalVertex,
+        E extends TemporalEdge,
+        LG extends TemporalGraph,
+        GC extends TemporalGraphCollection,
+        VV, EV> implements UnaryBaseGraphToBaseGraphOperator<LG> {
+
+  /**
+   * The graph used in {@link #execute}.
+   */
+  protected TemporalGraph currentGraph;
+
+  /**
+   * Function mapping temporal edge to gelly edge.
+   */
+  private final TemporalEdgeToGellyEdge<TemporalEdge, EV> toGellyEdge;
+
+  /**
+   * Function mapping temporal vertex to gelly vertex.
+   */
+  private final TemporalVertexToGellyVertex<TemporalVertex, VV> toGellyVertex;
+
+  /**
+   * Base constructor, only setting the mapper functions.
+   *
+   * @param toGellyVertex Function mapping temporal vertices from Gradoop to Gelly.
+   * @param toGellyEdge   function mapping temporal edges from Gradoop to Gelly.
+   */
+  public TemporalGellyAlgorithm(TemporalEdgeToGellyEdge<TemporalEdge, EV> toGellyEdge,
+                                  TemporalVertexToGellyVertex<TemporalVertex, VV> toGellyVertex) {
+    this.toGellyEdge = toGellyEdge;
+    this.toGellyVertex = toGellyVertex;
+  }
+
+    /**
+     * Execution of algorithm
+     * @param graph input graph
+     * @return Temporal Gradoop Graph
+     */
+  public LG execute(LG graph) {
+    this.currentGraph = graph;
+    try {
+      return executeInGelly(transformToGelly(graph));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Default transformation from a Gradoop Graph to a Gelly Graph.
+   *
+   * @param graph Temporal Gradoop Graph.
+   * @return Gelly Graph.
+   */
+  public Graph<GradoopId, VV, EV> transformToGelly(LG graph) {
+    DataSet<org.apache.flink.graph.Vertex<GradoopId, VV>>
+            gellyVertices = graph.getVertices().map(toGellyVertex);
+    DataSet<org.apache.flink.graph.Edge<GradoopId, EV>> gellyEdges = graph.getEdges().map(toGellyEdge);
+
+    return Graph.fromDataSet(gellyVertices, gellyEdges, graph.getConfig().getExecutionEnvironment());
+  }
+
+
+  /**
+   * Perform some operation in Gelly and transform the Gelly graph back to a Gradoop {@link TemporalGraph}.
+   *
+   * @param gellyGraph The Gelly graph.
+   * @return The Temporal Gradoop graph.
+   * @throws Exception on failure
+   */
+  public abstract LG executeInGelly(Graph<GradoopId, VV, EV> gellyGraph) throws Exception;
+}

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/functions/gelly/functions/TemporalEdgeToGellyEdge.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/functions/gelly/functions/TemporalEdgeToGellyEdge.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.functions.gelly.functions;
+
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.temporal.model.impl.pojo.TemporalEdge;
+
+/**
+ * Convert input to a Gelly Edge with K key and EV value.
+ * @param <E> Input type of temporal edge
+ * @param <EV>  Value type of the output gelly edge.
+ */
+public interface TemporalEdgeToGellyEdge<E extends TemporalEdge, EV> extends TemporalElementToGellyEdge<E, GradoopId, EV> {
+}

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/functions/gelly/functions/TemporalEdgeToGellyEdgeWithTimeValue.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/functions/gelly/functions/TemporalEdgeToGellyEdgeWithTimeValue.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.functions.gelly.functions;
+
+import org.apache.flink.api.java.functions.FunctionAnnotation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.temporal.model.impl.pojo.TemporalEdge;
+
+/**
+ * Maps Temporal edge to a Gelly edge consisting of Gradoop source and target
+ * identifier and Valid Time as edge value.
+ *
+ * @param <E>  Gradoop edge type.
+ */
+@FunctionAnnotation.ForwardedFields("sourceId->f0;targetId->f1")
+public class TemporalEdgeToGellyEdgeWithTimeValue<E extends TemporalEdge>
+        implements TemporalEdgeToGellyEdge<E, Tuple2<Long, Long>> {
+
+  /**
+   * Reduce object instantiations.
+   */
+  private final org.apache.flink.graph.Edge<GradoopId, Tuple2<Long, Long>> reuseEdge;
+
+  /**
+   * Constructor.
+   */
+  public TemporalEdgeToGellyEdgeWithTimeValue() {
+    this.reuseEdge = new org.apache.flink.graph.Edge<>();
+  }
+
+  @Override
+  public org.apache.flink.graph.Edge<GradoopId, Tuple2<Long, Long>> map(E temporalEdge) {
+    reuseEdge.setSource(temporalEdge.getSourceId());
+    reuseEdge.setTarget(temporalEdge.getTargetId());
+    reuseEdge.setValue(temporalEdge.getValidTime());
+    return reuseEdge;
+  }
+}

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/functions/gelly/functions/TemporalElementToGellyEdge.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/functions/gelly/functions/TemporalElementToGellyEdge.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.functions.gelly.functions;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.graph.Edge;
+
+/**
+ * Convert input to a Gelly Edge with K key and EV value.
+ *
+ * @param <I>   Input type.
+ * @param <K>   Key type of the output gelly edge.
+ * @param <EV>  Value type of the output gelly edge.
+ */
+public interface TemporalElementToGellyEdge<I, K, EV> extends MapFunction<I, Edge<K, EV>> {
+}

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/functions/gelly/functions/TemporalElementToGellyVertex.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/functions/gelly/functions/TemporalElementToGellyVertex.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.functions.gelly.functions;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.graph.Vertex;
+
+/**
+ * Convert input to a Gelly Vertex with K key and VV value.
+ *
+ * @param <I>   Input type.
+ * @param <K>   Key type of the output gelly vertex.
+ * @param <VV>  Value type of the output gelly vertex.
+ */
+public interface TemporalElementToGellyVertex<I, K, VV> extends MapFunction<I, Vertex<K, VV>> {
+}

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/functions/gelly/functions/TemporalVertexToGellyVertex.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/functions/gelly/functions/TemporalVertexToGellyVertex.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.functions.gelly.functions;
+
+import org.gradoop.flink.algorithms.gelly.functions.VertexToGellyVertex;
+import org.gradoop.temporal.model.impl.pojo.TemporalVertex;
+
+/**
+ * Convert input to a Gelly Vertex with K key and VV value.
+ * @param <V> Input type of temporal vertex
+ * @param <VV> Value type of the output gelly vertex.
+ */
+public interface TemporalVertexToGellyVertex<V extends TemporalVertex, VV> extends VertexToGellyVertex<V, VV> {
+}

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/functions/gelly/functions/TemporalVertexToGellyVertexWithTimeValue.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/functions/gelly/functions/TemporalVertexToGellyVertexWithTimeValue.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.functions.gelly.functions;
+
+import org.apache.flink.api.java.functions.FunctionAnnotation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.temporal.model.impl.pojo.TemporalVertex;
+
+/**
+ * Maps Temporal vertex to a Gelly vertex consisting of the {@link GradoopId} and Valid Time.
+ *
+ * @param <V> Gradoop Vertex type
+ */
+@FunctionAnnotation.ForwardedFields("id->f0")
+public class TemporalVertexToGellyVertexWithTimeValue<V extends TemporalVertex>
+  implements TemporalVertexToGellyVertex<V, Tuple2<Long, Long>> {
+  /**
+   * Reduce object instantiations
+   */
+  private final org.apache.flink.graph.Vertex<GradoopId, Tuple2<Long, Long>> reuseVertex;
+
+  /**
+   * Constructor
+   */
+  public TemporalVertexToGellyVertexWithTimeValue() {
+    this.reuseVertex = new org.apache.flink.graph.Vertex<>();
+  }
+
+  @Override
+  public org.apache.flink.graph.Vertex<GradoopId, Tuple2<Long, Long>> map(V vertex) throws Exception {
+    reuseVertex.setId(vertex.getId());
+    reuseVertex.setValue(vertex.getValidTime());
+    return reuseVertex;
+  }
+}

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/functions/gelly/functions/package-info.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/functions/gelly/functions/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Contains implementations of functions to map TPGM Elements to Gelly Elements
+ */
+package org.gradoop.temporal.model.impl.functions.gelly.functions;

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/functions/gelly/package-info.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/functions/gelly/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Contains implementations of functions with Apache Flink Gelly
+ */
+package org.gradoop.temporal.model.impl.functions.gelly;

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/gelly/earliestArrival/SingleSourceEarliestArrival.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/gelly/earliestArrival/SingleSourceEarliestArrival.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.operators.gelly.earliestArrival;
+
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.graph.Graph;
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.flink.model.impl.functions.epgm.Id;
+import org.gradoop.temporal.model.impl.TemporalGraph;
+import org.gradoop.temporal.model.impl.TemporalGraphCollection;
+import org.gradoop.temporal.model.impl.functions.gelly.TemporalGellyAlgorithm;
+import org.gradoop.temporal.model.impl.functions.gelly.functions.TemporalEdgeToGellyEdgeWithTimeValue;
+import org.gradoop.temporal.model.impl.functions.gelly.functions.TemporalVertexToGellyVertexWithTimeValue;
+import org.gradoop.temporal.model.impl.pojo.TemporalEdge;
+import org.gradoop.temporal.model.impl.pojo.TemporalGraphHead;
+import org.gradoop.temporal.model.impl.pojo.TemporalVertex;
+
+
+/**
+ * A gradoop operator for Single Source Earliest Arrival (SSEA).
+ *
+ * @param <G>  Gradoop graph head type.
+ * @param <V>  Gradoop vertex type.
+ * @param <E>  Gradoop edge type.
+ * @param <LG> Gradoop type of the graph.
+ * @param <GC> Gradoop type of the graph collection.
+ */
+public class SingleSourceEarliestArrival<
+        G extends TemporalGraphHead,
+        V extends TemporalVertex,
+        E extends TemporalEdge,
+        LG extends TemporalGraph,
+        GC extends TemporalGraphCollection>
+        extends TemporalGellyAlgorithm<G, V, E, LG, GC, Tuple2<Long, Long>, Tuple2<Long, Long>> {
+
+  /**
+   * ID of the source vertex
+   */
+  private final GradoopId srcVertexId;
+
+  /**
+   * Number of iterations.
+   */
+  private final int maxIterations;
+
+  /**
+   * Property key to store SSEA time in.
+  */
+  private final String vertexProperty;
+
+  /**
+   * use valid time as interval or only start timestamp
+   */
+  private final boolean interval;
+
+  /**
+   * starttime at source vertex
+   */
+  private final Long starttime;
+
+  /**
+   * overlap of interval allowed
+   */
+  private final boolean overlap;
+
+  /**
+   *Constructor for single source earliest arrival
+   *
+   *
+   * @param srcVertexId       Id of the source vertex.
+   * @param maxIterations     maximum number of iterations
+   * @param vertexProperty    vertex property to store SSEA time
+   * @param interval          edge valid time is interval (true) or timestamp (false)
+   * @param starttime         start time on source vertex
+   * @param overlap           valid time can overlap (true) or not (false)
+   */
+
+  public SingleSourceEarliestArrival(GradoopId srcVertexId, int maxIterations, String vertexProperty,
+                                     boolean interval, Long starttime, boolean overlap) {
+    super(
+            new TemporalEdgeToGellyEdgeWithTimeValue<>(),
+            new TemporalVertexToGellyVertexWithTimeValue<>());
+    this.srcVertexId = srcVertexId;
+    this.maxIterations = maxIterations;
+    this.vertexProperty = vertexProperty;
+    this.interval = interval;
+    this.starttime = starttime;
+    this.overlap = overlap;
+  }
+
+  @Override
+  public TemporalGraph executeInGelly(Graph gellyGraph) throws Exception {
+    DataSet<TemporalVertex> newVerticies =
+            new SingleSourceEarliestArrivalAlgorithm<GradoopId, Double>(
+                    maxIterations, srcVertexId, interval, starttime, overlap)
+            .run(gellyGraph)
+            .join(currentGraph.getVertices())
+            .where(0)
+            .equalTo(new Id<>())
+            .with(new SingleSourceEarliestArrivalAttribute(vertexProperty));
+
+    return currentGraph.getFactory().fromDataSets(
+            currentGraph.getGraphHead(), newVerticies, currentGraph.getEdges()
+    );
+  }
+}

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/gelly/earliestArrival/SingleSourceEarliestArrivalAlgorithm.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/gelly/earliestArrival/SingleSourceEarliestArrivalAlgorithm.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.operators.gelly.earliestArrival;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.GraphAlgorithm;
+import org.apache.flink.graph.Vertex;
+import org.apache.flink.graph.Edge;
+import org.apache.flink.graph.spargel.GatherFunction;
+import org.apache.flink.graph.spargel.MessageIterator;
+import org.apache.flink.graph.spargel.ScatterFunction;
+
+/**
+ *
+ * This is an implementation of the Single-Source-Earliest Arrival algorithm,
+ * using a scatter-gather iteration.
+ *
+ *@param <K>    Type of ID
+ *@param <VV>   Gelly Edge Data Type
+ */
+
+
+public class SingleSourceEarliestArrivalAlgorithm<K, VV> implements GraphAlgorithm<K, VV, Tuple2<Long, Long>, DataSet<VV>> {
+
+
+  /**
+   * Number of iterations.
+   */
+  private final int maxIterations;
+
+  /**
+   * ID of the source vertex
+   */
+  private final K srcVertexId;
+
+  /**
+   * use valid time as interval or only start timestamp
+   */
+  private final boolean interval;
+
+  /**
+   * starttime at source vertex
+   */
+  private final Long starttime;
+
+  /**
+   * overlap of interval allowed
+   */
+  private final boolean overlap;
+
+
+  /**
+   * Creates an instance of the SingleSourceEarliestArrival algorithm.
+   * @param maxIterations Number of iterations.
+   * @param srcVertex ID of the source vertex
+   * @param interval use valid time as interval or only start timestamp
+   * @param starttime starttime at source vertex
+   * @param overlap overlap of interval allowed
+   */
+  public SingleSourceEarliestArrivalAlgorithm(
+          int maxIterations, K srcVertex, boolean interval, Long starttime, boolean overlap) {
+    this.maxIterations = maxIterations;
+    this.srcVertexId = srcVertex;
+    this.interval = interval;
+    this.starttime = starttime;
+    this.overlap = overlap;
+  }
+
+  @Override
+  public DataSet<VV> run(Graph<K, VV, Tuple2<Long, Long>> input) throws Exception {
+    return input.mapVertices(new InitVerticesMapper<>(srcVertexId, starttime)).runScatterGatherIteration(
+            new MinDistanceMessenger<>(interval, overlap), new VertexDistanceUpdater(), maxIterations)
+            .getVertices();
+  }
+
+  /**
+   * init Vertices with start values
+   * @param <K> Type of ID
+   * @param <VV> Gelly Edge Data Type
+   */
+
+  private static final class InitVerticesMapper<K, VV> implements MapFunction<Vertex<K, VV>, Long> {
+
+    /**
+     * Vertex ID
+     */
+    private K srcVertexId;
+
+    /**
+     * Startime of start vertex
+     */
+    private Long starttime;
+
+    /**
+     * Constructor of Init Mapper
+     * @param srcId Typ of ID
+     * @param starttime Startime of start vertex
+     */
+    InitVerticesMapper(K srcId, Long starttime) {
+      this.srcVertexId = srcId;
+      this.starttime = starttime;
+    }
+
+    /**
+     * Mapping of start values
+     * @param value The input value.
+     * @return inicialised vertex
+     */
+    public Long map(Vertex<K, VV> value) {
+      if (value.f0.equals(srcVertexId)) {
+        return starttime;
+      } else {
+        return Long.MAX_VALUE;
+      }
+    }
+  }
+
+
+  /**
+   * Create Message and send to other Vertices
+   * @param <K> Type of ID
+   */
+  public static final class MinDistanceMessenger<K> extends
+          ScatterFunction<K, Long, Long, Tuple2<Long, Long>> {
+
+    /**
+     * use valid time as interval or only start timestamp
+     */
+    private final boolean interval;
+
+    /**
+     * overlap of interval allowed
+     */
+    private final boolean overlap;
+
+    /**
+     * Constructor for messenger
+     * @param interval use valid time as interval or only start timestamp
+     * @param overlap overlap of interval allowed
+     */
+    public MinDistanceMessenger(boolean interval, boolean overlap) {
+      this.interval = interval;
+      this.overlap = overlap;
+    }
+
+    /**
+     * send message to next vertex
+     * @param vertex currently to be processed vertex
+     *
+     */
+    public void sendMessages(Vertex<K, Long> vertex) {
+
+      for (Edge<K, Tuple2<Long, Long>> edge : getEdges()) {
+        if (!vertex.getValue().equals(Long.MAX_VALUE)) {
+          if (interval) {
+            if (overlap) {
+              if (vertex.getValue() <= edge.getValue().f1) {
+                Long value = edge.getValue().f0;
+                if (value < vertex.getValue()) {
+                  value = vertex.getValue();
+                }
+                sendMessageTo(edge.getTarget(), value);
+              }
+            } else {
+              if (vertex.getValue() <= edge.getValue().f0) {
+                sendMessageTo(edge.getTarget(), edge.getValue().f1);
+              }
+            }
+          } else {
+            if (vertex.getValue() <= edge.getValue().f0) {
+              sendMessageTo(edge.getTarget(), edge.getValue().f0);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * receive messages and update value on vertex
+   * @param <K> Type of ID
+   */
+  public static final class VertexDistanceUpdater<K> extends GatherFunction<K, Long, Long> {
+
+    /**
+     * receive messages and update value on vertex
+     * @param vertex Gelly vertex
+     * @param inMessages The incoming messages to this vertex.
+     *
+     */
+    public void updateVertex(Vertex<K, Long> vertex, MessageIterator<Long> inMessages) {
+      long minTime = Long.MAX_VALUE;
+
+      for (long msg : inMessages) {
+        if (msg < minTime) {
+          minTime = msg;
+        }
+      }
+
+      if (vertex.getValue() > minTime) {
+        setNewVertexValue(minTime);
+      }
+    }
+  }
+}

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/gelly/earliestArrival/SingleSourceEarliestArrivalAttribute.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/gelly/earliestArrival/SingleSourceEarliestArrivalAttribute.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.operators.gelly.earliestArrival;
+
+import org.apache.flink.api.common.functions.JoinFunction;
+import org.gradoop.common.model.api.entities.Vertex;
+import org.gradoop.common.model.impl.id.GradoopId;
+
+/**
+ * Stores the earliest arrival as a property in vertex.
+ *
+ * @param <V> Gradoop Vertex type
+ */
+public class SingleSourceEarliestArrivalAttribute<V extends Vertex>
+  implements JoinFunction<org.apache.flink.graph.Vertex<GradoopId, Long>, V, V> {
+
+  /**
+   * Property to store the earliest arrival time in
+   */
+  private final String earliestArrivalProperty;
+
+  /**
+   * Stores the earliest arrival as a property.
+   *
+   * @param earliestArrivalProperty property key to store the earliest arrival in
+   */
+  public SingleSourceEarliestArrivalAttribute(String earliestArrivalProperty) {
+    this.earliestArrivalProperty = earliestArrivalProperty;
+  }
+
+  @Override
+  public V join(org.apache.flink.graph.Vertex<GradoopId, Long> gellyVertex, V vertex) {
+    vertex.setProperty(earliestArrivalProperty, gellyVertex.getValue());
+    return vertex;
+  }
+}

--- a/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/gelly/earliestArrival/package-info.java
+++ b/gradoop-temporal/src/main/java/org/gradoop/temporal/model/impl/operators/gelly/earliestArrival/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Contains implementations of single source earliest arrival
+ */
+package org.gradoop.temporal.model.impl.operators.gelly.earliestArrival;

--- a/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/operators/gelly/earliestArrival/SingleSourceEarliestArrivalTest.java
+++ b/gradoop-temporal/src/test/java/org/gradoop/temporal/model/impl/operators/gelly/earliestArrival/SingleSourceEarliestArrivalTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2014 - 2021 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.temporal.model.impl.operators.gelly.earliestArrival;
+
+import org.gradoop.common.model.impl.id.GradoopId;
+import org.gradoop.flink.model.impl.epgm.LogicalGraph;
+import org.gradoop.flink.util.FlinkAsciiGraphLoader;
+import org.gradoop.temporal.model.impl.TemporalGraph;
+import org.gradoop.temporal.model.impl.pojo.TemporalEdge;
+import org.gradoop.temporal.util.TemporalGradoopTestBase;
+import org.junit.Test;
+
+/**
+ * Test each case of Single Source Earliest Arrival
+ */
+public class SingleSourceEarliestArrivalTest extends TemporalGradoopTestBase {
+
+  String graph = "input:test[" +
+          "(v1 {id:1})" +
+          "(v2 {id:2})" +
+          "(v3 {id:3})" +
+          "(v4 {id:4})" +
+          "(v5 {id:5})" +
+          "(v1)-[e1 {starttime: 0L, endtime: 3L}]->(v2)" +
+          "(v2)-[e2 {starttime: 2L, endtime: 7L}]->(v4)" +
+          "(v2)-[e3 {starttime: 4L, endtime: 5L}]->(v3)" +
+          "(v3)-[e4 {starttime: 6L, endtime: 8L}]->(v4)" +
+          "(v4)-[e5 {starttime: 8L, endtime: 10L}]->(v5)" +
+          "(v3)-[e6 {starttime: 7L, endtime: 12L}]->(v5)" +
+          "]" +
+          "intervalOverlap:test[" +
+          "(v6 {SSEA:0L,id:1})" +
+          "(v7 {SSEA:0L,id:2})" +
+          "(v8 {SSEA:4L,id:3})" +
+          "(v9 {SSEA:2L,id:4})" +
+          "(v10 {SSEA:7L,id:5})" +
+          "(v6)-[e7 {starttime: 0L, endtime: 3L}]->(v7)" +
+          "(v7)-[e8 {starttime: 2L, endtime: 7L}]->(v9)" +
+          "(v7)-[e9 {starttime: 4L, endtime: 5L}]->(v8)" +
+          "(v8)-[e10 {starttime: 6L, endtime: 8L}]->(v9)" +
+          "(v9)-[e11 {starttime: 8L, endtime: 10L}]->(v10)" +
+          "(v8)-[e12 {starttime: 7L, endtime: 12L}]->(v10)" +
+          "]" +
+          "noInterval:test[" +
+          "(v11 {SSEA:0L,id:1})" +
+          "(v12 {SSEA:0L,id:2})" +
+          "(v13 {SSEA:4L,id:3})" +
+          "(v14 {SSEA:2L,id:4})" +
+          "(v15 {SSEA:7L,id:5})" +
+          "(v11)-[e13 {starttime: 0L, endtime: 3L}]->(v12)" +
+          "(v12)-[e14 {starttime: 2L, endtime: 7L}]->(v14)" +
+          "(v12)-[e15 {starttime: 4L, endtime: 5L}]->(v13)" +
+          "(v13)-[e16 {starttime: 6L, endtime: 8L}]->(v14)" +
+          "(v14)-[e17 {starttime: 8L, endtime: 10L}]->(v15)" +
+          "(v13)-[e18 {starttime: 7L, endtime: 12L}]->(v15)" +
+          "]" +
+          "intervalNoOverlap:test[" +
+          "(v16 {SSEA:0L,id:1})" +
+          "(v17 {SSEA:3L,id:2})" +
+          "(v18 {SSEA:5L,id:3})" +
+          "(v19 {SSEA:8L,id:4})" +
+          "(v20 {SSEA:10L,id:5})" +
+          "(v16)-[e19 {starttime: 0L, endtime: 3L}]->(v17)" +
+          "(v17)-[e20 {starttime: 2L, endtime: 7L}]->(v19)" +
+          "(v17)-[e21 {starttime: 4L, endtime: 5L}]->(v18)" +
+          "(v18)-[e22 {starttime: 6L, endtime: 8L}]->(v19)" +
+          "(v19)-[e23 {starttime: 8L, endtime: 10L}]->(v20)" +
+          "(v18)-[e24 {starttime: 7L, endtime: 12L}]->(v20)" +
+          "]";
+
+
+  /**
+   * Test without interval
+   * @throws Exception
+   */
+  @Test
+  public void testByDataNoInterval() throws Exception {
+    FlinkAsciiGraphLoader loader = getLoaderFromString(graph);
+    LogicalGraph input = loader.getLogicalGraphByVariable("input");
+    GradoopId srcVertex = loader.getVertexByVariable("v1").getId();
+    TemporalGraph in = TemporalGraph.fromGraph(input)
+            .transformEdges(SingleSourceEarliestArrivalTest::extractTripPeriod);
+
+    TemporalGraph noIntervalOutput = in.singleSourceEarliestArrival(srcVertex, 100, "SSEA", false, 0L, true);
+
+    LogicalGraph inputNoInterval = loader.getLogicalGraphByVariable("noInterval");
+    TemporalGraph noIntervalResult = TemporalGraph.fromGraph(inputNoInterval)
+            .transformEdges(SingleSourceEarliestArrivalTest::extractTripPeriod);
+
+    collectAndAssertTrue(noIntervalOutput.equalsByData(noIntervalResult));
+  }
+
+  /**
+   * Test with interval and without overlap
+   * @throws Exception
+   */
+  @Test
+  public void testbyDataIntervalNoOverlap() throws Exception {
+    FlinkAsciiGraphLoader loader = getLoaderFromString(graph);
+    LogicalGraph input = loader.getLogicalGraphByVariable("input");
+    GradoopId srcVertex = loader.getVertexByVariable("v1").getId();
+    TemporalGraph in = TemporalGraph.fromGraph(input)
+            .transformEdges(SingleSourceEarliestArrivalTest::extractTripPeriod);
+    TemporalGraph intervalNoOverlapOutput = in.singleSourceEarliestArrival(srcVertex, 100, "SSEA", true, 0L, false);
+
+    LogicalGraph inputNoOverlapInterval = loader.getLogicalGraphByVariable("intervalNoOverlap");
+    TemporalGraph intervalNoOverlapResult = TemporalGraph.fromGraph(inputNoOverlapInterval)
+            .transformEdges(SingleSourceEarliestArrivalTest::extractTripPeriod);
+
+    collectAndAssertTrue(intervalNoOverlapOutput.equalsByData(intervalNoOverlapResult));
+  }
+
+  /**
+   * Test with interval and overlap
+   * @throws Exception
+   */
+  @Test
+  public void testbyDataIntervalOverlap() throws Exception {
+    FlinkAsciiGraphLoader loader = getLoaderFromString(graph);
+    LogicalGraph input = loader.getLogicalGraphByVariable("input");
+    GradoopId srcVertex = loader.getVertexByVariable("v1").getId();
+    TemporalGraph in = TemporalGraph.fromGraph(input)
+            .transformEdges(SingleSourceEarliestArrivalTest::extractTripPeriod);
+
+    TemporalGraph intervalOverlapOutput = in.singleSourceEarliestArrival(srcVertex, 100, "SSEA", true, 0L, true);
+
+    LogicalGraph inputIntervalOverlap = loader.getLogicalGraphByVariable("intervalOverlap");
+    TemporalGraph intervalOverlapResult = TemporalGraph.fromGraph(inputIntervalOverlap)
+            .transformEdges(SingleSourceEarliestArrivalTest::extractTripPeriod);
+
+    collectAndAssertTrue(intervalOverlapOutput.equalsByData(intervalOverlapResult));
+
+  }
+
+
+  /**
+   * Extract Trip Period from Edge
+   * @param current Temporal Edge
+   * @param transformed Temporal Edge
+   * @return  transformed Edge
+   */
+  private static TemporalEdge extractTripPeriod(TemporalEdge current, TemporalEdge transformed) {
+    transformed.setLabel(current.getLabel());
+    transformed.setProperties(current.getProperties());
+    //SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    try {
+      String startTime = "starttime";
+      if (current.hasProperty(startTime)) {
+        transformed.setValidFrom(current.getPropertyValue("starttime").getLong());
+        transformed.removeProperty(startTime);
+        String stopTime = "endtime";
+        if (current.hasProperty(stopTime)) {
+          transformed.setValidTo(current.getPropertyValue("endtime").getLong());
+          transformed.removeProperty(stopTime);
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Can not parse time.");
+    }
+    return transformed;
+  }
+}


### PR DESCRIPTION
Added an operator to calculate the single source earliest arrival times for a temporal graph.

## Description
Add an operator that calculates the single source earliest arrival time for each vertex starting from a start node and a start time. A temporal graph is used as input. The following parameters are supported
- interval -> difference between interval and timestamp at edge 
- overlap -> allow edges times to overlap

The output is a temporal graph with the earliest arrival times at the vertices.

## Related Issue
#1601 

## Motivation and Context
Operator solves the single source earliest arrival problem

## How Has This Been Tested?
Unit Tests with a test graph

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if necessary).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I ran a spell checker.

